### PR TITLE
Update Icon Selector

### DIFF
--- a/e107_handlers/form_handler.php
+++ b/e107_handlers/form_handler.php
@@ -1205,9 +1205,12 @@ class e_form
 		{
 			$ret = "<div class='imgselector-container'  style='display:block;width:64px;min-height:64px'>";
 			$thpath = isset($sc_parameters['nothumb']) || vartrue($hide) ? $default : $default_thumb;
-			$label = "<div id='{$name_id}_prev' class='text-center well well-small image-selector' >";
 			
-			$label .= $tp->toIcon($default_url);
+			$label = "<div id='{$name_id}_prev' class='text-center well well-small image-selector img-responsive img-fluid' >";			
+			$label .= $tp->toIcon($default_url,array('class'=>'img-responsive img-fluid'));
+
+            //$label = "<div id='{$name_id}_prev' class='text-center well well-small image-selector' >";			
+			//$label .= $tp->toIcon($default_url);
 			
 			$label .= "				
 			</div>";


### PR DESCRIPTION
make icon selector not disturb other field
when i try to create chapter, first row is icon selector and second is dropdown for new or existed book.
i try click the second field (dropdown) it always open media manager for icon selector. this is why :
![icon-selector](https://cloud.githubusercontent.com/assets/25628686/26071988/2e48fd4e-39d4-11e7-8269-99d7be3cead1.jpg)

with this patch, this is the result for the icon selector field
![icon-result](https://cloud.githubusercontent.com/assets/25628686/26072054/6a7bed12-39d4-11e7-9cc9-03e701f96016.jpg)
