### PR TITLE
[html] - Fix end tag mix-up in forum_viewforum_template 'item' block.

### DIFF
--- a/e107_plugins/forum/templates/forum_viewforum_template.php
+++ b/e107_plugins/forum/templates/forum_viewforum_template.php
@@ -307,21 +307,19 @@ $FORUM_VIEWFORUM_TEMPLATE['header'] 			= "<div class=' row-fluid'><div>{BREADCRU
 
 
 $FORUM_VIEWFORUM_TEMPLATE['item'] 				= "<tr>
-													<td>{ICON}</td>
-													<td>
-													<div class='row'>
-														<div class='col-xs-12 col-md-9'>
-														{THREADNAME}
-														<div><small>".LAN_FORUM_1004.": {POSTER} {THREADTIMELAPSE} &nbsp;</small></div>
-														</div><div class='col-xs-12 col-md-3 text-right'> {PAGESX}</div>
-														</div>
-														<div class='row'>
+												    <td>{ICON}</td>
+												    <td>
+												        <div class='row'>
+												            <div class='col-xs-12 col-md-9'>
+												            {THREADNAME}
+												            <div><small>".LAN_FORUM_1004.": {POSTER} {THREADTIMELAPSE} &nbsp;</small></div>
+												            </div><div class='col-xs-12 col-md-3 text-right'> {PAGESX}</div>
+												        </div>
+												    </td>
+												    <td class='text-center'>{REPLIESX}</td><td class='hidden-xs text-center'>{VIEWSX}</td>
+												    <td class='hidden-xs'><small>{LASTPOSTUSER} {LASTPOSTDATE} </small><div class='span2 right pull-right'>{ADMINOPTIONS}</div></td>
+												</tr>\n";
 
-													</td>
-													</div>
-														<td class='text-center'>{REPLIESX}</td><td class='hidden-xs text-center'>{VIEWSX}</td>
-													<td class='hidden-xs'><small>{LASTPOSTUSER} {LASTPOSTDATE} </small><div class='span2 right pull-right'>{ADMINOPTIONS}</div></td>
-													</tr>\n";
 
 $FORUM_VIEWFORUM_TEMPLATE['item-sticky'] 		= $FORUM_VIEWFORUM_TEMPLATE['item'] ; // "<tr><td>{THREADNAME}</td></tr>\n";
 $FORUM_VIEWFORUM_TEMPLATE['item-announce'] 		= $FORUM_VIEWFORUM_TEMPLATE['item'] ; // "<tr><td>{THREADNAME}</td></tr>\n";


### PR DESCRIPTION
Dear Admins,
This mixup caused unclosed div element in the generated markup. Please review and merge.

**FF view-source:**

![image](https://cloud.githubusercontent.com/assets/315195/26329939/975530c4-3f5a-11e7-94f3-54a9c32ef5c2.png)
