### PR TITLE
Permissive field validation in db_verify

### DIFF
--- a/e107_handlers/db_verify_class.php
+++ b/e107_handlers/db_verify_class.php
@@ -136,7 +136,7 @@ class db_verify
 	/**
 	 * Permissive field validation
 	 */
-	private function validateFieldPermissive($expected, $actual)
+	private function diffFieldPermissive($expected, $actual)
 	{
 		// Permit actual text types that default to null even when
 		// expected does not explicitly default to null
@@ -153,7 +153,8 @@ class db_verify
 			$expected['default'] = preg_replace("/DEFAULT '(\d+)'/i", 'DEFAULT $1', $expected['default']);
 			$actual['default']   = preg_replace("/DEFAULT '(\d+)'/i", 'DEFAULT $1', $actual['default']  );
 		}
-		return !count($off = array_diff_assoc($expected, $actual));
+
+		return array_diff_assoc($expected, $actual);
 	}
 	
 	/**
@@ -370,11 +371,11 @@ class db_verify
 					$this->results[$tbl][$field]['_valid'] = $info;
 					$this->results[$tbl][$field]['_file'] = $selection;
 				}
-				elseif(!$this->validateFieldPermissive($info, $sqlFieldData[$field]))
+				elseif(count($diff = $this->diffFieldPermissive($info, $sqlFieldData[$field])))
 				{
 					$this->errors[$tbl]['_status'] = 'mismatch';
 					$this->results[$tbl][$field]['_status'] = 'mismatch';
-					$this->results[$tbl][$field]['_diff'] = $off;	
+					$this->results[$tbl][$field]['_diff'] = $diff;
 					$this->results[$tbl][$field]['_valid'] = $info;
 					$this->results[$tbl][$field]['_invalid'] = $sqlFieldData[$field];
 					$this->results[$tbl][$field]['_file'] = $selection;
@@ -398,14 +399,14 @@ class db_verify
 					$this->indices[$tbl][$field]['_valid'] = $info;
 					$this->indices[$tbl][$field]['_file'] = $selection;
 				}
-				elseif(count($offin = array_diff_assoc($info,$sqlIndexData[$field]))) // missmatch data
+				elseif(count($diff = $this->diffFieldPermissive($info, $sqlIndexData[$field]))) // mismatched data
 				{
 					// print_a($info);
 					// print_a($sqlIndexData[$field]);
 					
 					$this->errors[$tbl]['_status'] = 'mismatch_index';
 					$this->indices[$tbl][$field]['_status'] = 'mismatch';
-					$this->indices[$tbl][$field]['_diff'] = $offin;	
+					$this->indices[$tbl][$field]['_diff'] = $diff;
 					$this->indices[$tbl][$field]['_valid'] = $info;
 					$this->indices[$tbl][$field]['_invalid'] = $sqlIndexData[$field];
 					$this->indices[$tbl][$field]['_file'] = $selection;

--- a/e107_handlers/db_verify_class.php
+++ b/e107_handlers/db_verify_class.php
@@ -136,7 +136,7 @@ class db_verify
 	/**
 	 * Permissive field validation
 	 */
