### PR TITLE
Language LANs change (latest files used)

### DIFF
--- a/e107_admin/auth.php
+++ b/e107_admin/auth.php
@@ -68,7 +68,7 @@ if (ADMIN)
 		if(e107::getUser()->getSessionDataAs())
 		{ // TODO - lan
 			$asuser = e107::getSystemUser(e107::getUser()->getSessionDataAs(), false);
-			e107::getMessage()->addInfo('Successfully logged in as '.($asuser->getId()  ? $asuser->getName().' ('.$asuser->getValue('email').')' : 'unknown'). ' <a href="'.e_ADMIN_ABS.'users.php?mode=main&amp;action=logoutas">[logout]</a>');
+			e107::getMessage()->addInfo(''.LAN_AUTH_USER_MESSAGE.' '.($asuser->getId()  ? $asuser->getName().' ('.$asuser->getValue('email').')' : 'unknown'). ' <a href="'.e_ADMIN_ABS.'users.php?mode=main&amp;action=logoutas">[logout]</a>');
 		}
 		// NEW, legacy 3rd party code fix, header called inside the footer o.O
 		if(deftrue('e_ADMIN_UI'))
@@ -304,13 +304,13 @@ class auth
 		    <div class='field'>
 		    	<label for='username'>".ADLAN_89."</label> 
 		    	<input class='tbox e-tip' type='text' autofocus required='required' name='authname' placeholder='".ADLAN_89."' id='username' size='30' value='' maxlength='".varset($pref['loginname_maxlength'], 30)."' />
-		    	<div class='field-help'>Please enter your username or email</div>
+		    	<div class='field-help'>".LAN_LOGIN_ADMINNAME_HOVER."</div>
 		   	</div>			
 		
 		    <div class='field'>
 		    	<label for='userpass'>".ADLAN_90."</label>
 		    	<input class='tbox e-tip' type='password' required='required' name='authpass' placeholder='".ADLAN_90."' id='userpass' size='30' value='' maxlength='30' />
-		    	<div class='field-help'>Password is required</div>
+		    	<div class='field-help'>".LAN_LOGIN_ADMINPWF_HOVER."</div>
 		    </div>";
 		
 		if ($use_imagecode)

--- a/e107_admin/includes/infopanel.php
+++ b/e107_admin/includes/infopanel.php
@@ -196,12 +196,12 @@ class adminstyle_infopanel
 	      
 			</div>";
 	
-		$text = $ns->tablerender(ucwords(USERNAME)."'s Control Panel", $mainPanel, "core-infopanel_mye107",true);
+		$text = $ns->tablerender(ucwords(USERNAME)."".LAN_ADMIN_TITEL_CP."", $mainPanel, "core-infopanel_mye107",true);
 		
 	
 	//  ------------------------------- e107 News --------------------------------
 		
-		$text2 = $ns->tablerender("e107 News","<div id='e-adminfeed'></div><div class='right'><a rel='external' href='".ADMINFEEDMORE."'>".LAN_MORE."</a></div>","core-infopanel_news",true); 
+		$text2 = $ns->tablerender("".LAN_E107_NEWS."","<div id='e-adminfeed'></div><div class='right'><a rel='external' href='".ADMINFEEDMORE."'>".LAN_MORE."</a></div>","core-infopanel_news",true); 
 	
 	
 	
@@ -214,7 +214,7 @@ class adminstyle_infopanel
 
 
 		
-		$text2 .= $ns->tablerender("Website Status", $this->renderWebsiteStatus(),"",true);	
+		$text2 .= $ns->tablerender("".LAN_WEB_STATUS."", $this->renderWebsiteStatus(),"",true);	
 		
 		
 	//	$text .= $ns->tablerender(ADLAN_LAT_1,$tp->parseTemplate("{ADMIN_LATEST=norender}"),"core-infopanel_latest",true);
@@ -385,11 +385,11 @@ class adminstyle_infopanel
 				</colgroup>
 				<thead>
 					<tr class='first'>
