### PR TITLE
PHP 7.2 consistency hack in xmlClass::xml2array()

### DIFF
--- a/e107_handlers/xml_class.php
+++ b/e107_handlers/xml_class.php
@@ -561,16 +561,17 @@ class xmlClass
 			//loop through tags
 			foreach ($tags as $tag)
 			{
+				if(is_int($tag)) continue;
 				switch($tag)
 				{
 					case '@attributes':
 						$tmp = (array) $xml->attributes();
 						$ret['@attributes'] = $tmp['@attributes'];
 
-						if($count_tags == 1) //only attributes & possible value
+						if($count_tags == 1 || ['@attributes', 0] === $tags) //only attributes & possible value
 						{
 							$ret[$this->_optValueKey] = trim((string) $xml);
-							return $ret;
+							//return $ret;
 						}
 					break;
 


### PR DESCRIPTION
This is a workaround to make the output of `xmlClass::xml2array()` in PHP 7.2 equal to that of prior PHP versions.

Consider this fix to be a part 2 of #3026.

PHP 7.2 changed the behavior of how we extract tags from SimpleXMLElement resources.  This hack adds a toleration for either the PHP 7.2 behavior and the past behavior, which allows consistent parsing
of XML files.

One side effect of this change is the fixing of an innocuous bug that provided blank values in some "`@value`" keys that should not have existed in the first place.  This should hopefully have no practical effect on current uses of the modified method.

@tgtje: The bug you reported should be fixed as a result of this pull request.

Fixes: #3027