### PR TITLE
New method to post forum attachment related data directly

### DIFF
--- a/e107_plugins/forum/forum_post.php
+++ b/e107_plugins/forum/forum_post.php
@@ -798,15 +798,10 @@ class forum_post_handler
 			}
 			
 			//Allows directly overriding the method of adding files (or other data) as attachments
-			if(isset($_POST['post_attachments_json']) && trim($_POST['post_attachments_json']))
+			if($attachmentsPosted = $this->processAttachmentsPosted())
 			{
-				$posted_attachments = json_decode($_POST['post_attachments_json'], true);
-				$attachments_json_errors = json_last_error();
-				if($attachments_json_errors === JSON_ERROR_NONE)
-				{
-				  $postInfo['post_attachments'] = e107::serialize($posted_attachments);
-				}
-			}
+				$postInfo['post_attachments'] = $attachmentsPosted;
+			}	
 			
 //		var_dump($uploadResult);
 
@@ -1019,16 +1014,10 @@ class forum_post_handler
 			}
 			
 			//Allows directly overriding the method of adding files (or other data) as attachments
-			if(isset($_POST['post_attachments_json']) && trim($_POST['post_attachments_json']))
+			if($attachmentsPosted = $this->processAttachmentsPosted($this->data['post_attachments']))
 			{
-				$existingValues   = e107::unserialize($this->data['post_attachments']);
-				$posted_attachments = json_decode($_POST['post_attachments_json'], true);
-				$attachments_json_errors = json_last_error();
-				if($attachments_json_errors === JSON_ERROR_NONE)
-				{
-				  $postVals['post_attachments'] =  e107::serialize(array_merge_recursive($existingValues,$posted_attachments));
-				}
-			}
+				$postVals['post_attachments'] = $attachmentsPosted;
+			}	
       
 			$postVals['post_edit_datestamp']    = time();
 			$postVals['post_edit_user']         = USERID;
@@ -1097,16 +1086,10 @@ class forum_post_handler
 		}
 		
 		//Allows directly overriding the method of adding files (or other data) as attachments
-		if(isset($_POST['post_attachments_json']) && trim($_POST['post_attachments_json']))
+		if($attachmentsPosted = $this->processAttachmentsPosted($this->data['post_attachments']))
 		{
-			$existingValues   = e107::unserialize($this->data['post_attachments']);
-			$posted_attachments = json_decode($_POST['post_attachments_json'], true);
-			$attachments_json_errors = json_last_error();
-			if($attachments_json_errors === JSON_ERROR_NONE)
-			{
-				$postVals['post_attachments'] =  e107::serialize(array_merge_recursive($existingValues,$posted_attachments));
-			}
-		}
+			$postVals['post_attachments'] = $attachmentsPosted;
+		}		
 
 		$this->forumObj->postUpdate($this->data['post_id'], $postVals);
 
@@ -1257,6 +1240,31 @@ class forum_post_handler
 			e107::getMessage()->addError('Something went wrong during the attachment uploading process.');
 		}
 		*/
+	}
+	
+	
+	//Allows directly overriding the method of adding files (or other data) as attachments
+	function processAttachmentsPosted($existingValues = false)
+	{		
+		if(isset($_POST['post_attachments_json']) && trim($_POST['post_attachments_json']))
+		{
+			$postedAttachments = json_decode($_POST['post_attachments_json'], true);
+			$attachmentsJsonErrors = json_last_error();
+			if($attachmentsJsonErrors === JSON_ERROR_NONE)
+			{
+		        if($existingValues)
+		        {
+		          $existingValues = e107::unserialize($existingValues);
+		          return e107::serialize(array_merge_recursive($existingValues,$postedAttachments));
+		        }
+		        else
+		        {
+				  return e107::serialize($postedAttachments);
+				}
+			}
+		}
+
+    	return false;
 	}
 
 }

--- a/e107_plugins/forum/forum_post.php
+++ b/e107_plugins/forum/forum_post.php
@@ -1244,7 +1244,7 @@ class forum_post_handler
 	
 	
 	//Allows directly overriding the method of adding files (or other data) as attachments
-	function processAttachmentsPosted($existingValues = false)
+	function processAttachmentsPosted($existingValues = '')
 	{		
 		if(isset($_POST['post_attachments_json']) && trim($_POST['post_attachments_json']))
 		{

--- a/e107_plugins/forum/forum_post.php
+++ b/e107_plugins/forum/forum_post.php
@@ -796,6 +796,18 @@ class forum_post_handler
 
 				$postInfo['post_attachments'] = e107::serialize($newValues);
 			}
+			
+			//Allows directly overriding the method of adding files (or other data) as attachments
+			if(isset($_POST['post_attachments_json']) && trim($_POST['post_attachments_json']))
+			{
+				$posted_attachments = json_decode($_POST['post_attachments_json'], true);
+				$attachments_json_errors = json_last_error();
+				if($attachments_json_errors === JSON_ERROR_NONE)
+				{
+				  $postInfo['post_attachments'] = e107::serialize($posted_attachments);
+				}
+			}
+			
 //		var_dump($uploadResult);
 
 			switch($this->action)
@@ -1005,7 +1017,19 @@ class forum_post_handler
 				$postVals['post_attachments'] = e107::serialize($newValues);
 				// $postVals['post_attachments'] = implode(',', $attachments);
 			}
-
+			
+			//Allows directly overriding the method of adding files (or other data) as attachments
+			if(isset($_POST['post_attachments_json']) && trim($_POST['post_attachments_json']))
+			{
+				$existingValues   = e107::unserialize($this->data['post_attachments']);
+				$posted_attachments = json_decode($_POST['post_attachments_json'], true);
+				$attachments_json_errors = json_last_error();
+				if($attachments_json_errors === JSON_ERROR_NONE)
+				{
+				  $postVals['post_attachments'] =  e107::serialize(array_merge_recursive($existingValues,$posted_attachments));
+				}
+			}
+      
 			$postVals['post_edit_datestamp']    = time();
 			$postVals['post_edit_user']         = USERID;
 			$postVals['post_entry']             = $_POST['post'];
@@ -1071,7 +1095,18 @@ class forum_post_handler
 
 			$postVals['post_attachments'] = e107::serialize($newValues);
 		}
-
+		
+		//Allows directly overriding the method of adding files (or other data) as attachments
+		if(isset($_POST['post_attachments_json']) && trim($_POST['post_attachments_json']))
+		{
+			$existingValues   = e107::unserialize($this->data['post_attachments']);
+			$posted_attachments = json_decode($_POST['post_attachments_json'], true);
+			$attachments_json_errors = json_last_error();
+			if($attachments_json_errors === JSON_ERROR_NONE)
+			{
+				$postVals['post_attachments'] =  e107::serialize(array_merge_recursive($existingValues,$posted_attachments));
+			}
+		}
 
 		$this->forumObj->postUpdate($this->data['post_id'], $postVals);
 


### PR DESCRIPTION
Allows posting new forum attachment file data directly with the $_POST request so that uploads and attachment data can be handled before the post is submitted. Alternate types of attachments also become possible then when overriding the forum attachment shortcodes. Data is posted with JSON instead of PHP Array to avoid the chance of eval() related security issues.