### PR TITLE
bug rework, array translation causes to login/user on NAVBAR to disap…

### DIFF
--- a/e107_themes/bootstrap3/languages/English_admin.php
+++ b/e107_themes/bootstrap3/languages/English_admin.php
@@ -14,10 +14,5 @@ define("LAN_THEMEPREF_03", "Bootswatch Styles:");
 define("LAN_THEMEPREF_04", "Site Name");
 define("LAN_THEMEPREF_05", "Logo");
 define("LAN_THEMEPREF_06", "Logo &amp; Site Name");
-define("LAN_THEMEPREF_07", "left");
-define("LAN_THEMEPREF_08", "right");
-define("LAN_THEMEPREF_09", "top");
-define("LAN_THEMEPREF_10", "bottom");
- 
 
 ?>

--- a/e107_themes/bootstrap3/theme_config.php
+++ b/e107_themes/bootstrap3/theme_config.php
@@ -32,11 +32,11 @@ class theme_bootstrap3 implements e_theme_config
 		$var[0]['help']		= "";
 
 		$var[1]['caption'] 	= LAN_THEMEPREF_01;
-		$var[1]['html'] 	= $frm->select('nav_alignment', array(LAN_THEMEPREF_07, LAN_THEMEPREF_08), e107::pref('theme', 'nav_alignment', 'left'),'useValues=1' );
+		$var[1]['html'] 	= $frm->select('nav_alignment', array('left', 'right'), e107::pref('theme', 'nav_alignment', 'left'),'useValues=1' );
 		$var[1]['help']		= "";
 
 		$var[2]['caption'] 	= LAN_THEMEPREF_02;
-		$var[2]['html'] 	= $frm->select('usernav_placement', array(LAN_THEMEPREF_09, LAN_THEMEPREF_10), e107::pref('theme', 'usernav_placement', 'top'),'useValues=1' );
+		$var[2]['html'] 	= $frm->select('usernav_placement', array('top', 'bottom'), e107::pref('theme', 'usernav_placement', 'top'),'useValues=1' );
 		$var[2]['help']		= "";
 
 


### PR DESCRIPTION
…pear

Behaviour of (arrays) left;right; top and bottom (when LAN's) in use causes the navbar 'area' for login/user to disappear  (admin area for preferences do work fine, but using the LAN,s (field)  as 'command' triggers non functional state.

All other LAN's and functions show no 'bug' 