### PR TITLE
Fix for wrong language in stage 2 #1459

### DIFF
--- a/install.php
+++ b/install.php
@@ -1634,6 +1634,11 @@ if($this->pdo == true)
 
 	function get_lan_file()
 	{
+		if(!empty($_POST['language']))
+		{
+			$this->previous_steps['language'] = $_POST['language'];
+		}		
+		
 		if(!isset($this->previous_steps['language']))
 		{
 			$this->previous_steps['language'] = "English";


### PR DESCRIPTION
This test was in stage_2() function, it was too late. 