### PR TITLE
e_pref::update() accepts existing keys with NULL

### DIFF
--- a/e107_handlers/pref_class.php
+++ b/e107_handlers/pref_class.php
@@ -240,7 +240,7 @@ class e_pref extends e_front_model
 		{
 			return $this;
 		}
-		if(isset($this->_data[$pref_name])) 
+		if(array_key_exists($pref_name, $this->_data))
 		{
 			if($this->_data[$pref_name] != $value) $this->data_has_changed = true;
 			$this->_data[$pref_name] = $value;


### PR DESCRIPTION
`e_pref::update()` will now update keys' values where the keys have a value of `NULL`.

Fixes: #3021
Fixes: #2933