### PR TITLE
Fix for not listing subcategories download plugin

### DIFF
--- a/e107_plugins/download/handlers/download_class.php
+++ b/e107_plugins/download/handlers/download_class.php
@@ -529,7 +529,7 @@ class download
 				
 				$dl_text .= $tp->parseTemplate($DOWNLOAD_CAT_TABLE_END, TRUE, $sc);
 				
-			//	$text = $ns->tablerender($dl_title, $dl_text, 'download-list', true);
+		 	$text = $ns->tablerender($dl_title, $dl_text, 'download-list', true);
 			}
 			
 		}// End of subcategory display


### PR DESCRIPTION
Not listing subcategories when you don't have them on main page
(unchecked in preferencies)
Found while working on #479.  Related with  #566. Probably only mistake.
