### PR TITLE
Several fixes to suppress PHP notices, also contains fix for Website Status dashboard chart.

### DIFF
--- a/e107_admin/cpage.php
+++ b/e107_admin/cpage.php
@@ -679,7 +679,7 @@ class page_admin_ui extends e_admin_ui
 
 					if(strpos($k,'menu_') === 0)
 					{
-						$this->fields[$k]['class'] = 'menu-field '.$this->fields[$k]['class'];
+						$this->fields[$k]['class'] = 'menu-field ' . varset($this->fields[$k]['class'], '');
 					}
 
 					$this->fields[$k]['width'] = '13%';

--- a/e107_admin/includes/flexpanel.php
+++ b/e107_admin/includes/flexpanel.php
@@ -143,16 +143,30 @@ class adminstyle_flexpanel extends adminstyle_infopanel
 		$ns->setStyle('flexpanel');
 		$ns->setUniqueId('core-infopanel_help');
 		$info = $this->getMenuPosition('core-infopanel_help');
+		if (!isset($panels[$info['area']][$info['weight']]))
+		{
+			$panels[$info['area']][$info['weight']] = '';
+		}
 		$panels[$info['area']][$info['weight']] .= $tp->parseTemplate('{ADMIN_HELP}', false, $admin_sc);
+
 
 		// "Latest" box.
 		$ns->setStyle('flexpanel');
 		$info = $this->getMenuPosition('e-latest-list');
+		if (!isset($panels[$info['area']][$info['weight']]))
+		{
+			$panels[$info['area']][$info['weight']] = '';
+		}
 		$panels[$info['area']][$info['weight']] .= $tp->parseTemplate('{ADMIN_LATEST=infopanel}', false, $admin_sc);
+
 
 		// "Status" box.
 		$ns->setStyle('flexpanel');
 		$info = $this->getMenuPosition('e-status-list');
+		if (!isset($panels[$info['area']][$info['weight']]))
+		{
+			$panels[$info['area']][$info['weight']] = '';
+		}
 		$panels[$info['area']][$info['weight']] .= $tp->parseTemplate('{ADMIN_STATUS=infopanel}', false, $admin_sc);
 
 
@@ -196,6 +210,10 @@ class adminstyle_flexpanel extends adminstyle_infopanel
 		$ns->setUniqueId('core-infopanel_mye107');
 		$coreInfoPanelMyE107 = $ns->tablerender($caption, $mainPanel, "core-infopanel_mye107", true);
 		$info = $this->getMenuPosition('core-infopanel_mye107');
+		if (!isset($panels[$info['area']][$info['weight']]))
+		{
+			$panels[$info['area']][$info['weight']] = '';
+		}
 		$panels[$info['area']][$info['weight']] .= $coreInfoPanelMyE107;
 
 
@@ -208,6 +226,10 @@ class adminstyle_flexpanel extends adminstyle_infopanel
 		$ns->setUniqueId('core-infopanel_news');
 		$coreInfoPanelNews = $ns->tablerender(LAN_LATEST_e107_NEWS, e107::getForm()->tabs($newsTabs, array('active' => 'coreFeed')), "core-infopanel_news", true);
 		$info = $this->getMenuPosition('core-infopanel_news');
+		if (!isset($panels[$info['area']][$info['weight']]))
+		{
+			$panels[$info['area']][$info['weight']] = '';
+		}
 		$panels[$info['area']][$info['weight']] .= $coreInfoPanelNews;
 
 
@@ -228,6 +250,10 @@ class adminstyle_flexpanel extends adminstyle_infopanel
 		$ns->setUniqueId('e-addon-updates');
 		$addonUpdates = $admin_sc->sc_admin_addon_updates();
 		$info = $this->getMenuPosition('e-addon-updates');
+		if (!isset($panels[$info['area']][$info['weight']]))
+		{
+			$panels[$info['area']][$info['weight']] = '';
+		}
 		$panels[$info['area']][$info['weight']] .= $addonUpdates;
 
 
@@ -250,6 +276,10 @@ class adminstyle_flexpanel extends adminstyle_infopanel
 					$inc = $tp->parseTemplate("{PLUGIN=$val|TRUE}");
 				}
 				$info = $this->getMenuPosition($id);
+				if (!isset($panels[$info['area']][$info['weight']]))
+				{
+					$panels[$info['area']][$info['weight']] = '';
+				}
 				$panels[$info['area']][$info['weight']] .= $inc;
 			}
 		}
@@ -265,12 +295,13 @@ class adminstyle_flexpanel extends adminstyle_infopanel
 				$id = $val['mode'];
 				$ns->setUniqueId($id);
 				$inc = $ns->tablerender($val['caption'], $val['text'], $val['mode'], true);
-
 				$info = $this->getMenuPosition($id);
