### PR TITLE
redefined LANs (install) #6 #1193 (latest)

### DIFF
--- a/e107_languages/English/lan_installer.php
+++ b/e107_languages/English/lan_installer.php
@@ -171,3 +171,17 @@ define("LANINS_126", "For security reasons you should now set the file permissio
 define("LANINS_127", "The database [x] already exists. Overwrite it? (any existing data will be lost)"); 
 define("LANINS_128", "Overwrite");
 define("LANINS_129", "Database not found.");
+define("LANINS_130", "Installation");
+define("LANINS_131", "of");   //single time use installer only as in .1 of 8  not replacing by LAN_SEARCH_12
+define("LANINS_132", "Deleted existing database");
+define("LANINS_133", "Found existing database");
+define("LANINS_134", "Version");
+
+define("LANINS_141", "Please fill in the form below with your MySQL details. If you do not know this information, please contact your hosting provider. You may hover over each field for additional information.");
+define("LANINS_142", "IMPORTANT: Please rename e107.htaccess to .htaccess");
+define("LANINS_143", "DEBUG: Rename from e107.htaccess to .htaccess was successful");
+define("LANINS_144", "IMPORTANT: Please copy and paste the contents of the [b]e107.htaccess[/b] into your [b].htaccess[/b] file. Please take care NOT to overwrite any existing data that may be in it.");
+define("LANINS_145", "A minimum version of PHP");
+define("LANINS_146", "is required");
+
+

--- a/e107_plugins/forum/forum_admin.php
+++ b/e107_plugins/forum/forum_admin.php
@@ -17,7 +17,7 @@ if (!getperms('P'))
 }
 
 
-e107::lan('forum', 'admin');
+e107::lan('forum', 'admin',true);
 e107::lan('forum','front', true);
 //e107::includeLan(e_PLUGIN.'forum/languages/'.e_LANGUAGE.'/English_admin.php');
 //e107::lan('forum','', 'front');
@@ -80,7 +80,7 @@ if(!deftrue('OLD_FORUMADMIN'))
 			'main/prefs' 		=> array('caption'=> LAN_PREFS, 'perm' => 'P'),
 			'opt2'              => array('divider'=>true),
 			'report/list'         => array('caption'=> FORLAN_116, 'perm'=>'P'),
-			'post/list'         => array('caption'=>"Latest Posts", 'perm'=>'P'),
+			'post/list'         => array('caption'=>FORLAN_188, 'perm'=>'P'),
 			'main/prune'		=> array('caption'=> LAN_PRUNE, 'perm' => 'P'),
 			'main/tools'        => array('caption'=>FORLAN_153, 'perm'=>'p')
 
@@ -1046,7 +1046,7 @@ if(!deftrue('OLD_FORUMADMIN'))
 
 		public function renderHelp()
 		{
-			return array('caption'=>'Help', 'text'=>"<p>Click the 'delete' button to delete the report. <br /><br />Click the 'view' button to view the topic/thread</p>");
+			return array('caption'=>LAN_HELP, 'text'=> FORLAN_189);
 
 		}
 

--- a/e107_plugins/forum/languages/English/English_admin.php
+++ b/e107_plugins/forum/languages/English/English_admin.php
@@ -211,5 +211,7 @@ define("FORLAN_185", "Indicates who can create new threads");
 
 define("FORLAN_186", "Threads per page");
 define("FORLAN_187", "Number of threads displayed per page");
+define("FORLAN_188", "Latest Posts");
+define("FORLAN_189", "Click the 'delete' button to delete the report.<br /><br />Click the 'view' button to view the topic/thread");
 
 ?>

--- a/install.php
+++ b/install.php
@@ -440,7 +440,7 @@ class e_install
 		
 		// $this->template->SetTag("onload", "document.getElementById('name').focus()");
 		// $page_info = nl2br(LANINS_023);