-						<th>Timestamp</th>
-						<th>Username</th>
-						<th>IP</th>
-						<th>Page</th>
-						<th class='center'>Agent</th>
+						<th>".LAN_SITESTAT_TAB_TIME."</th>
+						<th>".LAN_SITESTAT_TAB_USERN."</th>
+						<th>".LAN_SITESTAT_TAB_IP."</th>
+						<th>".LAN_SITESTAT_TAB_PAGE."</th>
+						<th class='center'>".LAN_SITESTAT_TAB_AGENT."</th>
 					</tr>
 				</thead>
 				<tbody>";	
@@ -496,8 +496,8 @@ class adminstyle_infopanel
 			<li id='comment-".$row['comment_id']."' class='media".$hide."'>
 				<span class='media-object pull-left'>{USER_AVATAR=".$row['comment_author_id']."}</span> 
 				<div class='btn-group pull-right'>
-	            	<button data-target='".e_BASE."comment.php' data-comment-id='".$row['comment_id']."' data-comment-action='delete' class='btn btn-sm btn-mini btn-danger'><i class='icon-remove'></i> Delete</button>
-	            	<button data-target='".e_BASE."comment.php' data-comment-id='".$row['comment_id']."' data-comment-action='approve' class='btn btn-sm btn-mini btn-success'><i class='icon-ok'></i> Approve</button>
+	            	<button data-target='".e_BASE."comment.php' data-comment-id='".$row['comment_id']."' data-comment-action='delete' class='btn btn-sm btn-mini btn-danger'><i class='icon-remove'></i> ".LAN_DELETE."</button>
+	            	<button data-target='".e_BASE."comment.php' data-comment-id='".$row['comment_id']."' data-comment-action='approve' class='btn btn-sm btn-mini btn-success'><i class='icon-ok'></i> ".LAN_APPROVE."</button>
 	            </div>
 				<div class='media-body'><small class='muted smalltext'>Posted by {USERNAME} {TIMEDATE=relative}</small><br />
 					<p>{COMMENT}</p> 
@@ -515,13 +515,13 @@ class adminstyle_infopanel
     	$text .= '
      		</ul>
 		    <div class="right">
-		      <a class="btn btn-mini btn-primary text-right" href="'.e_ADMIN.'comment.php?searchquery=&filter_options=comment_blocked__2">View all</a>
+		      <a class="btn btn-mini btn-primary text-right" href="'.e_ADMIN.'comment.php?searchquery=&filter_options=comment_blocked__2">'.LAN_VIEW_ALL.'</a>
 		    </div>
 		 ';		
 		// $text .= "<small class='text-center text-warning'>Note: Not fully functional at the moment.</small>";
 		
 		$ns = e107::getRender();
-		return $ns->tablerender("Latest Comments",$text,'core-infopanel_online',true);		
+		return $ns->tablerender("".LAN_INF_LCOM."",$text,'core-infopanel_online',true);		
 	}
 		
 		
@@ -550,7 +550,7 @@ class adminstyle_infopanel
 		$ns = e107::getRender();
 		
 		$start = "<div>
-		To customize this page, please <a title = 'Customize Admin' href='".e_SELF."?mode=customize&amp;iframe=1' class='e-modal-iframe'>click here</a>.
+		".LAN_INF_CUST." <a title = '".LAN_INF_CUSTTL."' href='".e_SELF."?mode=customize&amp;iframe=1' class='e-modal-iframe'>".LAN_INF_CUSTCH."</a>.
 		</div>
 	    ";
 	    
@@ -559,16 +559,16 @@ class adminstyle_infopanel
 		$text2 = "<div id='customize_icons' class='forumheader3' style='border:0px;margin:0px'>
 	    <form method='post' id='e-modal-form' action='".e_SELF."'>";
 	    
-		$text2 .= $ns->tablerender("Personalize Icons", $this->render_infopanel_icons(),'personalize',true); 
+		$text2 .= $ns->tablerender("".LAN_INFICON_PERS."", $this->render_infopanel_icons(),'personalize',true); 
 		$text2 .= "<div class='clear'>&nbsp;</div>";
