### PR TITLE
og:image setting if there is no already set one

### DIFF
--- a/e107_plugins/social/e_module.php
+++ b/e107_plugins/social/e_module.php
@@ -18,13 +18,6 @@ if(e_ADMIN_AREA !==true)
 
 	}
 
-	$ogImage = e107::pref('social','og_image', false);
-	if(!empty($ogImage))
-	{
-		e107::meta('og:image',e107::getParser()->thumbUrl($ogImage,'w=500',false,true));
-		unset($ogImage);
-	}
-
 	if(deftrue('XURL_TWITTER') && XURL_TWITTER !== '#')
 	{
 		$screenName = basename(XURL_TWITTER);


### PR DESCRIPTION
I think the logic for setting og:image in social plugin is to be used site wide when no other is defined, but currently it's set too early in header so for example if we looking at news item which have some images, the social plugin og:image is grabed first by fb sharer since it came first in page output. My modification check if there is og:image defined and if there is already, skips adding the social plugin one.