### PR TITLE
Styling edit button

### DIFF
--- a/e107_core/shortcodes/batch/page_shortcodes.php
+++ b/e107_core/shortcodes/batch/page_shortcodes.php
@@ -616,7 +616,7 @@ class cpage_shortcodes extends e_shortcode
 		$icon = deftrue('FONTAWESOME') ? $tp->toGlyph('fa-edit') : "<img src='".e_IMAGE_ABS."/admin_images/edit_16.png' alt='edit' style='border: 0px none; height: 16px; width: 16px;' />";
 
 
-	    return "<a rel='external'  title=\"".LAN_EDIT."\"  data-modal-caption=\"".LAN_EDIT."\" class='btn btn-default ".$modal."' href='".e_ADMIN_ABS."cpage.php?action=edit&id=".$this->var['page_id'].$iframe."' >".$icon."</a>";
+	    return "<a rel='external' style='float:right;margin:10px'  title=\"".LAN_EDIT."\"  data-modal-caption=\"".LAN_EDIT."\" class='btn btn-default ".$modal."' href='".e_ADMIN_ABS."cpage.php?action=edit&id=".$this->var['page_id'].$iframe."' >".$icon."</a>";
 	}
 
 


### PR DESCRIPTION
this edit button create an empty space after the page. with this we don't have to explain more to a client/user that it's only visible on editing mode / admin mode.. sometime a client just talk more than he should .. lol

thank you!

![gap](https://user-images.githubusercontent.com/25628686/29696182-5bbe4ef4-8971-11e7-92d1-ffdab4643b93.jpg)
