### PR TITLE
translation for messages when installing/deinstalling plugins admin s…

### DIFF
--- a/e107_admin/plugin.php
+++ b/e107_admin/plugin.php
@@ -1573,7 +1573,7 @@ class pluginManager{
 				}
 
 				$opts['delete_ipool'] = array(
-					'label'			=>'Remove icons from Media-Manager',
+					'label'			=> LAN_REM_ICONS,
 					'preview'		=> $iconText,
 					'helpText'		=> EPL_ADLAN_79,
 					'itemList'		=> array(1=>LAN_YES,0=>LAN_NO),

--- a/e107_handlers/plugin_class.php
+++ b/e107_handlers/plugin_class.php
@@ -531,7 +531,7 @@ class e107plugin
 			if (vartrue($this->unInstallOpts['delete_ipool'], FALSE))
 			{
 				$status = ($med->removePath(e_PLUGIN.$plugin, 'icon')) ? E_MESSAGE_SUCCESS : E_MESSAGE_ERROR;
-				$mes->add('Removing Icons from Media-Manager', $status);
+				$mes->add( LAN_REM_ICONS, $status);
 			}
 			return;
 		}
@@ -661,7 +661,7 @@ class e107plugin
 		$type = $this->ue_field_type($field_attrib);
 		$type_name = $this->ue_field_type_name($type);
 		
-		$mes->addDebug("Extended Field: ".$action.": ".$field_name." : ".$type_name);
+		$mes->addDebug("".LAN_EXTF." ".$action.": ".$field_name." : ".$type_name);
 		
 		// predefined
 		if($type == EUF_PREFIELD)
@@ -1609,7 +1609,7 @@ class e107plugin
 		{
 			if ($function == 'install')
 			{
-				$text = "Installation Complete.";
+				$text = LAN_INST_COMP;
 
 				if ($this->plugConfigFile)
 				{
@@ -1693,7 +1693,7 @@ class e107plugin
 						$query .= $tableData['data'][$k];
 						$query .= "\n) ENGINE=". vartrue($tableData['engine'][$k],"InnoDB")." DEFAULT CHARSET=utf8 ";
 
-						$txt = "Adding Table: <b>{$v}</b> ";
+						$txt = "".LAN_ADD_TABLE." <b>{$v}</b> ";
 						$status = $sql->db_Query($query) ? E_MESSAGE_SUCCESS : E_MESSAGE_ERROR;
 						break;
 
@@ -1701,7 +1701,7 @@ class e107plugin
 						if (!empty($options['delete_tables']))
 						{
 							$query = "DROP TABLE  `".MPREFIX.$v."`; ";
-							$txt = "Removing Table: {$v} <br />";
+							$txt = "".LAN_REM_TABLE." {$v} <br />";
 							$status = $sql->db_Query_all($query) ? E_MESSAGE_SUCCESS : E_MESSAGE_ERROR;
 
 						}
@@ -2007,14 +2007,14 @@ class e107plugin
 						if($result !== NULL)
 						{
 							$status = ($result) ? E_MESSAGE_SUCCESS : E_MESSAGE_ERROR;
-							$mes->add("Adding Link: {$linkName} with url [{$url}] and perm {$perm} ", $status); 
+							$mes->add("".LAN_ADD_LINK." {$linkName} ".LAN_INC_URL." [{$url}] ".LAN_PERM." {$perm} ", $status); 
 						}					
 					}
 
 					if ($function == 'upgrade' && $remove) //remove inactive links on upgrade
 					{
 						$status = ($this->manage_link('remove', $url, $linkName,false, $options)) ? E_MESSAGE_SUCCESS : E_MESSAGE_ERROR;
-						$mes->add("Removing Link: {$linkName} with url [{$url}]", $status);
+						$mes->add("".LAN_REM_LINK." {$linkName} ".LAN_INC_URL." [{$url}]", $status);
 					}
 					break;
 
@@ -2024,7 +2024,7 @@ class e107plugin
 				case 'uninstall': //remove all links
 
 					$status = ($this->manage_link('remove', $url, $linkName, $perm, $options)) ? E_MESSAGE_SUCCESS : E_MESSAGE_ERROR;
-					$mes->add("Removing Link: {$linkName} with url [{$url}]", $status);
+					$mes->add("".LAN_REM_LINK." {$linkName} ".LAN_INC_URL." [{$url}]", $status);
 					break;
 			}
 		}
