### PR TITLE
e_tree_model::multiFieldCmp() string sort fields

### DIFF
--- a/e107_handlers/model_class.php
+++ b/e107_handlers/model_class.php
@@ -3480,8 +3480,18 @@ class e_tree_model extends e_front_model
 	 */
 	protected static function multiFieldCmp($row1, $row2, $sort_field, $sort_order = 1)
 	{
+		// Multiple sort fields
 		if (is_array($sort_field))
+		{
 			$field = array_shift($sort_field);
+		}
+		// One sort field
+		else
+		{
+			$field = $sort_field;
+			$sort_field = [];
+		}
+
 		$cmp = strnatcmp((string) $row1[$field], (string) $row2[$field]);
 		if ($sort_order === -1 || $sort_order === 1) $cmp *= $sort_order;
 		if ($cmp === 0 && count($sort_field) >= 1)


### PR DESCRIPTION
An untested oversight in `e_tree_model::multiFieldCmp()` where `$sort_field` could be a string has now been corrected.

`$sort_field` now accepts a string to prevent infinite recursion.

Fixes: #3044