-
+				if (!isset($panels[$info['area']][$info['weight']]))
+				{
+					$panels[$info['area']][$info['weight']] = '';
+				}
 				$panels[$info['area']][$info['weight']] .= $inc;
 			}
-
 		}
 
 

--- a/e107_admin/newspost.php
+++ b/e107_admin/newspost.php
@@ -1271,7 +1271,7 @@ class news_admin_ui extends e_admin_ui
 								<tr>
 								<td>".LAN_NEWS_99."</td>
 								<td>
-									".$frm->select('subnews_attach_minsize', $imageSizes, $pref['subnews_attach_minsize'], null, LAN_NEWS_100)."
+									".$frm->select('subnews_attach_minsize', $imageSizes, varset($pref['subnews_attach_minsize'], null), null, LAN_NEWS_100)."
 								</td>
 							</tr>
 							<tr>

--- a/e107_core/shortcodes/batch/user_shortcodes.php
+++ b/e107_core/shortcodes/batch/user_shortcodes.php
@@ -165,15 +165,15 @@ class user_shortcodes extends e_shortcode
 		//require_once(e_HANDLER."level_handler.php");
 		//$ldata = get_level($this->var['user_id'], $this->var['user_forums'], $this->var['user_comments'], $this->var['user_chats'], $this->var['user_visits'], $this->var['user_join'], $this->var['user_admin'], $this->var['user_perms'], $pref);
 		$ldata = array();
-		if (strstr($ldata[0], "IMAGE_rank_main_admin_image")) 
+		if (isset($ldata[0]) && strstr($ldata[0], "IMAGE_rank_main_admin_image"))
 		{
 			return LAN_USER_31;
 		}
-		elseif(strstr($ldata[0], "IMAGE")) 
+		elseif(isset($ldata[0]) && strstr($ldata[0], "IMAGE"))
 		{
 			return LAN_USER_32;
 		}
-		else
+		elseif(isset($ldata[1]))
 		{
 			return $ldata[1];
 		}

--- a/e107_core/shortcodes/batch/user_shortcodes.php
+++ b/e107_core/shortcodes/batch/user_shortcodes.php
@@ -738,7 +738,7 @@ class user_shortcodes extends e_shortcode
 			
 			$cat_name = true; //XXX TEMP Fix. 
 			
