### PR TITLE
Proper file_inspector::inspect() optional arguments

### DIFF
--- a/e107_admin/fileinspector.php
+++ b/e107_admin/fileinspector.php
@@ -569,7 +569,7 @@ class file_inspector {
 	//	$dir
 	//	&$tree_end
 	//	&$parent_expand
-	function inspect($list, $deprecated, $level, $dir, &$tree_end, &$parent_expand)
+	function inspect($list, $deprecated, $level, $dir, &$tree_end = null, &$parent_expand = null)
 	{
 	  global $coredir;
 


### PR DESCRIPTION
`file_inspector::inspect()` now works in PHP 7 because the pass-by-reference variables are now optional as they were intended.

Fixes: #3013