### PR TITLE
Cache Handler Performance Improvement #2302

### DIFF
--- a/e107_handlers/cache_handler.php
+++ b/e107_handlers/cache_handler.php
@@ -150,7 +150,7 @@ class ecache {
 					}
 					elseif(strpos($ret,'<?php') === 0)
 					{
-						$ret = '<?php' ;			// Handle the history for now
+						$ret = substr($ret,5);			// Handle the history for now
 					}
 					return $ret;
 				}

--- a/e107_handlers/cache_handler.php
+++ b/e107_handlers/cache_handler.php
@@ -146,13 +146,13 @@ class ecache {
 				else
 				{
 					$ret = file_get_contents($cache_file);
-					if (substr($ret,0,strlen(self::CACHE_PREFIX)) == self::CACHE_PREFIX)
+					if (strpos($ret,self::CACHE_PREFIX) == 0 )  
 					{
-						$ret = substr($ret, strlen(self::CACHE_PREFIX));
+						$ret = self::CACHE_PREFIX;
 					}
-					elseif(substr($ret,0,5) == '<?php')
+					elseif(strpos($ret,'<?php') == 0)
 					{
-						$ret = substr($ret, 5);		// Handle the history for now
+						$ret ='<?php' ;			// Handle the history for now
 					}
 					return $ret;
 				}

--- a/e107_handlers/cache_handler.php
+++ b/e107_handlers/cache_handler.php
@@ -148,7 +148,7 @@ class ecache {
 					$ret = file_get_contents($cache_file);
 					if (strpos($ret,self::CACHE_PREFIX) == 0 )  
 					{
-						$ret = self::CACHE_PREFIX;
+						substr($ret, strlen(self::CACHE_PREFIX));
 					}
 					elseif(strpos($ret,'<?php') == 0)
 					{

--- a/e107_handlers/cache_handler.php
+++ b/e107_handlers/cache_handler.php
@@ -2,14 +2,12 @@
 /*
  * e107 website system
  *
- * Copyright (C) 2008-2010 e107 Inc (e107.org)
+ * Copyright (C) 2008-2017 e107 Inc (e107.org)
  * Released under the terms and conditions of the
  * GNU General Public License (http://www.gnu.org/licenses/gpl.txt)
  *
  * Cache handler
  *
- * $URL$
- * $Id$
 */
 
 if (!defined('e107_INIT')) { exit; }
@@ -146,11 +144,11 @@ class ecache {
 				else
 				{
 					$ret = file_get_contents($cache_file);
-					if (strpos($ret,self::CACHE_PREFIX) == 0 )  
+					if (strpos($ret,self::CACHE_PREFIX) === 0 )  
 					{
 						substr($ret, strlen(self::CACHE_PREFIX));
 					}
-					elseif(strpos($ret,'<?php') == 0)
+					elseif(strpos($ret,'<?php') === 0)
 					{
 						$ret ='<?php' ;			// Handle the history for now
 					}

--- a/e107_handlers/cache_handler.php
+++ b/e107_handlers/cache_handler.php
@@ -146,11 +146,11 @@ class ecache {
 					$ret = file_get_contents($cache_file);
 					if (strpos($ret,self::CACHE_PREFIX) === 0 )  
 					{
-						substr($ret, strlen(self::CACHE_PREFIX));
+						$ret = substr($ret, strlen(self::CACHE_PREFIX));
 					}
 					elseif(strpos($ret,'<?php') === 0)
 					{
-						$ret ='<?php' ;			// Handle the history for now
+						$ret = '<?php' ;			// Handle the history for now
 					}
 					return $ret;
 				}


### PR DESCRIPTION
strpos is faster and takes less memory than substr with very large files
such as S_Theme_meta.cache.php which contains around 1600 lines, 48k
chars. I have replicated the same logic but using strpos. There is a
small gain in php 5.6 and slightly more in php7.0
Test results shown here.
https://docs.google.com/document/d/1o4X4ds377esQUSy8lE_RGN9BruKZ2aETxr6G1WTdiRc/