### PR TITLE
Disable new password autocomplete for admins

### DIFF
--- a/e107_admin/users.php
+++ b/e107_admin/users.php
@@ -1615,7 +1615,7 @@ class users_admin_ui extends e_admin_ui
 
 		<tr>
 			<td>".LAN_PASSWORD."</td>
-			<td>".$frm->password('password', '', 20, array('size' => 'xlarge', 'class' => 'tbox e-password', 'generate' => 1, 'strength' => 1))."
+			<td>".$frm->password('password', '', 128, array('size' => 'xlarge', 'class' => 'tbox e-password', 'generate' => 1, 'strength' => 1, 'autocomplete' => 'new-password'))."
 			</td>
 		</tr>";
 		
@@ -2493,7 +2493,7 @@ class users_admin_form_ui extends e_admin_form_ui
 		{
 			$fieldName = 'user_password_'. $this->getController()->getId();
 
-			return $this->password($fieldName, '', 20, array('size' => 50, 'class' => 'tbox e-password', 'placeholder' => USRLAN_251, 'generate' => 1, 'strength' => 1, 'required'=>0, 'autocomplete'=>'off'))."
+			return $this->password($fieldName, '', 128, array('size' => 50, 'class' => 'tbox e-password', 'placeholder' => USRLAN_251, 'generate' => 1, 'strength' => 1, 'required'=>0, 'autocomplete'=>'new-password'))."
 			";			
 		}
 			


### PR DESCRIPTION
Admins can now set user passwords longer than 20 characters.  New character limit is 128.

Autocomplete is disabled for new user passwords set by admins so that they don't autofill their own passwords into the users'.

Fixes: #2882 

---

_My editor messed with the DOS-style line endings, so go to https://github.com/e107inc/e107/pull/3005/files?w=1 to see the real changes._