### PR TITLE
Fix classis style icons not lining up right

### DIFF
--- a/e107_themes/bootstrap/admin_style.css
+++ b/e107_themes/bootstrap/admin_style.css
@@ -46,7 +46,7 @@ body						{ padding-top: 75px;  }
 
 .core-mainpanel-block 		{ text-align:center; width:140px; float:left; height:80px; display:block; padding:1px; margin: 0px 2px 15px 2px;  }
 .core-mainpanel-link-text 	{ text-decoration: none; display:block;  }
-a.core-mainpanel-link-icon	{ height:80px; display:block; width: 120px; padding-top:20px;  }
+a.core-mainpanel-link-icon	{ height:80px; width: 120px; padding-top:20px;  }
 a.core-mainpanel-link-icon:hover { text-decoration: none; filter: none; }
 
 div.bbcode-panel {


### PR DESCRIPTION
This: a.core-mainpanel-link-icon	{ height:80px; display:block; width: 120px; padding-top:20px;  }


To This: a.core-mainpanel-link-icon	{ height:80px; width: 120px; padding-top:20px;  }

Removed: display:block; to fix admin area icons in the classis style. They should line up with the font after removing it.