### PR TITLE
Update bootstrsp switch CDN to 3.3.4

### DIFF
--- a/e107_handlers/library_manager.php
+++ b/e107_handlers/library_manager.php
@@ -498,7 +498,7 @@ class core_library
 			),
 			// Override library path to CDN.
 			'library_path'      => 'https://cdn.jsdelivr.net/bootstrap.switch',
-			'path'              => '3.3.2',
+			'path'              => '3.3.4',
 		);
 
 		// Bootstrap Switch (local).


### PR DESCRIPTION
Last stable is v. 3.3.4 (https://github.com/Bttstrp/bootstrap-switch), also is available via CDN (https://cdnjs.com/libraries/bootstrap-switch)

Also might be worth updating local files?

_NOTE: cdn.jsdelivr.net only has v3.3.3 & 4.0.0 alpha.1_