### PR TITLE
Fix invalid html for 'Delete' and 'Move' list items in forum Admin Options dropdown

### DIFF
--- a/e107_plugins/forum/forum_viewforum.php
+++ b/e107_plugins/forum/forum_viewforum.php
@@ -999,11 +999,11 @@ function fadminoptions($thread_info)
 	
 
 
-	$text .= "<li class='text-right'><a href='".e_REQUEST_URI."' data-forum-action='delete' data-forum-thread='".$id."'>".LAN_DELETE." ".$tp->toGlyph('trash');
+	$text .= "<li class='text-right'><a href='".e_REQUEST_URI."' data-forum-action='delete' data-forum-thread='".$id."'>".LAN_DELETE." ".$tp->toGlyph('trash')."</a></li>";
 	$text .= "<li class='text-right'><a href='".e_REQUEST_URI."' data-forum-action='".$stickUnstick."' data-forum-thread='".$id."'>".$lan[$stickUnstick]." ".$icon[$stickUnstick]."</a></li>";
 	$text .= "<li class='text-right'><a href='".e_REQUEST_URI."' data-forum-action='".$lockUnlock."' data-forum-thread='".$id."'>".$lan[$lockUnlock]." ".$icon[$lockUnlock]."</a></li>";
 	
-	$text .= "<li class='text-right'><a href='{$moveUrl}'>".LAN_FORUM_2042." ".$tp->toGlyph('move')."</i></a></li>";
+	$text .= "<li class='text-right'><a href='{$moveUrl}'>".LAN_FORUM_2042." ".$tp->toGlyph('move')."</a></li>";
 
 	if(e_DEVELOPER)
 	{


### PR DESCRIPTION
Dear Admins,
This commit cleanup unclosed 'li' tag, unclosed 'a' tag, remove stray 'i' end tags in 'Delete' and 'Move' list items in the forum 'Admin Options' drop down menu. 

Please review and merge if appropriate.

**FF view-source:**
![image](https://cloud.githubusercontent.com/assets/315195/26344650/745ac488-3fb1-11e7-8503-efcfa244861c.png)
