### PR TITLE
Fixing http_build_query causing return of &amp

### DIFF
--- a/e107_core/shortcodes/single/menu.php
+++ b/e107_core/shortcodes/single/menu.php
@@ -16,7 +16,7 @@ function menu_shortcode($parm, $mode='')
 		}
 		
 		unset($parm['path']);
-		return e107::getMenu()->renderMenu($plugin,$menu."_menu", http_build_query($parm,'&'));		
+		return e107::getMenu()->renderMenu($plugin,$menu."_menu", http_build_query($parm, '', '&'));			
 		
 	}
 	else


### PR DESCRIPTION
Fixing http_build_query function causing return of &amp instead of & on some servers when using {MENU: xxxxx} with parameters, thus breaking parameters passing to the menu.

Eg. {MENU: path=news/latestnews&test1=true&test2=false&test3=44}
Will return call the menu with test1=true&amptest2=false&amptest3=44 instead of est1=true&test2=false&test3=44
 causing only the first parameter key passed, to be valid