### PR TITLE
Update chapter_template.php

### DIFF
--- a/e107_core/templates/chapter_template.php
+++ b/e107_core/templates/chapter_template.php
@@ -111,15 +111,15 @@ $CHAPTER_TEMPLATE['nav']['showPage'] = $CHAPTER_TEMPLATE['nav']['listChapters'];
 
 // Used by e107_plugins/page/chapter_menu.php & /page.php?bk=x
 $CHAPTER_TEMPLATE['panel']['listChapters']['caption']			= "{BOOK_NAME}";
-$CHAPTER_TEMPLATE['panel']['listChapters']['start']				= "<div class='chapter-panel-list'>";
-$CHAPTER_TEMPLATE['panel']['listChapters']['item']				= "<div class='col-xs-12 col-md-4 text-center'>
-																	<h2>{CHAPTER_NAME}</h2>
+$CHAPTER_TEMPLATE['panel']['listChapters']['start']				= "<div class='row chapter-panel-list'>";
+$CHAPTER_TEMPLATE['panel']['listChapters']['item']				= "<div class='col-xs-12 col-md-4'>
+																	<h2 class='text-center'>{CHAPTER_NAME}</h2>
          															<h1><a href='{CHAPTER_URL}' >{CHAPTER_ICON}</a></h1><p>{CHAPTER_DESCRIPTION}</p><p>{CHAPTER_BUTTON}</p></div>";
 $CHAPTER_TEMPLATE['panel']['listChapters']['end']				= "</div>";
 
 
 $CHAPTER_TEMPLATE['panel']['listPages']['caption']				= "{CHAPTER_NAME}";
-$CHAPTER_TEMPLATE['panel']['listPages']['start'] 				= "{CHAPTER_BREADCRUMB}<div class='chapter-pages-list'>";
+$CHAPTER_TEMPLATE['panel']['listPages']['start'] 				= "{CHAPTER_BREADCRUMB}<div class='chapter-pages-list col-sm-12'>";
 $CHAPTER_TEMPLATE['panel']['listPages']['item'] 				= "<div class='section'><div class='row'>{CPAGEMENU}</div></div>";
 $CHAPTER_TEMPLATE['panel']['listPages']['end'] 					= "</div>";	
 


### PR DESCRIPTION
Some style fixes. At chapter panel, chapter-pages-list class div have a row class div inside, that make the content to expand outside of chapter-pages-list class div, so I added a col-sm-12 class to pull the content inside. Other solution can be to remove the class row.
At books panel, chapter-panel-list class div have inside a col-xs-12 class div inside that add 15px. padding/gap on the sides, in this way at list borders (left and right) we have also 15px. padding/gap, so I added class row to the parent div (.chapter-panel-list) and now the list looks good without 15px. gap on sides.