-			if($cat_name != FALSE && count($ueFieldList[$catnum]))
+			if($cat_name != FALSE && isset($ueFieldList[$catnum]) && count($ueFieldList[$catnum]))
 			{
 					
 				$ret .= str_replace("{EXTENDED_NAME}", $key, $EXTENDED_CATEGORY_START);

--- a/e107_core/shortcodes/single/user_extended.php
+++ b/e107_core/shortcodes/single/user_extended.php
@@ -110,6 +110,10 @@
 
 		if ($parms[1] == 'text')
 		{
+			if(!isset($ueStruct['user_'.$parms[0]]))
+			{
+				return FALSE;
+			}
 			$text_val = $ueStruct['user_'.$parms[0]]['user_extended_struct_text'];
 			if($text_val)
 			{

--- a/e107_handlers/e107_class.php
+++ b/e107_handlers/e107_class.php
@@ -667,7 +667,7 @@ class e107
 	{
 		if(null === $data)
 		{
-			if(is_object(self::$_registry[$id]) && method_exists(self::$_registry[$id], '__destruct'))
+			if(isset(self::$_registry[$id]) && is_object(self::$_registry[$id]) && method_exists(self::$_registry[$id], '__destruct'))
 			{
 				self::$_registry[$id]->__destruct();
 			}

--- a/e107_handlers/e_customfields_class.php
+++ b/e107_handlers/e_customfields_class.php
@@ -280,29 +280,27 @@
 				<tr><th>".LAN_NAME."</th><th>".LAN_TITLE."</th><th>".LAN_TYPE."</th><th>Params</th><th>".LAN_TOOLTIP."</th></tr>
 				";
 
-			for ($i = 0; $i <= $this->_field_limit; $i++)
+			for($i = 0; $i <= $this->_field_limit; $i++)
 			{
-
 				$writeParms = array(
-				//	'class' => 'form-control',
+					//	'class' => 'form-control',
 					'useValues' => 1,
 					'default'   => 'blank',
-					'data-src' => e_REQUEST_URI,
+					'data-src'  => e_REQUEST_URI,
 
 				);
 
-				$parmsWriteParms= array(
-					'size' => 'block-level',
-					'placeholder' => $this->getCustomFieldPlaceholder($value[$i]['type'])
-
+				$parmsWriteParms = array(
+					'size'        => 'block-level',
+					'placeholder' => isset($value[$i]['type']) ? $this->getCustomFieldPlaceholder($value[$i]['type']) : '',
 				);
 
-				$fieldName = $frm->text($name.'['.$i.'][key]', $value[$i]['key'],30, array('pattern'=>'^[a-z0-9-]*'));
-				$fieldTitle = $frm->text($name.'['.$i.'][title]',$value[$i]['title'], 80);
-				$fieldType = $frm->select($name.'['.$i.'][type]',$this->getFieldTypes(),$value[$i]['type'], $writeParms);
-				$fieldParms = $frm->text($name.'['.$i.'][writeParms]',$value[$i]['writeParms'], 255, $parmsWriteParms);
-				$fieldHelp = $frm->text($name.'['.$i.'][help]',$value[$i]['help'], 255, array('size'=>'block-level'));
-			   $text .= "<tr><td>".$fieldName."</td><td>".$fieldTitle."</td><td>".$fieldType."</td><td>".$fieldParms."</td><td>".$fieldHelp."</td></tr>";
+				$fieldName = $frm->text($name . '[' . $i . '][key]', varset($value[$i]['key']), 30, array('pattern' => '^[a-z0-9-]*'));
+				$fieldTitle = $frm->text($name . '[' . $i . '][title]', varset($value[$i]['title']), 80);
+				$fieldType = $frm->select($name . '[' . $i . '][type]', $this->getFieldTypes(), varset($value[$i]['type']), $writeParms);
+				$fieldParms = $frm->text($name . '[' . $i . '][writeParms]', varset($value[$i]['writeParms']), 255, $parmsWriteParms);
+				$fieldHelp = $frm->text($name . '[' . $i . '][help]', varset($value[$i]['help']), 255, array('size' => 'block-level'));
+				$text .= "<tr><td>" . $fieldName . "</td><td>" . $fieldTitle . "</td><td>" . $fieldType . "</td><td>" . $fieldParms . "</td><td>" . $fieldHelp . "</td></tr>";
 			}
 
 			$text .= "</tbody></table>";

--- a/e107_handlers/rate_class.php
+++ b/e107_handlers/rate_class.php
@@ -107,7 +107,10 @@ class rater
 		$text = "";
 		foreach($tmp as $k)
 		{
-			$text .= $TEMPLATE[$k];	
+			if (!empty($TEMPLATE[$k]))
+			{
+				$text .= $TEMPLATE[$k];
+			}
 		}	
 		
 		return $text;

--- a/e107_handlers/sitelinks_class.php
+++ b/e107_handlers/sitelinks_class.php
@@ -1977,13 +1977,13 @@ class navigation_shortcodes extends e_shortcode
 	 */
 	function sc_link_parent($parm='')
 	{
-		return intval($this->var['link_parent']);		
+		return intval($this->var['link_parent']);
 	}
 
 
 	function sc_link_identifier($parm='')
 	{
-		return $this->var['link_identifier'];	
+		return isset($this->var['link_identifier']) ? $this->var['link_identifier'] : '';
 	}
 
 	/**

--- a/e107_handlers/sitelinks_class.php
+++ b/e107_handlers/sitelinks_class.php
@@ -1453,7 +1453,7 @@ i.e-cat_users-32{ background-position: -555px 0; width: 32px; height: 32px; }
 				$replace[9] = varset($e107_vars[$act]['image']);	
 			}
 
-			$replace[10] = count($e107_vars[$act]['sub']) > 20 ? 'oversized' : '';
+			$replace[10] = (isset($e107_vars[$act]['sub']) && count($e107_vars[$act]['sub']) > 20) ? 'oversized' : '';
 
 			if(!empty($e107_vars[$act]['link_data']))
 			{

--- a/e107_handlers/theme_handler.php
+++ b/e107_handlers/theme_handler.php
@@ -725,28 +725,23 @@ class e_theme
 			unset($vars['stylesheets']);
 		}
 
-
 		$vars['glyphs'] = array();
 		if(!empty($vars['glyphicons']['glyph']))
 		{
-
 			foreach($vars['glyphicons']['glyph'] as $val)
 			{
 				$vars['glyphs'][] = array(
-						'name'      => $val['@attributes']['name'],
-						'pattern'   => $val['@attributes']['pattern'],
-						'path'      => $val['@attributes']['path'],
-						'class'     => $val['@attributes']['class'],
-						'prefix'    => $val['@attributes']['prefix'],
-						'tag'       => $val['@attributes']['tag'],
+					'name'    => isset($val['@attributes']['name']) ? $val['@attributes']['name'] : '',
+					'pattern' => isset($val['@attributes']['pattern']) ? $val['@attributes']['pattern'] : '',
+					'path'    => isset($val['@attributes']['path']) ? $val['@attributes']['path'] : '',
+					'class'   => isset($val['@attributes']['class']) ? $val['@attributes']['class'] : '',
+					'prefix'  => isset($val['@attributes']['prefix']) ? $val['@attributes']['prefix'] : '',
+					'tag'     => isset($val['@attributes']['tag']) ? $val['@attributes']['tag'] : '',
 				);
-
 			}
 
 			unset($vars['glyphicons']);
-
 		}
-
 
 		if($path == "landingzero" )
 		{

--- a/e107_handlers/upload_handler.php
+++ b/e107_handlers/upload_handler.php
@@ -893,7 +893,7 @@ function get_image_mime($filename, $extended = false)
 		global $pref;
 		$admin_log = e107::getAdminLog();
 		// Work out maximum allowable file size
-		if (UH_DEBUG)
+		if (deftrue('UH_DEBUG'))
 		{
 			$admin_log->
 				e_log_event(10, __FILE__."|".__FUNCTION__."@".__LINE__, "DEBUG", "Upload Handler test", "File size limits - user set: ".$pref['upload_maxfilesize']." Post_max_size: ".ini_get('post_max_size')." upload_max_size: ".ini_get('upload_max_size'), FALSE, FALSE);
@@ -909,7 +909,7 @@ function get_image_mime($filename, $extended = false)
 			if (varset($pref['upload_maxfilesize'], 0) > 0)
 				$max_upload_size = file_size_decode($pref['upload_maxfilesize'], $max_upload_size, 'lt');
 		}
-		if (UH_DEBUG)
+		if (deftrue('UH_DEBUG'))
 			$admin_log->
 				e_log_event(10, __FILE__."|".__FUNCTION__."@".__LINE__, "DEBUG", "Upload Handler test", "Final max upload size: {$max_upload_size}", FALSE, FALSE);
 		return $max_upload_size;

--- a/e107_languages/English/English.php
+++ b/e107_languages/English/English.php
@@ -131,6 +131,7 @@ define("LAN_RE_ORDER", "Re-order");
 define("LAN_RELATED", "Related");
 define("LAN_CLOSE", "Close");
 define("LAN_EXPAND", "Expand");
+define("LAN_LIST", "List");
 
 define("LAN_ENTER_USRNAME_EMAIL", "Please enter your username or email"); // admin php hover field admin name
 define("LAN_PWD_REQUIRED", "Password is required"); // admin php hover field admin password

--- a/e107_languages/English/admin/lan_admin.php
+++ b/e107_languages/English/admin/lan_admin.php
@@ -391,7 +391,6 @@ define("LAN_MEDIAMANAGER", "Media Manager");
 define("LAN_MOREINFO","More Information...");
 define("LAN_COMMENTMAN", "Comments Manager");
 
-define("LAN_LIST", "List");
 define("LAN_FILTER", "Filter");
 // define("LAN_NO_RECORDS", "No Records Found");
 define("LAN_STATUS", "Status");

--- a/e107_plugins/gallery/templates/gallery_template.php
+++ b/e107_plugins/gallery/templates/gallery_template.php
@@ -94,7 +94,7 @@ $GALLERY_TEMPLATE['prettyphoto']['content'] = '
 				<div class="pp_content">
 					<div class="pp_loaderIcon"></div>
 					<div class="pp_fade">
-						<a href="#" class="pp_expand" title="'.LAN_GALLERY_FRONT_02.'">'.LAN_EXPAND.'</a>
+						<a href="#" class="pp_expand" title="'.LAN_EXPAND.'">'.LAN_EXPAND.'</a>
 						<div class="pp_hoverContainer">
 							<a class="pp_next" href="#">' . LAN_NEXT . '</a>
 							<a class="pp_previous" href="#">' . LAN_PREVIOUS . '</a>

--- a/e107_plugins/user/e_dashboard.php
+++ b/e107_plugins/user/e_dashboard.php
@@ -57,14 +57,15 @@ class user_dashboard // plugin-folder + '_url'
 
 			$months = e107::getDate()->terms('month');
 
-			$data['labels'] = array($months[0], //"January",
- 						$months[1], //"February",
- 						$months[2], //"March",
- 						$months[3], //"April",
- 						$months[4], //"May",
- 						$months[5], //"June",
- 						$months[6]  //"July"
- 			);
+			foreach($months as $month)
+			{
+				// We need only the first 6 months for demo.
+				if (!empty($data['labels']) && count($data['labels']) >= 6)
+				{
+					continue;
+				}
+				$data['labels'][] = $month;
+			}
 
 			$data['datasets'][]	= array(
 							'fillColor'			=> "rgba(220,220,220,0.5)",


### PR DESCRIPTION
Invalid month for (demo) chart:
![kepernyokep_2017-12-10_11-53-10](https://user-images.githubusercontent.com/6043821/33804329-d18b7e06-dda2-11e7-9aa6-485ee375e07f.png)
