### PR TITLE
Update forum_icons_template.php

### DIFF
--- a/e107_plugins/forum/templates/forum_icons_template.php
+++ b/e107_plugins/forum/templates/forum_icons_template.php
@@ -17,7 +17,7 @@ if(deftrue("FONTAWESOME", 4)) {
 
 define('IMAGE_e', 					'e');
 define('IMAGE_new', 				$tp->toGlyph('fa-star', 'size=2x'));
-define('IMAGE_nonew', 				$tp->toGlyph('fa-comment', 'size=2x'));
+define('IMAGE_nonew', 				$tp->toGlyph('fa-comment-o', 'size=2x'));
 define('IMAGE_new_small',  			$tp->toGlyph('fa-star'));
 define('IMAGE_nonew_small',  		$tp->toGlyph('fa-comment-o'));
 define('IMAGE_new_popular',  		$tp->toGlyph('fa-comments', 'size=2x'));


### PR DESCRIPTION
Issue with forum icons. The default large forum icon indicates new posts as it does not follow the key at bottom of page. The logic is icon-o indicates no new posts, a solid icon indicates new posts. This fix  makes the comments icon logical.  (nonew_small icon is 'comment-o' but nonew x2 is 'comment')