### PR TITLE
Fix for non-Latin characters in textareas

### DIFF
--- a/e107_handlers/e_parse_class.php
+++ b/e107_handlers/e_parse_class.php
@@ -4139,7 +4139,7 @@ return;
 	//    libxml_use_internal_errors(true); // hides errors.
         $doc  = $this->domObj;
 	    libxml_use_internal_errors(true);
-        @$doc->loadHTML($html);
+        @$doc->loadHTML($html, 'HTML-ENTITIES', 'UTF-8');
 		// $doc->encoding = 'UTF-8';
 
      //   $doc->resolveExternals = true;


### PR DESCRIPTION
Fixing and issue with non-Latin characters breaking in textareas if html tags are used