### PR TITLE
[html] - Fix forum search button start tag using self closing syntax

### DIFF
--- a/e107_plugins/forum/shortcodes/batch/forum_shortcodes.php
+++ b/e107_plugins/forum/shortcodes/batch/forum_shortcodes.php
@@ -181,7 +181,7 @@ class forum_shortcodes extends e_shortcode
 		<input type='hidden' name='forum' value='all' />
 		<input class='tbox form-control' type='text' name='q' size='20' value='' maxlength='50' />
 		<span class='input-group-btn'>
-		<button class='btn btn-default button' type='submit' name='s' value='search' />".$srchIcon."</button>
+		<button class='btn btn-default button' type='submit' name='s' value='search' >".$srchIcon."</button>
 		</span>
 		</div>
 


### PR DESCRIPTION
Should fix 'Self-closing syntax (/>) used on a non-void HTML element' html validation error on the search button.

**FF view-source:**
![image](https://cloud.githubusercontent.com/assets/315195/26330891/3dec2d44-3f5f-11e7-8404-1a8a53f4ce9b.png)
