### PR TITLE
Defers setting the SITEURL constant and dependencies until MySQL is connected

### DIFF
--- a/class2.php
+++ b/class2.php
@@ -464,6 +464,10 @@ elseif ($merror === 'e2')
 /* PHP Compatabilty should *always* be on. */
 e107_require_once(e_HANDLER.'php_compatibility_handler.php');
 
+// SITEURL constant depends on the database
+// See https://github.com/e107inc/e107/issues/3033 for details.
+$e107->set_urls_deferred();
+
 //
 // L: Extract core prefs from the database
 //

--- a/thumb.php
+++ b/thumb.php
@@ -149,9 +149,12 @@ class e_thumbpage
 		// basic Admin area detection - required for proper path parsing
 		define('ADMIN', strpos(e_SELF, ($e107->getFolder('admin')) !== false || strpos(e_PAGE, 'admin') !== false));
 		$e107->set_urls(false);
-			
+		// Next function call maintains behavior identical to before; might not be needed
+		//  See https://github.com/e107inc/e107/issues/3033
+		$e107->set_urls_deferred();
+
 		$pref = $e107->getPref(); //TODO optimize/benchmark
-		
+
 		$this->_watermark = array(
 			'activate'		=> vartrue($pref['watermark_activate'], false),
 			'text'			=> vartrue($pref['watermark_text']),


### PR DESCRIPTION
This is the least intrusive solution I could come up with.

Anything else I tried to reduce technical debt would break the very tangled dependency web, so I settled for this.

I also removed some unnecessary layers of indentation by replacing them with [guard clauses](https://refactoring.com/catalog/replaceNestedConditionalWithGuardClauses.html), so the diff in GitHub might be harder to read.  Try viewing the diff [here](https://github.com/e107inc/e107/pull/3037/commits/d1a69b0c16ad06c45078b428aa12913df9959966?w=1).

Fixes: #3033 