-		$text2 .= $ns->tablerender("Personalize Menus", $this->render_infopanel_menu_options(),'personalize',true); 
+		$text2 .= $ns->tablerender("".LAN_INFMENU_PERS."", $this->render_infopanel_menu_options(),'personalize',true); 
 	//	$text2 .= render_infopanel_icons();
 		//$text2 .= "<div class='clear'>&nbsp;</div>";
 	//	$text2 .= "<h3>Menus</h3>";
 	//	$text2 .= render_infopanel_menu_options();
 		$text2 .= "<div class='clear'>&nbsp;</div>";
 		$text2 .= "<div id='button' class='buttons-bar center'>";
-		$text2 .= $frm->admin_button('submit-mye107', 'Save', 'create');
+		$text2 .= $frm->admin_button('submit-mye107', ''.LAN_SAVE.'', ''.LAN_INF_CREA.'');
 		$text2 .= "</div></form>";
 	//	$text2 .= "</div>";
 		
@@ -677,7 +677,7 @@ class adminstyle_infopanel
 		{
 			$data = array();
 		
-			$data['labels'] 	= array("January","February","March","April","May","June","July");
+			$data['labels'] 	= array("".LAN_SITESTAT_PANEL_DATEJ."","".LAN_SITESTAT_PANEL_DATEF."","".LAN_SITESTAT_PANEL_DATMAR."","".LAN_SITESTAT_PANEL_DATAP."","".LAN_SITESTAT_PANEL_DATMAY."","".LAN_SITESTAT_PANEL_DATJUN."","".LAN_SITESTAT_PANEL_DATJUL."");
 			
 			
 			$data['datasets'][]	= array(
@@ -686,7 +686,7 @@ class adminstyle_infopanel
 								'pointColor '  		=>  "rgba(220,220,220,1)",
 								'pointStrokeColor'  =>  "#fff",
 								'data'				=> array(65,59,90,81,56,55,40),
-								'title'				=> "Visits"
+								'title'				=> "".LAN_SITESTAT_VISITS.""
 				
 			);
 			
@@ -696,7 +696,7 @@ class adminstyle_infopanel
 								'pointColor '  		=>  "rgba(151,187,205,1)",
 								'pointStrokeColor'  =>  "#fff",
 								'data'				=> array(28,48,40,19,96,27,100),
-								'title'				=> "Unique Visits"		
+								'title'				=> "".LAN_SITESTAT_UNI_VISITS.""		
 			);	
 			
 			return $data;
@@ -860,13 +860,12 @@ class adminstyle_infopanel
 			
 		if($type == 'demo')
 		{
-			$text .= "<div class='center'><small>These stats are for demonstration purposes only. <a class='btn btn-mini' href='".e_ADMIN."plugin.php?avail'>Install Site Stats Plugin</a></small></div>";
-		}
+	$text .= "<div class='center'><small> ".LAN_SITESTAT_PANEL_PURPOSE."<a class='btn btn-mini' href='".e_ADMIN."plugin.php?avail'> ".LAN_SITESTAT_PANEL_INSTALL."</a></small></div>";	}
 		else
 		{
 			$text .= "<div class='center'><small>
-			<span style='color:rgba(220,220,220,0.5)'>&diams;</span> Visitors  &nbsp;&nbsp;  
-			<span style='color:rgba(151,187,205,1)'>&diams;</span> Unique Visitors
+			<span style='color:rgba(220,220,220,0.5)'>&diams;</span> ".LAN_SITESTAT_VISITORS."  &nbsp;&nbsp;  
+			<span style='color:rgba(151,187,205,1)'>&diams;</span> ".LAN_SITESTAT_UNI_VISITORS."
 			</small></div>";
 		}
 		

--- a/e107_admin/users.php
+++ b/e107_admin/users.php
@@ -672,7 +672,7 @@ class users_admin_ui extends e_admin_ui
 			$user = e107::getUser();
 			
 			// TODO - lan
