### PR TITLE
Hide drag-n-drop re-ordering icon if "private $sortField" is not set.

### DIFF
--- a/e107_handlers/admin_ui.php
+++ b/e107_handlers/admin_ui.php
@@ -2561,8 +2561,15 @@ class e_admin_controller_ui extends e_admin_controller
 	{
 		return deftrue($this->pluginTitle, $this->pluginTitle);
 	}
-	
-	
+
+	/**
+	 * Get Sort Field data
+	 * @return string
+	 */
+	public function getSortField()
+	{
+		return $this->sortField;
+	}
 	
 	/**
 	 * Get Tab data
@@ -5808,6 +5815,11 @@ class e_admin_form_ui extends e_form
 			{
 				$fields[$k]['inline'] = false;
 			}
+		}
+
+		if(!$controller->getSortField())
+		{
+			$fields['options']['sort'] = false;
 		}
 
 		// ------------------------------------------


### PR DESCRIPTION
Result if "$sortField" is set:
![kepernyokep - 2016-02-03 - 16 56 56](https://cloud.githubusercontent.com/assets/6043821/12787779/325cbf2c-ca97-11e5-9ffa-f54104a61b28.png)

Result if "$sortField" is NOT set:
![kepernyokep - 2016-02-03 - 16 52 23](https://cloud.githubusercontent.com/assets/6043821/12787735/f8fb24bc-ca96-11e5-922b-d13986a4ee58.png)