### PR TITLE
Make it possible for non admins to download more files with send()

### DIFF
--- a/e107_handlers/file_class.php
+++ b/e107_handlers/file_class.php
@@ -845,7 +845,7 @@ class e_file
 		$path_downloads = realpath($DOWNLOADS_DIRECTORY);
 		$path_public = realpath($FILES_DIRECTORY."public/");
 		
-		if(strstr($path, $SYSTEM_DIRECTORY) && !ADMIN)
+		if(strstr($path, $SYSTEM_DIRECTORY) && !strstr($path, e_IMPORT) && !ADMIN)
 		{
 			header("location: {$e107->base_path}");
 			exit();


### PR DESCRIPTION
There seemed to be a bug that only admins can download files located in the system import folder. It is possible that this was some kind of security mechanism at one point although calling this function would require PHP access to modify what you are attempting to download anyway, so if there is something sensitive in that files location it would be vulnerable anyway.