-			$mes->addSuccess('Successfully logged in as '.$sysuser->getName().' <a href="'.e_ADMIN_ABS.'users.php?mode=main&amp;action=logoutas">[logout]</a>')
+			$mes->addSuccess(''.LAN_AUTH_USER_MESSAGE.' '.$sysuser->getName().' <a href="'.e_ADMIN_ABS.'users.php?mode=main&amp;action=logoutas">[logout]</a>')
 				->addSuccess('Please, <a href="'.SITEURL.'" rel="external">Leave Admin</a> to browse the system as this user. Use &quot;Logout&quot; option in Administration to end front-end session');
 			
 			$search = array('--UID--', '--NAME--', '--EMAIL--', '--ADMIN_UID--', '--ADMIN_NAME--', '--ADMIN_EMAIL--');
@@ -701,7 +701,7 @@ class users_admin_ui extends e_admin_ui
 	  	if(e107::getUser()->logoutAs() && $sysuser && $sysuser->getId())
 	  	{
 	  		 // TODO - lan
-			e107::getMessage()->addSuccess('Successfully logged out from '.$sysuser->getName().' ('.$sysuser->getValue('email').') account', 'default', true);
+			e107::getMessage()->addSuccess(''.USRLAN_AS_4.' '.$sysuser->getName().' ('.$sysuser->getValue('email').')', 'default', true);
 			
 			$search = array('--UID--', '--NAME--', '--EMAIL--', '--ADMIN_UID--', '--ADMIN_NAME--', '--ADMIN_EMAIL--');
 			$replace = array($sysuser->getId(), $sysuser->getName(), $sysuser->getValue('email'), $user->getId(), $user->getName(), $user->getValue('email'));

--- a/e107_core/shortcodes/batch/admin_shortcodes.php
+++ b/e107_core/shortcodes/batch/admin_shortcodes.php
@@ -30,8 +30,8 @@ class admin_shortcodes
 		
             if($parm=='alert')
             {
-            	$text = 'A new update is ready to install! Click to unzip and install  v'.$cacheData.'</a>.
-            	<a class="btn btn-success" href="'.$installUrl.'">Install</a>'; 
+            	$text = ''.LAN_NEW_UPDATE.''.$cacheData.'</a>.
+            	<a class="btn btn-success" href="'.$installUrl.'">'.LAN_BUTTON_INSTALL.'</a>'; 
 				
                  $mes->addInfo($text);
 				return; //  $mes->render(); 
@@ -46,7 +46,7 @@ class admin_shortcodes
                 	'.E_16_E107.' <b class="caret"></b>
             	</a> 
             	<ul class="dropdown-menu" role="menu">
-                	<li class="nav-header navbar-header">Update Available</li>
+                	<li class="nav-header navbar-header">'.LAN_NAV_HEADU.'</li>
                     <li><a href="'.$installUrl.'">e107 v'.$cacheData.'</a></li>
 	          	 </ul>
 	        	</li>
@@ -869,7 +869,7 @@ class admin_shortcodes
 				unset($tmp);
 			}
 
-			$e107_var['lout']['text']=LAN_LOGOUT;
+			$e107_var['lout']['text']=ADLAN_46;
 			$e107_var['lout']['link']=e_ADMIN_ABS.'admin.php?logout';
 
 			$text = e_admin_menu('', '', $e107_var);
@@ -1634,7 +1634,7 @@ Inverse 	10 	<span class="badge badge-inverse">10</span>
 		{
 			$tmp = array();
 			
-			$tmp[1]['text'] = LAN_SETTINGS;
+			$tmp[1]['text'] = ADLAN_CL_1;
 			$tmp[1]['description'] = ADLAN_151;
 			$tmp[1]['link'] = e_BASE.'usersettings.php';
 			$tmp[1]['image'] =  "<i class='S16 e-settings-16'></i>"; // "<img src='".E_16_CAT_SETT."' alt='".ADLAN_151."' class='icon S16' />";
@@ -1643,7 +1643,7 @@ Inverse 	10 	<span class="badge badge-inverse">10</span>
 			$tmp[1]['image_large_src'] = '';
 			
 						
-			$tmp[2]['text'] = "Personalize"; // TODO - generic LAN in lan_admin.php 
+			$tmp[2]['text'] = LAN_LOGIN_PERSONAL;
 			$tmp[2]['description'] = "Customize administration panels";
 			$tmp[2]['link'] = e_ADMIN.'admin.php?mode=customize';
 			$tmp[2]['image'] =  "<i class='S16 e-admins-16'></i>"; //E_16_ADMIN; // "<img src='".E_16_NAV_ADMIN."' alt='".ADLAN_151."' class='icon S16' />";
@@ -1653,7 +1653,7 @@ Inverse 	10 	<span class="badge badge-inverse">10</span>
 		//	$tmp[2]['perm'] = '';	
 			
 			
-			$tmp[3]['text'] = LAN_LOGOUT;
+			$tmp[3]['text'] = ADLAN_46;
 			$tmp[3]['description'] = ADLAN_151;
 			$tmp[3]['link'] = e_ADMIN_ABS.'admin.php?logout';
 			$tmp[3]['image'] = "<i class='S16 e-logout-16'></i>"; // "<img src='".E_16_NAV_LGOT."' alt='".ADLAN_151."' class='icon S16' />";
@@ -1664,7 +1664,7 @@ Inverse 	10 	<span class="badge badge-inverse">10</span>
 				
 				
 					
-			$tmp[4]['text'] = LAN_LOGOUT;
+			$tmp[4]['text'] = ADLAN_46;
 			$tmp[4]['description'] = ADLAN_151;
 			$tmp[4]['link'] = e_ADMIN_ABS.'admin.php?logout';
 			$tmp[4]['image'] = "";
@@ -1684,7 +1684,7 @@ Inverse 	10 	<span class="badge badge-inverse">10</span>
 			$tmp[5]['link_class']		= '';
 
 										
-			$tmp[6]['text'] 			= "e107 on Twitter";
+			$tmp[6]['text'] 			= LAN_USER_SOCIALTW;
 			$tmp[6]['description'] 		= '';
 			$tmp[6]['link'] 			= 'http://twitter.com/e107';
 			$tmp[6]['image'] 			= E_16_TWITTER; // "<img src='".E_16_NAV_LGOT."' alt='".ADLAN_151."' class='icon S16' />";
@@ -1694,7 +1694,7 @@ Inverse 	10 	<span class="badge badge-inverse">10</span>
 			$tmp[6]['link_class']		= '';
 								
 							
-			$tmp[7]['text'] 			= "e107 on Facebook";
+			$tmp[7]['text'] 			= LAN_USER_SOCIALFAB;
 			$tmp[7]['description'] 		= '';
 			$tmp[7]['link'] 			= 'https://www.facebook.com/e107CMS';
 			$tmp[7]['image'] 			= E_16_FACEBOOK; // "<img src='".E_16_NAV_LGOT."' alt='".ADLAN_151."' class='icon S16' />";
@@ -1704,7 +1704,7 @@ Inverse 	10 	<span class="badge badge-inverse">10</span>
 			$tmp[7]['link_class']		= '';	
 	
 			
-			$tmp[8]['text'] 			= "e107 on Github";
+			$tmp[8]['text'] 			= LAN_USER_SOCIALGIT;
 			$tmp[8]['description'] 		= '';
 			$tmp[8]['link'] 			= 'https://github.com/e107inc';
 			$tmp[8]['image'] 			= E_16_GITHUB; // "<img src='".E_16_NAV_LGOT."' alt='".ADLAN_151."' class='icon S16' />";
@@ -1716,7 +1716,7 @@ Inverse 	10 	<span class="badge badge-inverse">10</span>
 			$menu_vars['logout']['text'] = ADMINNAME; // ""; // ADMINNAME;
 			$menu_vars['logout']['link'] = '#';
 			$menu_vars['logout']['image'] = $tp->toGlyph('fa-user'); // "<i class='icon-user'></i>"; // "<img src='".E_16_NAV_LGOT."' alt='".ADLAN_151."' class='icon S16' />";
-			$menu_vars['logout']['image_src'] = LAN_LOGOUT;
+			$menu_vars['logout']['image_src'] = ADLAN_46;
 			$menu_vars['logout']['sub'] = $tmp;	
 		}
 

--- a/e107_languages/English/English.php
+++ b/e107_languages/English/English.php
@@ -21,7 +21,6 @@ define("CORE_LAN7", "Core is attempting to restore prefs from automatic backup."
 define("CORE_LAN8", "Core Prefs Error");
 define("CORE_LAN9", "Core could not restore from automatic backup. Execution halted.");
 define("CORE_LAN10", "Corrupted cookie detected - logged out.");
-
 // Footer
 define("CORE_LAN11", "Render time: ");
 define("CORE_LAN12", " sec (");
@@ -29,23 +28,19 @@ define("CORE_LAN13", "% of that for queries) ");
 define("CORE_LAN14", "%2.3f cpu sec (%2.2f%% load, %2.3f startup). Clock: ");
 define("CORE_LAN15", "DB queries: ");
 define("CORE_LAN16", "Memory: ");
-
 // img.bb
 define("CORE_LAN17", "[ image disabled ]");
 define("CORE_LAN18", "Image: ");
-
 define("CORE_LAN_B", "B");
 define("CORE_LAN_KB", "kB");
 define("CORE_LAN_MB", "MB");
 define("CORE_LAN_GB", "GB");
 define("CORE_LAN_TB", "TB");
-
 define("EMESSLAN_TITLE_INFO", "System Information");
 define("EMESSLAN_TITLE_ERROR", "Error");
 define("EMESSLAN_TITLE_SUCCESS", "Success");
 define("EMESSLAN_TITLE_WARNING", "Warning");
 define("EMESSLAN_TITLE_DEBUG", "System Debug");
-
 define("LAN_EDIT","Edit");
 define("LAN_DELETE","Delete");
 define("LAN_MORE", "More..");
@@ -83,6 +78,9 @@ define("LAN_LOGOUT", "Logout");
 define("LAN_SETTINGS", "Settings");
 define("LAN_PASSWORD", "Password");
 
-
+define('LAN_E107_NEWS', 		'e107 News');
+define('LAN_WEB_STATUS', 		'Website Status');
+define("LAN_APPROVE", "Approve");
+define("LAN_VIEW_ALL", "View All");
 
 ?>

--- a/e107_languages/English/admin/lan_admin.php
+++ b/e107_languages/English/admin/lan_admin.php
@@ -403,6 +403,21 @@ define("LAN_USER_PRUNE", "Prune Users");
 define("LAN_USER_OPTIONS", "User Options");
 define("LAN_USER_RANKS", "User Ranks");
 
+// dropdown menu admin
+define("LAN_LOGIN_PERSONAL", "Personalize");
+define('LAN_USER_SOCIALTW', 		'e107 on Twitter');
+define('LAN_USER_SOCIALFAB', 		'e107 on Facebook');
+define('LAN_USER_SOCIALGIT', 		'e107 on Github');
+
+define("LAN_NEW_UPDATE", "A new update is ready to install! Click to unzip and install  v");
+define("LAN_BUTTON_INSTALL", "Install");
+define("LAN_NAV_HEADU", "Update available");
+
+// V2      hover messages and  system information
+define("LAN_LOGIN_ADMINNAME_HOVER", "Please enter your username or email");// auth php
+define("LAN_LOGIN_ADMINPWF_HOVER", "Password is required"); //auth php
+define("LAN_AUTH_USER_MESSAGE", "Successfully logged in as ");  // in auth php and user php
+
 
 
 // TODO - move e_form related LANS below, add new lan_form.php file (for both front/back-end)

--- a/e107_languages/English/admin/lan_footer.php
+++ b/e107_languages/English/admin/lan_footer.php
@@ -26,4 +26,33 @@ define("FOOTLAN_17", "Charset");
 define("FOOTLAN_18", "Site Theme");
 define("FOOTLAN_19", "Server Time");
 define("FOOTLAN_20", "Security level");
+
+//Admin Stat Infopanel  LANs
+define("LAN_ADMIN_TITEL_CP", "'s Control Panel");
+define("LAN_INF_LCOM", "Latest Comments");
+define("LAN_INF_CUST", "To customize this page, please ");
+define("LAN_INF_CUSTTL", "Customize Admin ");
+define("LAN_INF_CUSTCH", "click here ");
+define("LAN_INFICON_PERS", "Personalize Icons ");
+define("LAN_INFMENU_PERS", "Personalize Menus ");
+define("LAN_INF_CREA", "create ");
+
+define("LAN_SITESTAT_PANEL_PURPOSE", "These stats are for demonstration purposes only.");
+define("LAN_SITESTAT_PANEL_INSTALL", "Install Site Stats Plugin");
+define("LAN_SITESTAT_PANEL_DATEJ", "January");
+define("LAN_SITESTAT_PANEL_DATEF", "February");
+define("LAN_SITESTAT_PANEL_DATMAR", "March");
+define("LAN_SITESTAT_PANEL_DATAP", "April");
+define("LAN_SITESTAT_PANEL_DATMAY", "May");
+define("LAN_SITESTAT_PANEL_DATJUN", "June");
+define("LAN_SITESTAT_PANEL_DATJUL", "July");
+define("LAN_SITESTAT_VISITS", "Visits");
+define("LAN_SITESTAT_VISITORS", "Visitors");
+define("LAN_SITESTAT_UNI_VISITS", "Unique Visits");
+define("LAN_SITESTAT_UNI_VISITORS", "Unique Visitors");
+define("LAN_SITESTAT_TAB_TIME", "Timestamp");
+define("LAN_SITESTAT_TAB_USERN", "Username");
+define("LAN_SITESTAT_TAB_PAGE", "Page");
+define("LAN_SITESTAT_TAB_AGENT", "Agent");
+define("LAN_SITESTAT_TAB_IP", "IP");
 ?>

--- a/e107_languages/English/admin/lan_users.php
+++ b/e107_languages/English/admin/lan_users.php
@@ -297,6 +297,6 @@ define("USFLAN_7", "User Information");
 define('USRLAN_AS_1', 'Login as %s'); //FIXME use [x]
 define('USRLAN_AS_2', 'Logout from %s account');
 define('USRLAN_AS_3', 'You are already logged in as another user account. Please logout first.');
+define('USRLAN_AS_4', 'Successfully logged out from account  ');
 
-// Always search lan_admin.php before adding more. 
-
+define("LAN_AUTH_USER_MESSAGE", "Successfuly logged in as ");  // in auth php & users php


### PR DESCRIPTION
Txts replaced by LANs, where needed created defines in files active in region and most likely (if none existing)
Worked on : 
E......admin/ admin php  hovering txt's
Admin > dropdown admin option (personalize AND  links txt lan's )
Admin> stats DEMO panel (up to installed )

Note : installed stats screendisplays  the  3 digit DAY ;  is likely coded ? > can not find it....

hope i've got everything, tested a lot embed screenshot to display what has changed (Dutch = new defines working)

![pers](https://cloud.githubusercontent.com/assets/1811857/8145216/b8704472-11ff-11e5-8c39-8bab7759c4ae.jpg)
![demo](https://cloud.githubusercontent.com/assets/1811857/8145215/b86f0242-11ff-11e5-9a7d-434c0fd57beb.jpg)
![installed](https://cloud.githubusercontent.com/assets/1811857/8145217/b87120b8-11ff-11e5-956e-9888ba1ed922.jpg)
![logg](https://cloud.githubusercontent.com/assets/1811857/8145218/b871d058-11ff-11e5-9991-2b12c79b4bf8.jpg)

I am aware it is not probably the best way (workflow) but Dutch is quite well developed so any non working will show quickly