### PR TITLE
Conditional check for PM plugin install status prior to 'li' generation for PM_NAV (bootstrap3 theme)

### DIFF
--- a/e107_themes/bootstrap3/theme_shortcodes.php
+++ b/e107_themes/bootstrap3/theme_shortcodes.php
@@ -195,8 +195,14 @@ class theme_shortcodes extends e_shortcode
 
 		$text = '
 		
-		<ul class="nav navbar-nav navbar-right'.$direction.'">
-		<li class="dropdown">{PM_NAV}</li>
+		<ul class="nav navbar-nav navbar-right'.$direction.'">';
+		
+		if( e107::isInstalled('pm') )
+		{
+			$text .= '<li class="dropdown">{PM_NAV}</li>';
+		}
+		
+		$text .= '
 		<li class="dropdown dropdown-avatar"><a href="#" class="dropdown-toggle" data-toggle="dropdown">{SETIMAGE: w=30} {USER_AVATAR: shape=circle} '. $userNameLabel.' <b class="caret"></b></a>
 		<ul class="dropdown-menu">
 		<li>


### PR DESCRIPTION
Dear Admins,
Generate list item for PM_NAV in BOOTSTRAP_USERNAV of bootstrap3 theme only if PM plugin installed. 

Please review.

![image](https://cloud.githubusercontent.com/assets/315195/26351004/a51b0096-3fc6-11e7-9c5d-b6d941c951a5.png)
