### PR TITLE
[html] - Fix 'Duplicate ID' html validation error when Bootstrap3 theme user-login-dropdown menu and login_menu rendered together on a page.

### DIFF
--- a/e107_plugins/login_menu/login_menu_shortcodes.php
+++ b/e107_plugins/login_menu/login_menu_shortcodes.php
@@ -85,7 +85,7 @@ e107::getLanguage()->bcDefs($bcDefs);
 				// If logging in with email address - ignore pref and increase to 100 chars.
 				$maxLength  = ($this->allowEmailLogin == 1 || $this->allowEmailLogin) ? 100 : varset($pref['loginname_maxlength'],30);
 
-				return "<input class='form-control tbox login user' type='text' name='username' placeholder='".$this->usernameLabel."' required='required' id='username' size='15' value='' maxlength='".$maxLength."' />\n";
+				return "<input class='form-control tbox login user' type='text' name='username' placeholder='".$this->usernameLabel."' required='required' id='".vartrue( $parm['idprefix'] )."username' size='15' value='' maxlength='".$maxLength."' />\n";
 			}
 
 
@@ -98,7 +98,7 @@ e107::getLanguage()->bcDefs($bcDefs);
 			function sc_lm_password_input($parm='')
 			{
 				$pref = e107::getPref();
-				$t_password = "<input class='form-control tbox login pass' type='password' placeholder='".LAN_PASSWORD."' required='required' name='userpass' id='userpass' size='15' value='' maxlength='30' />\n";
+				$t_password = "<input class='form-control tbox login pass' type='password' placeholder='".LAN_PASSWORD."' required='required' name='userpass' id='".vartrue( $parm['idprefix'] )."userpass' size='15' value='' maxlength='30' />\n";
 				if (!USER && e107::getSession()->is('challenge') && varset($pref['password_CHAP'],0)) $t_password .= "<input type='hidden' name='hashchallenge' id='hashchallenge' value='".e107::getSession()->get('challenge')."' />\n\n";
 				return $t_password;
 			}

--- a/e107_themes/bootstrap3/theme_shortcodes.php
+++ b/e107_themes/bootstrap3/theme_shortcodes.php
@@ -137,8 +137,8 @@ class theme_shortcodes extends e_shortcode
 				$text .='	
 				
 				<form method="post" onsubmit="hashLoginPassword(this);return true" action="'.e_REQUEST_HTTP.'" accept-charset="UTF-8">
-				<p>{LM_USERNAME_INPUT}</p>
-				<p>{LM_PASSWORD_INPUT}</p>
+				<p>{LM_USERNAME_INPUT: idprefix=bs3-}</p>
+				<p>{LM_PASSWORD_INPUT: idprefix=bs3-}</p>
 
 
 				<div class="form-group"></div>
@@ -147,10 +147,10 @@ class theme_shortcodes extends e_shortcode
 				
 				<div class="checkbox">
 				
-				<label class="string optional" for="autologin"><input style="margin-right: 10px;" type="checkbox" name="autologin" id="autologin" value="1">
+				<label class="string optional" for="bs3-autologin"><input style="margin-right: 10px;" type="checkbox" name="autologin" id="bs3-autologin" value="1">
 				'.LAN_LOGINMENU_6.'</label>
 				</div>
-				<input class="btn btn-primary btn-block" type="submit" name="userlogin" id="userlogin" value="'.LAN_LOGINMENU_51.'">
+				<input class="btn btn-primary btn-block" type="submit" name="userlogin" id="bs3-userlogin" value="'.LAN_LOGINMENU_51.'">
 				';
 				
 				$text .= '


### PR DESCRIPTION
![screen shot 2017-06-16 at 3 22 28 pm](https://user-images.githubusercontent.com/315195/27224727-c79d79b6-52a7-11e7-8179-5a7c6b54166c.png)

Dear Admins,
Please review and merge if applicable.