@@ -2201,7 +2201,7 @@ class e107plugin
 						if($result !== NULL)
 						{
 							$status = ($result) ? E_MESSAGE_SUCCESS : E_MESSAGE_ERROR;
-							$mes->add('Adding Userclass: '.$name, $status);	
+							$mes->add( LAN_ADD_EXTFIELD .$name, $status);	
 						}						
 					}
 
@@ -2209,7 +2209,7 @@ class e107plugin
 
 					{
 						$status = $this->manage_userclass('remove', $name, $description) ? E_MESSAGE_SUCCESS : E_MESSAGE_ERROR;
-						$mes->add('Removing Userclass: '.$name, $status);
+						$mes->add( LAN_REM_EXTFIELD .$name, $status);
 					}
 
 					break;
@@ -2219,7 +2219,7 @@ class e107plugin
 					if (vartrue($this->unInstallOpts['delete_userclasses'], FALSE))
 					{
 						$status = $this->manage_userclass('remove', $name, $description) ? E_MESSAGE_SUCCESS : E_MESSAGE_ERROR;
-						$mes->add('Removing Userclass: '.$name, $status);
+						$mes->add( LAN_REM_USCLS .$name, $status);
 					}
 					else
 					{
@@ -2268,14 +2268,14 @@ class e107plugin
 						//$status = $this->manage_extended_field('add', $name, $type, $attrib['default'], $source) ? E_MESSAGE_SUCCESS : E_MESSAGE_ERROR;
 
 						$status = $this->manage_extended_field('add', $name, $attrib, $source) ? E_MESSAGE_SUCCESS : E_MESSAGE_ERROR;
-						$mes->add('Adding Extended Field: '.$name.' ... ', $status);
+						$mes->add( LAN_ADD_EXTFIELD .$name.' ... ', $status);
 					}
 
 					if ($function == 'upgrade' && $remove) //If upgrading, removing any inactive extended fields
 
 					{
 						$status = $this->manage_extended_field('remove', $name, $attrib, $source) ? E_MESSAGE_SUCCESS : E_MESSAGE_ERROR;
-						$mes->add('Removing Extended Field: '.$name.' ... ', $status);
+						$mes->add( LAN_REM_EXTFIELD .$name.' ... ', $status);
 					}
 					break;
 
@@ -2284,11 +2284,11 @@ class e107plugin
 					if (vartrue($this->unInstallOpts['delete_xfields'], FALSE))
 					{
 						$status = ($this->manage_extended_field('remove', $name, $attrib, $source)) ? E_MESSAGE_SUCCESS : E_MESSAGE_ERROR;
-						$mes->add('Removing Extended Field: '.$name.' ... ', $status);
+						$mes->add( LAN_REM_EXTFIELD .$name.' ... ', $status);
 					}
 					else
 					{
-						$mes->add('Extended Field: '.$name.' left in place', E_MESSAGE_SUCCESS);
+						$mes->add( LAN_EXTF .$name.  LAN_EXTF_PL , E_MESSAGE_SUCCESS);
 					}
 					break;
 			}
@@ -2342,7 +2342,7 @@ class e107plugin
 					$ret = $config->add($key, $value);
 					if($ret->data_has_changed == TRUE)
 					{
-						$mes->addSuccess("Adding Pref: ".$key);	
+						$mes->addSuccess("".LAN_ADD_PREF."".$key);	
 					}								
 					break;
 
