### PR TITLE
Remove stray end anchor tag on the 'Move' link of 'sc_postoptions'

### DIFF
--- a/e107_plugins/forum/shortcodes/batch/view_shortcodes.php
+++ b/e107_plugins/forum/shortcodes/batch/view_shortcodes.php
@@ -772,7 +772,7 @@
 				if($type == 'thread')
 				{
 					$url = e107::url('forum', 'move', array('thread_id' => $this->postInfo['post_thread']));
-					$text .= "<li class='text-right'><a href='" . $url . "'>" . LAN_FORUM_2042 . " " . $tp->toGlyph('move') . "</a></a></li>";
+					$text .= "<li class='text-right'><a href='" . $url . "'>" . LAN_FORUM_2042 . " " . $tp->toGlyph('move') . "</a></li>";
 				}
 				elseif(e_DEVELOPER === true) //TODO
 				{


### PR DESCRIPTION
Dear Admins please review,

Remove stray end anchor tag on the 'Move' link of 'sc_postoptions' in e107_plugins/forum/shortcodes/batch/view_shortcodes.php which fix associated html validation error.