### PR TITLE
Update e_shortcode.php

### DIFF
--- a/e107_plugins/social/e_shortcode.php
+++ b/e107_plugins/social/e_shortcode.php
@@ -316,7 +316,7 @@ class social_shortcodes extends e_shortcode
 			$text = '<div class="btn-group hidden-print '.$dir.'">
 				  <a class="'.$tooltip.' btn btn-dropdown btn-default btn-'.$size.' dropdown-toggle" data-toggle="dropdown" href="#" title="Share">'.$label.'</a>
 				 
-				  <ul class="dropdown-menu" role="menu"  style="min-width:435px">
+				  <ul class="dropdown-menu" role="menu"  style="min-width:225px">
 				  
 				    <li><div class="'.$class.'" style="padding-left: 7px;">'.implode("\n",$opt).'</div></li>
 				  </ul>


### PR DESCRIPTION
I changed min-width form 435 to 225px in social dropdown-menu for 2 rows of icons. If you use less icons, empty space is smaller than with 435px. for 1 row of icons.