-		$page_info = "<div class='alert alert-block alert-info'>Please fill in the form below with your MySQL details. If you do not know this information, please contact your hosting provider. You may hover over each field for additional information.</div>";
+		$page_info = "<div class='alert alert-block alert-info'>".LANINS_141."</div>";
 		$e_forms->start_form("versions", $_SERVER['PHP_SELF'].($_SERVER['QUERY_STRING'] == "debug" ? "?debug" : ""));
 		$isrequired = (($_SERVER['SERVER_ADDR'] == "127.0.0.1") || ($_SERVER['SERVER_ADDR'] == "localhost") || ($_SERVER['SERVER_ADDR'] == "::1") || preg_match('^192\.168\.\d{1,3}\.\d{1,3}$',$_SERVER['SERVER_ADDR'])) ? "" :  "required='required'"; // Deals with IP V6, and 192.168.x.x address ranges, could be improved to validate x.x to a valid IP but for this use, I dont think its required to be that picky.
 
@@ -670,7 +670,7 @@ class e_install
 				{
 					if($this->dbqry('DROP DATABASE `'.$this->previous_steps['mysql']['db'].'` '))
 					{
-						$page_content .= "<br /><span class='glyphicon glyphicon-ok'></span> Deleted existing database";
+						$page_content .= "<br /><span class='glyphicon glyphicon-ok'></span> ".LANINS_132;
 					}
 					else 
 					{
@@ -688,7 +688,7 @@ class e_install
 				}
 				else
 				{
-					$notification = "<br /><span class='glyphicon glyphicon-ok'></span> Found existing database";
+					$notification = "<br /><span class='glyphicon glyphicon-ok'></span> ".LANINS_133;
 				    $query = 'ALTER DATABASE `'.$this->previous_steps['mysql']['db'].'` CHARACTER SET `utf8` ';
 				}
 
@@ -1347,17 +1347,17 @@ class e_install
 		{
 			if(!rename("e107.htaccess",".htaccess"))
 			{
-				$error = "IMPORTANT: Please rename e107.htaccess to .htaccess";
+				$error = LANINS_142;
 			}
 			elseif($_SERVER['QUERY_STRING'] == "debug")
 			{
 				rename(".htaccess","e107.htaccess");
-				$error = "DEBUG: Rename from e107.htaccess to .htaccess was successful";		
+				$error = LANINS_143;		
 			}
 		}
 		elseif(file_exists("e107.htaccess"))
 		{		
-			$error = "IMPORTANT: Please copy and paste the contents of the <b>e107.htaccess</b> into your <b>.htaccess</b> file. Please take care NOT to overwrite any existing data that may be in it.";				
+			$error = LANINS_144;				
 		}		
 		return $error;	
 	}
@@ -2017,7 +2017,7 @@ function template_data()
 
 		  <div class="masthead">
 			<ul class="nav nav-pills pull-right" >
-			  <li class="active" style="width:200px;text-align:center" ><a href="#" >Installation: {stage_pre} {stage_num} of 8</a>
+			  <li class="active" style="width:200px;text-align:center" ><a href="#" >'.LANINS_130.' &#58 {stage_pre} {stage_num} '.LANINS_131.' 8</a>
 			  <div class="progress progress-{bartype}">
 				<div class="progress-bar bar" style="width: {percent}%"></div>
 			</div>
@@ -2042,7 +2042,7 @@ function template_data()
 
 		  <div class="footer">
 			<p class="pull-left">&copy; e107 Inc. '.date("Y").'</p>
-			<p class="pull-right">Version: '.e_VERSION.'</p> 
+			<p class="pull-right">'.LANINS_134.' &#58 '.e_VERSION.'</p> 
 		  </div>
 		 <div>{debug_info}</div>
 		</div> <!-- /container -->


### PR DESCRIPTION
Amended LAN defines>  third version;  as i found out that NOT all texts inside can carry LANs at certain positions > lines involved  up to 350.(install php)
 (most > die fatal error lines :  'hidden' when 5.3 is running and all is as should. 
Up to that point ( around 350) LANs are not being called ( testcase php 4.*  with added lan's display the lans, not the defines)...(as mentioned hidden if all is correct on newer version of php).

(Note : unsure for LAN 142,143,144 as i can  not access/trigger them)

Not translated are : 
logLines.... are NOT transformed to LAN's (reason : international sharing of logs when errors appear)
template >SetTag..lines .. are NOT transformed to LAN's.
( if i am correct and also above (log/TAG) is ok,, this would be the last revision for install php and language use). 

Second commit : forum  since no reaction and working method #1177 is covered  + update caption/help file