### PR TITLE
Remind admin to delete online_extended menu #1109

### DIFF
--- a/e107_admin/admin.php
+++ b/e107_admin/admin.php
@@ -258,7 +258,10 @@ class admin_start
 			e_PLUGIN."banner/config.php",
 			e_PLUGIN."forum/newforumposts_menu_config.php",
 			e_PLUGIN."forum/e_latest.php",
-			e_PLUGIN."forum/e_status.php"
+			e_PLUGIN."forum/e_status.php",
+			e_PLUGIN."online_extended_menu/online_extended_menu.php",
+			e_PLUGIN."online_extended_menu/images/user.png",
+			e_PLUGIN."online_extended_menu/languages/English.php"
 
 		);
 


### PR DESCRIPTION
Remind admin to delete online_extended menu #1109 because if they do not
delete it then each time they open the menu manager, the plugin folder
is scanned for menus and they get the DB Update Available Warning - over
and over.