@@ -2352,19 +2352,19 @@ class e107plugin
 
 					{
 						$config->remove($key, $value);
-						$mes->addSuccess("Removing Pref: ".$key);
+						$mes->addSuccess(" ".LAN_REM_PREF." ".$key);
 					}
 					else
 					{
 						$config->update($key, $value);
-						$mes->addSuccess("Updating Pref: ".$key);
+						$mes->addSuccess(LAN_UPD_PREF .$key);
 					}
 
 					break;
 
 				case 'uninstall':
 					$config->remove($key, $value);
-					$mes->addSuccess("Removing Pref: ".$key);
+					$mes->addSuccess("".LAN_REM_PREF." ".$key);
 					break;
 			}
 		}

--- a/e107_handlers/pref_class.php
+++ b/e107_handlers/pref_class.php
@@ -599,7 +599,7 @@ class e_pref extends e_front_model
 					$logId = 'PREFS_01';	
 				}
 				
-				$log->addSuccess('Settings successfully saved.', ($session_messages === null || $session_messages === true));
+				$log->addSuccess( LAN_SET_SAVE, ($session_messages === null || $session_messages === true));
 
 				$uid = USERID;
 

--- a/e107_languages/English/admin/lan_admin.php
+++ b/e107_languages/English/admin/lan_admin.php
@@ -363,6 +363,28 @@ define("LAN_PREVIEW", "Preview");
 define("LAN_CREATE_CATEGORY", "Create Category");
 define("LAN_CREATE_ITEM",	"Create Item");
 
+//plugin related messages
+define("LAN_ADD_TABLE",	"Adding Table:");
+define("LAN_ADD_LINK",	"Adding Link:");
+define("LAN_ADD_PREF",	"Adding Pref:");
+define("LAN_ADD_USCLS",	"Adding Userclass:");
+define("LAN_REM_USCLS",	"Removing Userclass:");
+define("LAN_ADD_EXTFIELD",	"Adding Extended Field:");
+define("LAN_REM_EXTFIELD",	"Removing Extended Field:");
+define("LAN_REM_TABLE",	"Removing Table:");
+define("LAN_REM_PREF",	"Removing Pref:");
+define("LAN_REM_ICONS",	"Removing Icons from Media-manager:");
+define("LAN_REM_LINK",	"Removing Link:");
+define("LAN_SET_SAVE",	"Settings successfully saved:");
+define("LAN_INST_COMP",	"Installation Complete.");
+define("LAN_INC_URL",	"with url"); 
+define("LAN_PERM",	"and perm ");
+define("LAN_EXTF",	"Extended Field: ");
+define("LAN_EXTF_PL",	".left in place ");
+define("LAN_UPD_PREF",	"Updating Pref: ");
+
+
+
 
 define("LAN_SECURITYL_0", "Looking for trouble (none)");
 define("LAN_SECURITYL_5", "Balanced");

--- a/e107_plugins/forum/forum_admin.php
+++ b/e107_plugins/forum/forum_admin.php
@@ -17,7 +17,7 @@ if (!getperms('P'))
 }
 
 
-e107::lan('forum', 'admin',true);
+e107::lan('forum', 'admin', true);
 e107::lan('forum','front', true);
 //e107::includeLan(e_PLUGIN.'forum/languages/'.e_LANGUAGE.'/English_admin.php');
 //e107::lan('forum','', 'front');

--- a/e107_plugins/forum/forum_admin.php
+++ b/e107_plugins/forum/forum_admin.php
@@ -17,7 +17,7 @@ if (!getperms('P'))
 }
 
 
-e107::lan('forum', 'admin');
+e107::lan('forum', 'admin',true);
 e107::lan('forum','front', true);
 //e107::includeLan(e_PLUGIN.'forum/languages/'.e_LANGUAGE.'/English_admin.php');
 //e107::lan('forum','', 'front');


### PR DESCRIPTION
…creen (most common used)

(i am aware of using double quotes (double); but too much change has effect on following lines so walked the path between; so it becomes functional, and throws no errors (lack in coding skills, or missing things, since all LAN's need different approaches  depending position in code line..)