### PR TITLE
Fix for displaying multiple comment forms on the same page

### DIFF
--- a/e107_handlers/comment_class.php
+++ b/e107_handlers/comment_class.php
@@ -276,12 +276,12 @@ class comment
 			// -------------------------------------------------------------
 			
 			$indent = ($action == 'reply') ? " class='media col-md-offset-1 offset1' " : " class='media' ";
-			$formid = ($action == 'reply') ? "e-comment-form-reply" : "e-comment-form";
+			$formclass = ($action == 'reply') ? "e-comment-form-reply" : "e-comment-form";
 			
 			$text = "\n<div{$indent}>\n".e107::getMessage()->render('postcomment', true, false, false);//temporary here
 			
 		//	$text .= "Indent = ".$indent;
-			$text .= "<form id='{$formid}' method='post' action='".str_replace('http:', '', $_SERVER['REQUEST_URI'])."'  >";	
+			$text .= "<form class='{$formclass}' method='post' action='".str_replace('http:', '', $_SERVER['REQUEST_URI'])."'  >";	
 					
 			$data = array(
 				'action'	=> $action,
@@ -1134,11 +1134,11 @@ class comment
 		if($text)
 		{
 			//XXX Do NOT add to template - too important to allow for modification. 
-			$text = "<ul class='media-list' id='comments-container'>\n".$text."\n</ul>";
+			$text = "<ul class='media-list comments-container'>\n".$text."\n</ul>";
 		}
 		else
 		{
-			$text = "<ul class='media-list' id='comments-container'><li><!-- --></li></ul>";	
+			$text = "<ul class='media-list comments-container'><li><!-- --></li></ul>";	
 		}
 		
 		$search = array("{MODERATE}","{COMMENTS}","{COMMENTFORM}","{COMMENTNAV}");
@@ -1154,7 +1154,7 @@ class comment
 			if ($tablerender)
 			{
 					
-					echo $ns->tablerender("<span id='e-comment-total'>".$this->totalComments."</span> ".LAN_COMMENTS, $TEMPL, 'comment', TRUE);
+					echo $ns->tablerender("<span class='e-comment-total'>".$this->totalComments."</span> ".LAN_COMMENTS, $TEMPL, 'comment', TRUE);
 			}
 			else
 			{
@@ -1163,7 +1163,7 @@ class comment
 		}
 		elseif($return === 'html')
 		{
-			return $ns->tablerender("<span id='e-comment-total'>".$this->totalComments."</span> ".LAN_COMMENTS, $TEMPL, 'comment', true);
+			return $ns->tablerender("<span class='e-comment-total'>".$this->totalComments."</span> ".LAN_COMMENTS, $TEMPL, 'comment', true);
 		}
 			//echo $modcomment.$comment;
 			//echo $text;
@@ -1179,7 +1179,7 @@ class comment
 		$ret['comment'] = $text;
 		
 		$ret['comment_form'] = $comment;
-		$ret['caption'] = "<span id='e-comment-total'>".$this->totalComments."</span> ".LAN_COMMENTS;
+		$ret['caption'] = "<span class='e-comment-total'>".$this->totalComments."</span> ".LAN_COMMENTS;
 
 		return (!$return) ? "" : $ret;
 	}

--- a/e107_web/js/core/front.jquery.js
+++ b/e107_web/js/core/front.jquery.js
@@ -80,12 +80,15 @@ $(document).ready(function()
 
     $(document).on("click", ".e-comment-submit", function(){
 			
+			var commentsParent = $(this).parent().parent().parent().parent().parent().parent().parent();
 			var url		= $(this).attr("data-target");
 			var sort	= $(this).attr("data-sort");
 			var pid 	= parseInt($(this).attr("data-pid"));
-			var formid 	= (pid != '0') ? "#e-comment-form-reply" : "#e-comment-form";
-			var data 	= $('form'+formid).serialize() ;
-			var total 	= parseInt($("#e-comment-total").text());		
+			var formid 	= (pid != '0') ? ".e-comment-form-reply" : ".e-comment-form";
+			var data 	= $(commentsParent).find('form'+formid).serialize();
+			var total 	= parseInt($(commentsParent).find(".e-comment-total").text());
+			var commentsContainer = $(commentsParent).find(".comments-container");
+			
 				
 			$.ajax({
 			  type: 'POST',
@@ -99,7 +102,7 @@ $(document).ready(function()
 	
 				$("#comment").val('');
 				
-				if($('#comments-container').length){
+				if($(commentsContainer).length){
 				//	alert('true');
 				}else{
 			//		$("#e-comment-form").parent().prepend("<div id='comments-container'></div>");
@@ -111,17 +114,17 @@ $(document).ready(function()
 				}
 				else if(sort == 'desc')
 				{
-					$('#comments-container').prepend(a.html).hide().slideDown(800);	// FIXME - works in jquery 1.7, not 1.8
+					$(commentsContainer).prepend(a.html).hide().slideDown(800);	// FIXME - works in jquery 1.7, not 1.8
 				}
 				else
 				{
-					$('#comments-container').append(a.html).hide().slideDown(800); // FIXME - works in jquery 1.7, not 1.8
+					$(commentsContainer).append(a.html).hide().slideDown(800); // FIXME - works in jquery 1.7, not 1.8
 					alert('Thank you for commenting'); // possibly needed as the submission may go unoticed	by the user
 				}  
 				
 				if(!a.error)
 				{
-					$("#e-comment-total").text(total + 1);
+					$(commentsParent).find(".e-comment-total").text(total + 1);
 					if(pid != '0')
 					{
 						$(formid).hide();		
@@ -152,7 +155,7 @@ $(document).ready(function()
 			var sp 		= $(this).attr('id').split("-");
 			var id 		= "#comment-" + sp[3];
 
-			var present = $('#e-comment-form-reply'); 
+			//var present = $('#e-comment-form-reply');  // NES: Not beign used?
 		//	console.log(present);
 			
 
@@ -270,10 +273,11 @@ $(document).ready(function()
 
     $(document).on("click", ".e-comment-delete", function(){
 			
+			var commentsParent = $(this).parent().parent().parent().parent().parent().parent().parent();
 			var url 	= $(this).attr("data-target");
 			var sp 		= $(this).attr('id').split("-");	
 			var id 		= "#comment-" + sp[3];
-			var total 	= parseInt($("#e-comment-total").text());
+			var total 	= parseInt($(commentsParent).find(".e-comment-total").text());
 	
 			$.ajax({
 			  type: 'POST',
@@ -285,7 +289,7 @@ $(document).ready(function()
 				if(!a.error)
 				{
 					$(id).hide('slow');
-					$("#e-comment-total").text(total - 1);	
+					$(commentsParent).find(".e-comment-total").text(total + 1);
 				}
 
 			  }


### PR DESCRIPTION
Because the use of IDs in order of Classes as identifiers, the comment
form was not able to work properly.
NOTE: Next and Prev buttons doesnt work, but I think its not related to
this issue. Please, confirm that they are not working on the e107
previous this commit.