### PR TITLE
Permissive numeric field validation in db_verify

### DIFF
--- a/e107_handlers/db_verify_class.php
+++ b/e107_handlers/db_verify_class.php
@@ -147,11 +147,11 @@ class db_verify
 			$expected['default'] = $actual['default'];
 		}
 
-		// Loosely typed default value for int-like types
-		if(1 === preg_match('/[A-Z]*INT/i', $expected['type']))
+		// Loosely typed default value for numeric types
+		if(1 === preg_match('/([A-Z]*INT|NUMERIC|DEC|FIXED|FLOAT|REAL|DOUBLE)/i', $expected['type']))
 		{
-			$expected['default'] = preg_replace("/DEFAULT '(\d+)'/i", 'DEFAULT $1', $expected['default']);
-			$actual['default']   = preg_replace("/DEFAULT '(\d+)'/i", 'DEFAULT $1', $actual['default']  );
+			$expected['default'] = preg_replace("/DEFAULT '(\d*\.?\d*)'/i", 'DEFAULT $1', $expected['default']);
+			$actual['default']   = preg_replace("/DEFAULT '(\d*\.?\d*)'/i", 'DEFAULT $1', $actual['default']  );
 		}
 
 		return array_diff_assoc($expected, $actual);


### PR DESCRIPTION
`db_verify::diffStructurePermissive()` now checks for all MySQL/MariaDB numeric types and permissively allows the expected and actual default values to be strings rather than numerical.

Fixes: #3011
Related: #2998