### PR TITLE
Avatar shortcode for forum templates and encoding fix for date

### DIFF
--- a/e107_handlers/date_handler.php
+++ b/e107_handlers/date_handler.php
@@ -197,7 +197,7 @@ class convert
 			break;
 		}
 	
-		return strftime($mask, $datestamp);
+		return utf8_encode(strftime($mask, $datestamp));
 	}
 
 

--- a/e107_plugins/forum/shortcodes/batch/forum_shortcodes.php
+++ b/e107_plugins/forum/shortcodes/batch/forum_shortcodes.php
@@ -699,8 +699,4 @@ $gen = new convert;
 		return $frm->breadcrumb($breadarray);
 	}
 
-	function sc_avatar($opts)
-	{
-		return e107::getParser()->toAvatar(e107::user($this->var['forum_lastpost_user']),$opts);
-	}
 }

--- a/e107_plugins/forum/shortcodes/batch/forum_shortcodes.php
+++ b/e107_plugins/forum/shortcodes/batch/forum_shortcodes.php
@@ -699,4 +699,8 @@ $gen = new convert;
 		return $frm->breadcrumb($breadarray);
 	}
 
+	function sc_avatar($opts)
+	{
+		return e107::getParser()->toAvatar(e107::user($this->var['forum_lastpost_user']),$opts);
+	}
 }

--- a/e107_plugins/forum/shortcodes/batch/viewforum_shortcodes.php
+++ b/e107_plugins/forum/shortcodes/batch/viewforum_shortcodes.php
@@ -888,5 +888,19 @@ $LASTPOSTUSER = $this->var['lastpost_username'];
   }
 
 */
+	function sc_avatar($opts)
+	{
+		if (isset($this->var['thread_id']))
+		{
+			return e107::getParser()->toAvatar(e107::user($this->var['thread_lastuser']),$opts);
+		}
+		elseif (isset($this->var['forum_id']))
+		{
+			return e107::getParser()->toAvatar(e107::user($this->var['forum_lastpost_user']),$opts);
+		}
+		
+		return '';
+		// return print_r($this->var);
+	}
 }
 ?>

--- a/e107_plugins/forum/shortcodes/batch/viewforum_shortcodes.php
+++ b/e107_plugins/forum/shortcodes/batch/viewforum_shortcodes.php
@@ -900,7 +900,6 @@ $LASTPOSTUSER = $this->var['lastpost_username'];
 		}
 		
 		return '';
-		// return print_r($this->var);
 	}
 }
 ?>

--- a/e107_plugins/forum/shortcodes/batch/viewforum_shortcodes.php
+++ b/e107_plugins/forum/shortcodes/batch/viewforum_shortcodes.php
@@ -888,19 +888,5 @@ $LASTPOSTUSER = $this->var['lastpost_username'];
   }
 
 */
-	function sc_avatar($opts)
-	{
-		if (isset($this->var['thread_id']))
-		{
-			return e107::getParser()->toAvatar(e107::user($this->var['thread_lastuser']),$opts);
-		}
-		elseif (isset($this->var['forum_id']))
-		{
-			return e107::getParser()->toAvatar(e107::user($this->var['forum_lastpost_user']),$opts);
-		}
-		
-		return '';
-		// return print_r($this->var);
-	}
 }
 ?>


### PR DESCRIPTION
-Added AVATAR shortcode for use in both forum_template and viewforum_template, display the avatars of the last posts users.

-Fixed encoding problem with accented weekdays in spanish (and maybe other languages)