### PR TITLE
extending newstags shortcode

### DIFF
--- a/e107_core/shortcodes/batch/news_shortcodes.php
+++ b/e107_core/shortcodes/batch/news_shortcodes.php
@@ -948,12 +948,15 @@ class news_shortcodes extends e_shortcode
 		return $info;
 	}
 
-	function sc_newstags($parm='')
+	/* example {NEWSTAGS} */
+	/* example {NEWSTAGS: separator=</li> <li>} */
+	/* example {NEWSTAGS: type=label&separator=</li><li>} */
+	function sc_newstags($parm=null)
 	{
 		$tmp = explode(",",$this->news_item['news_meta_keywords']);
 		$words = array();
-		
-		if($parm == 'label')
+
+		if($parm['type']=='label')
 		{
 			$start = "<span class='label label-default'>";
 			$end	= "</span>";	
@@ -965,7 +968,7 @@ class news_shortcodes extends e_shortcode
 			$end = "";
 			$sep = ", ";
 		}
-		
+		$sep = vartrue($parm['separator'],$sep);
 		foreach($tmp as $val)
 		{
 			if(trim($val))


### PR DESCRIPTION
I needed this markup for tags:
```
            <div class="blog__footer">
              <ul class="blog__tags">
                <li><a href="#">Bootstrap</a></li>
                <li><a href="#">HTML5</a></li>
                <li><a href="#">CSS3</a></li>
                <li><a href="#">jQuery</a></li>
              </ul>
            </div> <!-- / .blog__footer -->
```
I was able to get it with this code in template and changes in core shortcode:
```
            <div class="blog__footer"> 
              <ul class="blog__tags">
	        <li>{NEWSTAGS: separator=</li> <li>}	</li>
                <li>{NEWSCATEGORY}</li>
              </ul>
            </div> <!-- / .blog__footer -->
```
Result:
![image](https://cloud.githubusercontent.com/assets/5429548/14929295/18a4f9b4-0e5d-11e6-9d9e-0412f317759a.png)

I didn't find using label param with this shortcode in e107 code.  If there is other way how to do it, let me know.