### PR TITLE
[suggestion] Allow local install without password.

### DIFF
--- a/install_.php
+++ b/install_.php
@@ -386,6 +386,11 @@ class e_install
 		// $page_info = nl2br(LANINS_023);
 		$page_info = "<div class='alert alert-block alert-info'>Please fill in the form below with your MySQL details. If you do not know this information, please contact your hosting provider. You may hover over each field for additional information.</div>";
 		$e_forms->start_form("versions", $_SERVER['PHP_SELF'].($_SERVER['QUERY_STRING'] == "debug" ? "?debug" : ""));
+		if (($_SERVER['SERVER_ADDR'] == "127.0.0.1") OR ($_SERVER['SERVER_ADDR'] == "localhost")) { // + regex for 198.168.x.x
+			$isrequired = "";
+		} else {
+			$isrequired = "required='required'";
+		}
 		$output = "
 			<div style='width: 100%; padding-left: auto; padding-right: auto;'>
 			<table class='table table-striped' >
@@ -408,7 +413,7 @@ class e_install
 				<tr>
 					<td><label for='password'>".LANINS_026."</label></td>
 					<td>
-						<input class='tbox' type='password' name='password' size='40' id='password' value='' maxlength='100' required='required' />
+						<input class='tbox' type='password' name='password' size='40' id='password' value='' maxlength='100' $isrequired />
 						<span class='field-help'>".LANINS_032."</span>
 					</td>
 				</tr>


### PR DESCRIPTION
Just an idea for a local SQL DB without password.
(very quick fix, of course a regex should be better)

form "required=required" is now optional for 127.0.0.1 and localhost.
Should be better with regex + 192.168._._

line 389 (GH software fail at diff file)
- line 416
