### PR TITLE
Placeholder (required) field on login menu (menu) AND signup field

### DIFF
--- a/e107_handlers/form_handler.php
+++ b/e107_handlers/form_handler.php
@@ -3152,7 +3152,7 @@ class e_form
 					{
 						$mode = preg_replace('/[^\w]/', '', vartrue($_GET['mode'], ''));
 						$from = intval(vartrue($_GET['from'],0));
-						$value .= "<a class='e-sort sort-trigger btn btn-default' style='cursor:move' data-target='".e_SELF."?mode={$mode}&action=sort&ajax_used=1&from={$from}' title='Re-order'>".ADMIN_SORT_ICON."</a> ";	
+						$value .= "<a class='e-sort sort-trigger btn btn-default' style='cursor:move' data-target='".e_SELF."?mode={$mode}&action=sort&ajax_used=1&from={$from}' title='".LAN_RE_ORDER."'>".ADMIN_SORT_ICON."</a> ";	
 					}	
 					
 					$cls = false;

--- a/e107_languages/English/English.php
+++ b/e107_languages/English/English.php
@@ -113,6 +113,7 @@ define("LAN_USER", "User");
 define("LAN_EMAIL","Email address");
 define("LAN_WROTE", "wrote"); // as in John wrote.."  ";
 define("LAN_SEARCH", "Search");
+define("LAN_RE_ORDER", "Re-order");
 
 define("LAN_ENTER_USRNAME_EMAIL", "Please enter your username or email"); // admin php hover field admin name
 define("LAN_PWD_REQUIRED", "Password is required"); // admin php hover field admin password

--- a/e107_plugins/forum/e_frontpage.php
+++ b/e107_plugins/forum/e_frontpage.php
@@ -2,6 +2,7 @@
 
 if (!defined('e107_INIT')) { exit; }
 
