### PR TITLE
og:image setting if there is no already set one

### DIFF
--- a/e107_plugins/social/e_event.php
+++ b/e107_plugins/social/e_event.php
@@ -26,8 +26,43 @@ class social_event
 
 	function config()
 	{
+		$event = array();
+		
+		$event[] = array(
+			'name'     => "system_meta_pre",
+			'function' => "ogg_image_add",
+		);
 
-
+		return $event;
+		
+	}
+	
+	/**
+	 * Callback function to add og:image if there is no any
+	 */
+	function ogg_image_add()
+	{
+		$ogImage = e107::pref('social','og_image', false);
+		
+		if(e_ADMIN_AREA !==true) {
+			$ogimgexist = FALSE;
+			
+			// check if we have og:image defined
+			$response = e107::getSingleton('eResponse');
+			$data = $response->getMeta();
+			foreach($data as $m) {
+				if($m['name'] == 'og:image') {
+					$ogimgexist = TRUE;
+				}
+			}
+			
+			if(!empty($ogImage) && !$ogimgexist) {
+				e107::meta('og:image',e107::getParser()->thumbUrl($ogImage,'w=500',false,true));
+				unset($ogImage);
+			}
+		
+		}		
+		
 	}
 
 } //end class


### PR DESCRIPTION
I think the logic for setting og:image in social plugin is to be used site wide when no other is defined, but currently it's set too early in header so for example if we looking at news item which have some images, the social plugin og:image is grabed first by fb sharer since it came first in page output. My modification check if there is og:image defined and if there is already, skips adding the social plugin one.