### PR TITLE
Ability to change error page contents.

### DIFF
--- a/e107_handlers/error_page_class.php
+++ b/e107_handlers/error_page_class.php
@@ -62,6 +62,36 @@ class error_page
 	}
 
 	/**
+	 * Change title on the error page.
+	 *
+	 * @param $title
+	 */
+	public function setTitle($title)
+	{
+		$this->title = $title;
+	}
+
+	/**
+	 * Change panel caption on the error page.
+	 *
+	 * @param $caption
+	 */
+	public function setCaption($caption)
+	{
+		$this->caption = $caption;
+	}
+
+	/**
+	 * Change panel content on the error page.
+	 *
+	 * @param $content
+	 */
+	public function setContent($content)
+	{
+		$this->content = $content;
+	}
+
+	/**
 	 * Set a "Bad Request" error page.
 	 */
 	private function setPageBadRequest()


### PR DESCRIPTION
Example:
```php
$error = e107::getError();
$error->set(403);
$error->setCaption('Access denied');
$error->setContent('You are not allowed to access this page.');
$error->render();
```