### PR TITLE
Update pm_shortcodes.php

### DIFF
--- a/e107_plugins/pm/pm_shortcodes.php
+++ b/e107_plugins/pm/pm_shortcodes.php
@@ -575,13 +575,13 @@ if(!class_exists('plugin_pm_pm_shortcodes'))
 			}
 
 
-			if($parm != '')
+			if(count($parm) == 0)
 			{
-				$extra = '.'.$parm;
+				$extra = '.'.($this->pmMode == 'outbox' ? 'outbox' : 'inbox');
 			}
 			else
 			{
-				$extra = '.'.($this->pmMode == 'outbox' ? 'outbox' : 'inbox');
+				$extra = '.'.$parm;
 			}
 
 

--- a/e107_plugins/pm/pm_shortcodes.php
+++ b/e107_plugins/pm/pm_shortcodes.php
@@ -575,13 +575,13 @@ if(!class_exists('plugin_pm_pm_shortcodes'))
 			}
 
 
-			if(count($parm) == 0)
+			if(!empty($parm))
 			{
-				$extra = '.'.($this->pmMode == 'outbox' ? 'outbox' : 'inbox');
+				$extra = '.'.$parm;
 			}
 			else
 			{
-				$extra = '.'.$parm;
+				$extra = '.'.($this->pmMode == 'outbox' ? 'outbox' : 'inbox');
 			}
 
 


### PR DESCRIPTION
Where no parameter is passed in the shortcode $parm is received as an array. This resulted in 'inbox' being added to the delete url in the outbox where {PM_DELETE} is called.