### PR TITLE
Sanity check in xmlClass::xml2array() for PHP 7.2

### DIFF
--- a/e107_handlers/xml_class.php
+++ b/e107_handlers/xml_class.php
@@ -553,7 +553,7 @@ class xmlClass
 		}
 
 		//Recursive calls start here
-		if($tags)
+		if(self::is_assoc($tags))
 		{
 			$tags = array_keys($tags);
 			$count_tags = count($tags);
@@ -747,6 +747,25 @@ class xmlClass
 		}
 		
 		return $vars;
+	}
+
+	/**
+	 * Determine if the provided variable is an associative array
+	 *
+	 * This method is necessary because since PHP 7.2, get_object_vars() on
+	 * a SimpleXMLElement object began returning sequential arrays, and
+	 * xmlClass::xml2array() interpreted the sequence as XML tags.
+	 *
+	 * See https://github.com/e107inc/e107/issues/3018 for details.
+	 *
+	 * @param array $array The variable to check
+	 * @return boolean true if the provided variable is an associative array,
+	 *                 false if it's a sequential array or anything else
+	 */
+	private static function is_assoc($array)
+	{
+		if (!is_array($array) || array() === $array) return false;
+		return array_keys($array) !== range(0, count($array) - 1);
 	}
 
 	/**


### PR DESCRIPTION
Since PHP 7.2, running `get_object_vars()` on a `SimpleXMLElement` object may return sequential arrays rather than nothing if there were no children.

This pull request introduces a sanity check in `xmlClass::xml2array()` that ensures child tags are processed rather than sequential array keys.

This sanity check does not affect past major versions of PHP.

Fixes: #3018
Supersedes: #3019