### PR TITLE
Update English.php

### DIFF
--- a/e107_languages/English/English.php
+++ b/e107_languages/English/English.php
@@ -140,5 +140,7 @@ define("LAN_SUMMARY", "Summary");  // TODO   more files use summary replace
 define("LAN_REQUIRED_BLANK", "Required field(s) were left blank.");
 define("LAN_PLEASEWAIT", "Please Wait");
 define("LAN_CHOOSE_FILE", "Choose a file");
+define("LAN_FROM", "from");
+define("LAN_TO", "to");
 
 ?>


### PR DESCRIPTION
Added used coded LAN's :  fixes (see #6 #2659) These two defines are added but not implemented into a lot of other files. 
These can be used (implemented) whenever a text to lan defines change takes place. The words (singular) 'from' and 'to' are represented through these two LAN's. Replacing all in 1 go will deliver too much stressload on multiple files... 
Do NOT merge if not ok using these two.