### PR TITLE
Fix Emote Spacing Issue #311 

### DIFF
--- a/e107_handlers/emote.php
+++ b/e107_handlers/emote.php
@@ -36,6 +36,7 @@ function r_emote()
 		$value2 = substr($value, 0, strpos($value, " "));
 		$value = ($value2 ? $value2 : $value);
 		$value = ($value == '&|') ? ':((' : $value;
+		$value = " ".$value." ";
 		//TODO CSS class
 		$str .= "\n<a href=\"javascript:addtext('$value',true)\"><img src='$key' alt='' /></a> ";
 	}


### PR DESCRIPTION
This adds a space before AND after each emote, so there's no conflict with any text or other emotes before or after them. Same fix was done in an much earlier version. 
