### PR TITLE
[LAN] - Optimize theme admin LANs

### DIFF
--- a/e107_languages/English/admin/lan_theme.php
+++ b/e107_languages/English/admin/lan_theme.php
@@ -130,3 +130,15 @@ define("TPVLAN_92", "New Theme Folder");
 define("TPVLAN_93", "Selection");
 define("TPVLAN_94", "Site theme changed to [x].");
 
+// theme admin config
+define("TPVLAN_95", "Branding:");
+define("TPVLAN_96", "Navbar Alignment:");
+define("TPVLAN_97", "Signup/Login Placement:");
+define("TPVLAN_98", "Bootswatch Styles:");
+define("TPVLAN_99", "Site Name");
+define("TPVLAN_100", "Logo");
+define("TPVLAN_101", "Logo &amp; Site Name");
+define("TPVLAN_102", "left");
+define("TPVLAN_103", "right");
+define("TPVLAN_104", "top");
+define("TPVLAN_105", "bottom");

--- a/e107_themes/bootstrap3/languages/English_admin.php
+++ b/e107_themes/bootstrap3/languages/English_admin.php
@@ -7,16 +7,16 @@
 +----------------------------------------------------------------------------+
 */
 
-define("LAN_THEMEPREF_00", "Branding:");
-define("LAN_THEMEPREF_01", "Navbar Alignment:");
-define("LAN_THEMEPREF_02", "Signup/Login Placement:");
-define("LAN_THEMEPREF_03", "Bootswatch Styles:");
-define("LAN_THEMEPREF_04", "Site Name");
-define("LAN_THEMEPREF_05", "Logo");
-define("LAN_THEMEPREF_06", "Logo &amp; Site Name");
-define("LAN_THEMEPREF_07", "left");
-define("LAN_THEMEPREF_08", "right");
-define("LAN_THEMEPREF_09", "top");
-define("LAN_THEMEPREF_10", "bottom");
+//define("LAN_THEMEPREF_00", "Branding:");
+//define("LAN_THEMEPREF_01", "Navbar Alignment:");
+//define("LAN_THEMEPREF_02", "Signup/Login Placement:");
+//define("LAN_THEMEPREF_03", "Bootswatch Styles:");
+//define("LAN_THEMEPREF_04", "Site Name");
+//define("LAN_THEMEPREF_05", "Logo");
+//define("LAN_THEMEPREF_06", "Logo &amp; Site Name");
+//define("LAN_THEMEPREF_07", "left");
+//define("LAN_THEMEPREF_08", "right");
+//define("LAN_THEMEPREF_09", "top");
+//define("LAN_THEMEPREF_10", "bottom");
 
 ?>

