### PR TITLE
Replace jsapi with loader.js in chart_class

### DIFF
--- a/e107_handlers/chart_class.php
+++ b/e107_handlers/chart_class.php
@@ -2,7 +2,7 @@
  /*
  * e107 website system
  *
- * Copyright (C) 2008-2013 e107 Inc (e107.org)
+ * Copyright (C) 2008-2016 e107 Inc (e107.org)
  * Released under the terms and conditions of the
  * GNU General Public License (http://www.gnu.org/licenses/gpl.txt)
  *
@@ -333,8 +333,8 @@ class e_chart
 
 			$fName = 'draw'.ucfirst($id);	
 				
-		      $js = " google.load('visualization', '1', {packages:['corechart']});
-			      google.setOnLoadCallback(".$fName.");
+		      $js = " google.charts.load('visualization', '1', {packages:['corechart']});
+			      google.charts.setOnLoadCallback(".$fName.");
 			      function ".$fName."() {
 			        var data = google.visualization.arrayToDataTable(".$this->getData().");
 			
@@ -387,7 +387,7 @@ class e_chart
 
 		      ";
 
-			e107::js('footer','https://www.google.com/jsapi');
+			e107::js('footer','https://www.gstatic.com/charts/loader.js');
 			e107::js('footer-inline', $js);
 
 			return "<div class='e-graph e-chart' id='".$id."' style='width: ".$width."; height: ".$height."px;'></div>";


### PR DESCRIPTION
This avoids 2 warnings when opening admin.
jsapi:22 A Parser-blocking, cross-origin script,
https://www.google.com/uds/?file=visualization&v=1&packages=corechart,
is invoked via document.write. This may be blocked by the browser if the
device has poor network connectivity. See
https://www.chromestatus.com/feature/5718547946799104 for more details.
Reference information:

http://stackoverflow.com/questions/39719334/javascript-google-visualization-selection-option