### PR TITLE
Event triggering after updating plugins table.

### DIFF
--- a/e107_handlers/plugin_class.php
+++ b/e107_handlers/plugin_class.php
@@ -543,6 +543,11 @@ class e107plugin
 			$this->rebuildUrlConfig();
 			e107::getConfig('core')->save(true,false,false);
 		}
+
+		// Triggering system (post) event.
+		e107::getEvent()->trigger('system_plugins_table_updated', array(
+			'mode' => $mode,
+		));
 	}
 
 	function manage_category($cat)


### PR DESCRIPTION
This would be very useful for my plugins use custom addon files, for example:
- Metatag (e_metatag.php)
- NodeJS (e_nodejs.php)
- NodeJS Notify (e_nodejs_notify.php)

All of them provide API other plugins can use, so it would be great that I could update my custom addon file lists using the core "Scan plugin directories" feature. I could achieve it using this event-triggering.
