### PR TITLE
Enable forum_post custom caption

### DIFF
--- a/e107_plugins/forum/forum_post.php
+++ b/e107_plugins/forum/forum_post.php
@@ -859,6 +859,11 @@ class forum_post_handler
 		$sc         = e107::getScBatch('post', 'forum')->setScVar('forum', $this->forumObj)->setScVar('threadInfo', vartrue($data))->setVars($data);
 		$text       = e107::getParser()->parseTemplate($template['form'], true, $sc);
 
+		if(!empty($template['caption']))
+		{
+      			$this->forumObj->prefs->set('title', $template['caption']);
+    		}
+
 		$this->render($text);
 
 		if(empty($data))

--- a/e107_plugins/forum/forum_post.php
+++ b/e107_plugins/forum/forum_post.php
@@ -861,7 +861,7 @@ class forum_post_handler
 
 		if(!empty($template['caption']))
 		{
-      			$this->forumObj->prefs->set('title', $template['caption']);
+      			$this->forumObj->prefs->set('title', e107::getParser()->parseTemplate($template['caption'], true, $sc));
     		}
 
 		$this->render($text);

--- a/e107_plugins/forum/templates/forum_post_template.php
+++ b/e107_plugins/forum/templates/forum_post_template.php
@@ -12,6 +12,7 @@ if (!defined('e107_INIT')) { exit; }
 
 // New in v2.x - requires a bootstrap theme be loaded.  
 
+//$FORUM_POST_TEMPLATE['caption']		= "Custom caption";
 $FORUM_POST_TEMPLATE['form']		= "
 									{FORUM_POST_FORM_START}
 									<div class='row-fluid'>


### PR DESCRIPTION
Enable forum_post custom caption

P.S.: Why does this forum_post.php file is such different form the other forum .php files?
It's quite hard to go throught this code, since it's a class inside the file, and it's quite a "overkill" for a forum post form.... Even the template handling is a "mess": after defined text, call internal render function that after all just calls core render... Real odd...
Or i miss something here?
