### PR TITLE
fix double caption when it failed

### DIFF
--- a/fpw.php
+++ b/fpw.php
@@ -380,8 +380,9 @@ if (!empty($_POST['pwsubmit']))
 	{
 		//$text = LAN_213;
 		//$ns->tablerender(LAN_214, "<div style='text-align:center'>".$text."</div>");
-		e107::getMessage()->addError(LAN_213); 
-		$ns->tablerender(LAN_214, e107::getMessage()->render()); 
+		//e107::getMessage()->addError(LAN_213); 
+		//$ns->tablerender(LAN_214, e107::getMessage()->render());
+		fpw_error(LAN_213);
 	}
 }
 


### PR DESCRIPTION
tablerender make additional caption and breadcrumb above the error message when the process failed. (email not recognized)
no problem if the caption, is simple .. but if we have styled caption it look weird.
maybe there are better solutions ?

thank you