### PR TITLE
Fix for PHP Warning array_merge(): Argument #2 is not an array, Line 156…

### DIFF
--- a/e107_handlers/e107_class.php
+++ b/e107_handlers/e107_class.php
@@ -3553,7 +3553,7 @@ class e107
 	}
 
 
-	public static function minify($js,$options=null)
+	public static function minify($js,$options=array())
 	{
 		if(empty($js))
 		{


### PR DESCRIPTION
… of /e107_handlers/jsshrink/Minifier.php