-	private function diffFieldPermissive($expected, $actual)
+	private function diffStructurePermissive($expected, $actual)
 	{
 		// Permit actual text types that default to null even when
 		// expected does not explicitly default to null
@@ -316,11 +316,11 @@ class db_verify
 		//	echo "<h4>PARSED</h4>";
 		//	print_a($sqlDataArr);
 
-			$fileFieldData	= $this->getFields($this->sqlFileTables[$selection]['data'][$key]);
-			$sqlFieldData	= $this->getFields($sqlDataArr['data'][0]);	
+			$fileData['field']	= $this->getFields($this->sqlFileTables[$selection]['data'][$key]);
+			$sqlData['field']	= $this->getFields($sqlDataArr['data'][0]);
 			
-			$fileIndexData	= $this->getIndex($this->sqlFileTables[$selection]['data'][$key]);
-			$sqlIndexData	= $this->getIndex($sqlDataArr['data'][0]);
+			$fileData['index']	= $this->getIndex($this->sqlFileTables[$selection]['data'][$key]);
+			$sqlData['index']	= $this->getIndex($sqlDataArr['data'][0]);
 		/*		
 			$debugA = print_r($fileFieldData,TRUE);	// Extracted Field Arrays	
 			$debugA .= "<h2>Index</h2>";
@@ -353,73 +353,39 @@ class db_verify
 			 	$tbl = "lan_".$language."_".$tbl;
 			}
 			
-			
-			// Check Field Data. 
-			foreach($fileFieldData as $field => $info )
+			// Check field and index data
+			foreach(['field', 'index'] as $type)
 			{
-				 
-					
-				$this->results[$tbl][$field]['_status'] = 'ok';	
-				
-				if(!is_array($sqlFieldData[$field]))
+				foreach($fileData[$type] as $key => $value)
 				{
-				//	 echo "<h2>".$field."</h2><table><tr><td><pre>".print_r($info,TRUE)."</pre></td>
-				// <td style='border:1px solid silver'><pre> - ".print_r($sqlFieldData[$field],TRUE)."</pre></td></tr></table>";
-					
-					$this->errors[$tbl]['_status'] = 'error'; // table status
-					$this->results[$tbl][$field]['_status'] = 'missing_field';	 // field status					
-					$this->results[$tbl][$field]['_valid'] = $info;
-					$this->results[$tbl][$field]['_file'] = $selection;
+					$this->results[$tbl][$key]['_status'] = 'ok';
+
+					//print("EXPECTED");
+					//print_a($value);
+					//print("ACTUAL");
+					//print_a($sqlData[$type][$key]);
+
+					if(!is_array($sqlData[$type][$key]))
+					{
+						$this->errors[$tbl]['_status'] = 'error'; // table status
+						$this->results[$tbl][$key]['_status'] = "missing_$type"; // type status
+						$this->results[$tbl][$key]['_valid'] = $value;
+						$this->results[$tbl][$key]['_file'] = $selection;
+					}
+					elseif(count($diff = $this->diffStructurePermissive($value, $sqlData[$type][$key])))
+					{
+						$this->errors[$tbl]['_status'] = "mismatch_$type";
+						$this->results[$tbl][$key]['_status'] = 'mismatch';
+						$this->results[$tbl][$key]['_diff'] = $diff;
+						$this->results[$tbl][$key]['_valid'] = $value;
+						$this->results[$tbl][$key]['_invalid'] = $sqlData[$type][$key];
+						$this->results[$tbl][$key]['_file'] = $selection;
+					}
+
+					// TODO Check for additional fields in SQL that should be removed.
+					// TODO Add support for MYSQL 5 table layout .eg. journal_id INT( 10 ) UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY ,
 				}
-				elseif(count($diff = $this->diffFieldPermissive($info, $sqlFieldData[$field])))
-				{
-					$this->errors[$tbl]['_status'] = 'mismatch';
-					$this->results[$tbl][$field]['_status'] = 'mismatch';
-					$this->results[$tbl][$field]['_diff'] = $diff;
-					$this->results[$tbl][$field]['_valid'] = $info;
-					$this->results[$tbl][$field]['_invalid'] = $sqlFieldData[$field];
-					$this->results[$tbl][$field]['_file'] = $selection;
-				}
-				
-				
 			}
-
-		//	 print_a($fileIndexData);
-		//	print_a($sqlIndexData);
-			// Check Index data
-			foreach($fileIndexData as $field => $info )
-			{
-				if(!is_array($sqlIndexData[$field])) // missing index. 
-				{
-					// print_a($info);
-					// print_a($sqlIndexData[$field]);
-					
-					$this->errors[$tbl]['_status'] = 'error'; // table status
-					$this->indices[$tbl][$field]['_status'] = 'missing_index';	 // index status					
-					$this->indices[$tbl][$field]['_valid'] = $info;
-					$this->indices[$tbl][$field]['_file'] = $selection;
-				}
-				elseif(count($diff = $this->diffFieldPermissive($info, $sqlIndexData[$field]))) // mismatched data
-				{
-					// print_a($info);
-					// print_a($sqlIndexData[$field]);
-					
-					$this->errors[$tbl]['_status'] = 'mismatch_index';
-					$this->indices[$tbl][$field]['_status'] = 'mismatch';
-					$this->indices[$tbl][$field]['_diff'] = $diff;
-					$this->indices[$tbl][$field]['_valid'] = $info;
-					$this->indices[$tbl][$field]['_invalid'] = $sqlIndexData[$field];
-					$this->indices[$tbl][$field]['_file'] = $selection;
-					 
-				}
-				
-				// TODO Check for additional fields in SQL that should be removed. 
-				// TODO Add support for MYSQL 5 table layout .eg. journal_id INT( 10 ) UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY ,
-
-			}
-
-
-			
 
 			unset($data);
 			


### PR DESCRIPTION
Even if it's a new installation of e107, `db_verify` will be too strict in
validating database field defaults that are equivalent to each other.

This can happen on some MySQL or MariaDB servers that correct the field
definitions, which were not strictly correct in the table structures built into
e107 in the first place.

This pull request introduces `db_verify::diffStructurePermissive()`, a
backwards-compatible way to validate database field defaults.  It works
regardless of whether the MySQL server stores a corrected representation of the
schema and does not require fixing the schema in any existing table structure
files.

Fixes: #2998