+e107::lan('forum', "front", true);
 // e107::lan('forum', 'English_front');
 
 /**

--- a/e107_plugins/forum/e_linkgen.php
+++ b/e107_plugins/forum/e_linkgen.php
@@ -13,7 +13,8 @@ if (!defined('e107_INIT')) { exit; }
 // Usage: sublink_type[x]['title'].
 //  x should be the same as the plugin folder.
 
-include_lan(e_PLUGIN.'forum/languages/'.e_LANGUAGE.'/lan_forum_admin.php'); // FIXME needs changing after forum lan rewrite
+e107::lan('forum', "admin", true);
+//include_lan(e_PLUGIN.'forum/languages/'.e_LANGUAGE.'/lan_forum_admin.php'); // FIXME needs changing after forum lan rewrite
 
 $sublink_type['forum']['title'] = FORLAN_155; // "News Categories"; // FIXME needs changing after forum lan rewrite
 $sublink_type['forum']['table'] = 'forum';

--- a/e107_plugins/forum/e_search.php
+++ b/e107_plugins/forum/e_search.php
@@ -1,7 +1,8 @@
 <?php
 if (!defined('e107_INIT')) { exit(); }
 
-include_lan(e_PLUGIN.'forum/languages/'.e_LANGUAGE.'/'.e_LANGUAGE.'_search.php');
+e107::lan('forum', "search", true);
+//include_lan(e_PLUGIN.'forum/languages/'.e_LANGUAGE.'/'.e_LANGUAGE.'_search.php');
 
 $search_info[] = array(
 	'sfile' => e_PLUGIN.'forum/search/search_parser.php', 

--- a/e107_plugins/forum/forum.php
+++ b/e107_plugins/forum/forum.php
@@ -23,7 +23,7 @@ if (!$e107->isInstalled('forum'))
 	header('Location: '.SITEURL);
 	exit;
 }
-
+e107::lan('forum', "front", true);
 // include_lan(e_PLUGIN.'forum/languages/'.e_LANGUAGE.'/lan_forum.php'); // using English_front.php now
 
 require_once(e_PLUGIN.'forum/forum_class.php');

--- a/e107_plugins/forum/forum_admin.php
+++ b/e107_plugins/forum/forum_admin.php
@@ -17,8 +17,9 @@ if (!getperms('P'))
 }
 
 
-e107::includeLan(e_PLUGIN.'forum/languages/'.e_LANGUAGE.'/English_admin.php');
-	e107::lan('forum','', 'front');
+e107::lan('forum', 'admin');
+//e107::includeLan(e_PLUGIN.'forum/languages/'.e_LANGUAGE.'/English_admin.php');
+//e107::lan('forum','', 'front');
 
 $legacy = false;
 

--- a/e107_plugins/forum/forum_conf.php
+++ b/e107_plugins/forum/forum_conf.php
@@ -22,7 +22,8 @@ $tp = e107::getParser();
 require_once(e_PLUGIN.'forum/forum_class.php');
 $forum = new e107forum;
 
-include_lan(e_PLUGIN.'forum/languages/'.e_LANGUAGE.'/lan_forum_conf.php');
+e107::lan('forum', 'admin');
+//include_lan(e_PLUGIN.'forum/languages/'.e_LANGUAGE.'/lan_forum_conf.php');
 
 $e_sub_cat = 'forum';
 

--- a/e107_plugins/forum/forum_post.php
+++ b/e107_plugins/forum/forum_post.php
@@ -31,7 +31,8 @@ if (!$e107->isInstalled('forum'))
 	exit;
 }
 
-e107::lan('forum','English_front');
+//e107::lan('forum','English_front');
+e107::lan('forum', "front", true);
 e107::css('forum','forum.css');
 
 

--- a/e107_plugins/forum/forum_stats.php
+++ b/e107_plugins/forum/forum_stats.php
@@ -30,8 +30,9 @@ class forumStats
 
 	function __construct()
 	{
-		include_lan(e_PLUGIN.'forum/languages/'.e_LANGUAGE.'/lan_forum_stats.php');
-		e107::lan('forum','front');
+		//include_lan(e_PLUGIN.'forum/languages/'.e_LANGUAGE.'/lan_forum_stats.php');
+		//e107::lan('forum','front');
+		e107::lan('forum', "front", true);
 		e107::css('forum', 'forum.css');
 	}
 

--- a/e107_plugins/forum/forum_viewforum.php
+++ b/e107_plugins/forum/forum_viewforum.php
@@ -20,6 +20,7 @@ if (!$e107->isInstalled('forum'))
 	header('Location: '.SITEURL);
 	exit;
 }
+e107::lan('forum', "front", true);
 //include_lan(e_PLUGIN.'forum/languages/'.e_LANGUAGE.'/lan_forum_viewforum.php'); // now uses English_front.php
 define('NAVIGATION_ACTIVE','forum');
 

--- a/e107_plugins/forum/forum_viewtopic.php
+++ b/e107_plugins/forum/forum_viewtopic.php
@@ -15,6 +15,7 @@ if(!defined('e107_INIT'))
 	require_once('../../class2.php');
 }
 
+e107::lan('forum', "front", true);
 define('NAVIGATION_ACTIVE','forum');
 
 $e107 = e107::getInstance();

--- a/e107_plugins/login_menu/login_menu_shortcodes.php
+++ b/e107_plugins/login_menu/login_menu_shortcodes.php
@@ -98,7 +98,7 @@ e107::getLanguage()->bcDefs($bcDefs);
 			function sc_lm_password_input($parm='')
 			{
 				$pref = e107::getPref();
-				$t_password = "<input class='form-control tbox login pass' type='password' placeholder='Password' required='required' name='userpass' id='userpass' size='15' value='' maxlength='30' />\n";
+				$t_password = "<input class='form-control tbox login pass' type='password' placeholder='".LAN_PASSWORD."' required='required' name='userpass' id='userpass' size='15' value='' maxlength='30' />\n";
 				if (!USER && e107::getSession()->is('challenge') && varset($pref['password_CHAP'],0)) $t_password .= "<input type='hidden' name='hashchallenge' id='hashchallenge' value='".e107::getSession()->get('challenge')."' />\n\n";
 				return $t_password;
 			}


### PR DESCRIPTION
Required placeholder field for Password (translation) hardcoded txt replaced by LAN, hover field admin icon (re-order), and latest commit to be able to use forum plugin translated defines (not fully implemented at previous state?)