### PR TITLE
Allow spaces in passwords system-wide by default

### DIFF
--- a/e107_handlers/form_handler.php
+++ b/e107_handlers/form_handler.php
@@ -1798,7 +1798,7 @@ class e_form
 			$addon .= "<div style='margin-top:4px'><div  class='progress' style='float:left;display:inline-block;width:218px;margin-bottom:0'><div class='progress-bar bar' id='pwdMeter' style='width:0%' ></div></div> <div id='pwdStatus' class='smalltext' style='float:left;display:inline-block;width:150px;margin-left:5px'></span></div>";
 		}
 		
-		$options['pattern'] = vartrue($options['pattern'],'[\S]{4,}');
+		$options['pattern'] = vartrue($options['pattern'],'.{4,}');
 		$options['required'] = varset($options['required'], 1);
 		$options['class'] = vartrue($options['class'],'e-password tbox');
 

--- a/e107_handlers/form_handler.php
+++ b/e107_handlers/form_handler.php
@@ -1798,7 +1798,7 @@ class e_form
 			$addon .= "<div style='margin-top:4px'><div  class='progress' style='float:left;display:inline-block;width:218px;margin-bottom:0'><div class='progress-bar bar' id='pwdMeter' style='width:0%' ></div></div> <div id='pwdStatus' class='smalltext' style='float:left;display:inline-block;width:150px;margin-left:5px'></span></div>";
 		}
 		
-		$options['pattern'] = vartrue($options['pattern'],'.{4,}');
+		$options['pattern'] = vartrue($options['pattern'],'[\S].{2,}[\S]');
 		$options['required'] = varset($options['required'], 1);
 		$options['class'] = vartrue($options['class'],'e-password tbox');
 


### PR DESCRIPTION
Some e107 users and admins may use whitespace in their passwords, but the
client-side HTML validation currently prohibited them by default.

The server accepts passwords with whitespace if this client-side validation is
disabled, so there does not appear to be a technical reason for this
restriction.

This pull request allows whitespaces in passwords by default.

Fixes: #3006