### PR TITLE
viewport meta tag is using the attribute 'property' instead of 'name' 

### DIFF
--- a/e107_core/templates/header_default.php
+++ b/e107_core/templates/header_default.php
@@ -139,7 +139,7 @@ else
 if(vartrue($pref['meta_copyright'][e_LANGUAGE])) e107::meta('copyright',$pref['meta_copyright'][e_LANGUAGE]);
 if(vartrue($pref['meta_author'][e_LANGUAGE])) e107::meta('author',$pref['meta_author'][e_LANGUAGE]);
 if($pref['sitebutton']) e107::meta('og:image',$tp->replaceConstants($pref['sitelogo'],'full'));
-if(defined("VIEWPORT")) e107::meta('viewport',VIEWPORT); //BC ONLY 
+if(defined("VIEWPORT")) echo '<meta name="viewport" content="'.VIEWPORT.'" />'; //BC ONLY 
 
 echo e107::getUrl()->response()->renderMeta()."\n";
 


### PR DESCRIPTION
Possible Fix #405 - viewport meta tag is using the attribute 'property' instead of 'name' which is preventing the e107 bootstrap responsive theme behave adaptively with screen width, when testing with actual mobile device. (Used an android device with 480x800 px resolution). Replacing the 'property' attribute with 'name' attribute fixes the issue. Screenshots attached before and after applying this change. The meta tag attribute name of 'property' is used in OG meta protocol only I believe. Kindly consider the last commit only.

Ref links to developer notes on meta viewport for some major browsers:
https://developer.mozilla.org/en-US/docs/Mozilla/Mobile/Viewport_meta_tag
http://developer.apple.com/library/safari/#documentation/appleapplications/reference/SafariHTMLRef/Articles/MetaTags.html
http://dev.opera.com/articles/view/an-introduction-to-meta-viewport-and-viewport/

Screenshots:
before:
![screenshot_2013-07-05-23-47-35](https://f.cloud.github.com/assets/315195/755911/afd54a98-e5cd-11e2-8aba-46f587be1a20.png)
after:
![device-2013-07-06-001020](https://f.cloud.github.com/assets/315195/755912/bb7f254e-e5cd-11e2-91f5-374455d2d114.png)