--- a/e107_themes/bootstrap3/theme_config.php
+++ b/e107_themes/bootstrap3/theme_config.php
@@ -11,7 +11,7 @@ class theme_config implements e_theme_config
 	function config($type='front')
 	{
 
-		$brandingOpts = array('sitename'=>LAN_THEMEPREF_04, 'logo' => LAN_THEMEPREF_05, 'sitenamelogo'=>LAN_THEMEPREF_06);
+		$brandingOpts = array('sitename'=>TPVLAN_99, 'logo' => TPVLAN_100, 'sitenamelogo'=>TPVLAN_101);
 
 		$bootswatch = array(
 			"cerulean"=> 'Cerulean',
@@ -36,10 +36,10 @@ class theme_config implements e_theme_config
 		$previewLink = " <a class='btn btn-default e-modal' data-modal-caption=\"Use the 'Themes' menu to view the selection.\" href='http://bootswatch.com/default/'>".LAN_PREVIEW."</a>";
 
 		$fields = array(
-			'branding'          => array('title'=>LAN_THEMEPREF_00, 'type'=>'dropdown', 'writeParms'=>array('optArray'=> $brandingOpts)),
-			'nav_alignment'     => array('title'=>LAN_THEMEPREF_01, 'type'=>'dropdown', 'writeParms'=>array('optArray'=> array('left'=> LAN_THEMEPREF_07,'right'=> LAN_THEMEPREF_08))),
-			'usernav_placement' => array('title'=>LAN_THEMEPREF_02, 'type'=>'dropdown', 'writeParms'=>array('optArray'=> array('top'=> LAN_THEMEPREF_09, 'bottom'=> LAN_THEMEPREF_10))),
-			'bootswatch'        => array('title'=>LAN_THEMEPREF_03, 'type'=>'dropdown', 'writeParms'=>array('optArray'=> $bootswatch, 'post'=>$previewLink, 'default'=>LAN_DEFAULT)),
+			'branding'          => array('title'=>TPVLAN_95, 'type'=>'dropdown', 'writeParms'=>array('optArray'=> $brandingOpts)),
+			'nav_alignment'     => array('title'=>TPVLAN_96, 'type'=>'dropdown', 'writeParms'=>array('optArray'=> array('left'=> TPVLAN_102,'right'=> TPVLAN_103))),
+			'usernav_placement' => array('title'=>TPVLAN_97, 'type'=>'dropdown', 'writeParms'=>array('optArray'=> array('top'=> TPVLAN_104, 'bottom'=> TPVLAN_105))),
+			'bootswatch'        => array('title'=>TPVLAN_98, 'type'=>'dropdown', 'writeParms'=>array('optArray'=> $bootswatch, 'post'=>$previewLink, 'default'=>LAN_DEFAULT)),
 		);
 
 		return $fields;

--- a/e107_themes/landingzero/languages/English_admin.php
+++ b/e107_themes/landingzero/languages/English_admin.php
@@ -11,7 +11,7 @@ define("LAN_LZ_THEMEPREF_00", "Image background for video [1920x1080px]");
 define("LAN_LZ_THEMEPREF_01", "Image background for mobile devices");
 define("LAN_LZ_THEMEPREF_02", "First frame of video  [1920x1080px]");
 define("LAN_LZ_THEMEPREF_03", "URL path to header video in mp4 format"); 
-define("LAN_LZ_THEMEPREF_04", "Signup/Login Placement"); 
-define("LAN_LZ_THEMEPREF_05", "top");
-define("LAN_LZ_THEMEPREF_06", "bottom");
+//define("LAN_LZ_THEMEPREF_04", "Signup/Login Placement"); 
+//define("LAN_LZ_THEMEPREF_05", "top");
+//define("LAN_LZ_THEMEPREF_06", "bottom");
 ?>

--- a/e107_themes/landingzero/theme_config.php
+++ b/e107_themes/landingzero/theme_config.php
@@ -22,7 +22,7 @@ class theme_config implements e_theme_config
 			'videomobilebackground' => array('title' => LAN_LZ_THEMEPREF_01, 'type'=>'image', 'help'=>''),
 			'videoposter'           => array('title' => LAN_LZ_THEMEPREF_02, 'type'=>'image', 'help'=>''),
 			'videourl'              => array('title' => LAN_LZ_THEMEPREF_03, 'type'=>'text', 'writeParms'=>array('size'=>'xxlarge'),'help'=>''),
-			'usernav_placement'     => array('title' => LAN_LZ_THEMEPREF_04, 'type'=>'dropdown', 'writeParms'=>array('optArray'=>array('top'=>LAN_LZ_THEMEPREF_05, 'bottom'=>LAN_LZ_THEMEPREF_06))),
+			'usernav_placement'     => array('title' => TPVLAN_97, 'type'=>'dropdown', 'writeParms'=>array('optArray'=>array('top'=>TPVLAN_104, 'bottom'=>TPVLAN_105))),
 		//	'cdn'   		        => array('title' => 'CDN', 'type'=>'dropdown', 'writeParms'=>array('optArray'=>array( 'cdnjs' => 'CDNJS (Cloudflare)', 'jsdelivr' => 'jsDelivr')))
 		);
 

--- a/e107_themes/voux/theme_config.php
+++ b/e107_themes/voux/theme_config.php
@@ -13,9 +13,9 @@ class theme_config implements e_theme_config
 
 
 		$fields = array(
-			'branding'          => array('title'=> "Branding", 'type'=>'dropdown', 'writeParms'=>array('optArray'=> $brandingOpts)),
-			'nav_alignment'     => array('title'=> "Navbar Alignment", 'type'=>'dropdown', 'writeParms'=>array('optArray'=> array('left'=> "Left",'right'=> "Right"))),
-			'usernav_placement' => array('title'=> "Signup/Login Placement", 'type'=>'dropdown', 'writeParms'=>array('optArray'=> array('top'=> "Top", 'bottom'=> "Bottom"))),
+			'branding'          => array('title'=> TPVLAN_95, 'type'=>'dropdown', 'writeParms'=>array('optArray'=> $brandingOpts)),
+			'nav_alignment'     => array('title'=> TPVLAN_96, 'type'=>'dropdown', 'writeParms'=>array('optArray'=> array('left'=> TPVLAN_102,'right'=> TPVLAN_103))),
+			'usernav_placement' => array('title'=> TPVLAN_97, 'type'=>'dropdown', 'writeParms'=>array('optArray'=> array('top'=> TPVLAN_104, 'bottom'=> TPVLAN_105))),
 		);
 
 		return $fields;


### PR DESCRIPTION
Changes:

	- Move all theme admin config LANs from e107_themes/bootstrap3/languages/English_admin.php to e107_languages/English/admin/lan_theme.php
	- Update e107_themes/bootstrap3/theme_config.php reflect the LAN terms change
	- Update hardcoded terms in e107_themes/voux/theme_config.php to use corresponding LANs from e107_languages/English/admin/lan_theme.php
	- Update e107_themes/landingzero/theme_config.php
	- Comment out duplicated LANs that have been moved to e107_languages/English/admin/lan_theme.php in e107_themes/landingzero/languages/English_admin.php and e107_themes/bootstrap3/languages/English_admin.php

Hi @CaMer0n,
If these changes comply with the LAN optimization changes you've proposed in issue #6 please review and merge.

If not please advise so that I can modify and resubmit.