### PR TITLE
Update forum_post.php

### DIFF
--- a/e107_plugins/forum/forum_post.php
+++ b/e107_plugins/forum/forum_post.php
@@ -1046,7 +1046,7 @@ class forum_post_handler
 
 	//	$url = e107::getUrl()->create('forum/thread/post', "id={$this->data['post_id']}", 'encode=0&full=1'); // XXX what data is available, find thread name
 
-		$url = e107::url('forum','topic',$this->data,true); // ."&f=post";
+		$url = e107::url('forum','topic',$this->data); // ."&f=post";
 
 		$this->redirect($url);
 


### PR DESCRIPTION
under function updateReply()
$url = e107::url('forum','topic',$this->data,true);
to
$url = e107::url('forum','topic',$this->data);

With true at the end, I get the redirect url creating a recursive e107_plugins/forum within the url and causing a 404.