### PR TITLE
Changed back 'loginbox' to 'login' to match v1 naming

### DIFF
--- a/e107_plugins/login_menu/login_menu.php
+++ b/e107_plugins/login_menu/login_menu.php
@@ -47,7 +47,7 @@ if (defined('CORRUPT_COOKIE') && CORRUPT_COOKIE == TRUE)
 {
 	$text = "<div class='core-sysmsg loginbox'>".LOGIN_MENU_L7."<br /><br />
 	{$bullet} <a href='".SITEURL."index.php?logout'>".LOGIN_MENU_L8."</a></div>";
-	$ns->tablerender(LOGIN_MENU_L9, $text, 'loginbox_error');
+	$ns->tablerender(LOGIN_MENU_L9, $text, 'login_error');
 }
     
 //Image code
@@ -152,7 +152,7 @@ if (USER == TRUE || ADMIN == TRUE)
 	}
 	
 	//render
-	$ns->tablerender($caption, $text, 'loginbox');
+	$ns->tablerender($caption, $text, 'login');
 
 // END LOGGED CODE	
 } 


### PR DESCRIPTION
May otherwise result in BC issues with v1 themes.

Started this in https://github.com/e107inc/e107/commit/976c386cf25b170e5cb6311fa8e0c3f42dae1994#diff-99152c2c22704b20b8cc720f89b9f005 but forgot these two.
