### PR TITLE
e_tree_model performance improvements

### DIFF
--- a/e107_handlers/admin_ui.php
+++ b/e107_handlers/admin_ui.php
@@ -4364,8 +4364,6 @@ class e_admin_controller_ui extends e_admin_controller
 	public function getParentChildQry($orderby=false)
 	{
 		return "SELECT SQL_CALC_FOUND_ROWS * FROM `#".$this->getTableName()."` ";
-		// Use the following return statement to break e107 native sorting but speed up tree creation by presorting for e_tree_model::arrayToTree()
-		#return "SELECT SQL_CALC_FOUND_ROWS * FROM `#".$this->getTableName()."` ORDER BY ".$this->getSortParent().", ".$this->getSortField();
 	}
 
 


### PR DESCRIPTION
e_tree_model is apparently used for flat lists as well as parent-child
relationships (trees). Trees are expected to be far smaller than possible flat
lists. Very large flat lists (10,000+ rows or greater) are rendered very slowly
because of the tree computation overhead.

This change figures out whether a flat list or a tree is requested and chooses
the appropriate code to run based on what is requested. Trees run the more
expensive code while flat lists are returned as-is.

In addition, the tree rendering code has been optimized. Optimizations:

* Unchanging tree node ID is set once instead of inside a foreach() loop
* The parent-child query is now sorted by the sort parent ID so that each move
  rows to tree nodes iteration doesn't have to run through every remaining row

Fixes: #3062