### PR TITLE
Removed pointless second sort in e_tree_model

### DIFF
--- a/e107_handlers/model_class.php
+++ b/e107_handlers/model_class.php
@@ -3617,7 +3617,7 @@ class e_tree_model extends e_front_model
 				return "";
 			}, $db_query)
 			// Optimization goes with e_tree_model::moveRowsToTreeNodes()
-			. " ORDER BY " . $this->getParam('sort_parent') . ", " . $this->getParam('sort_field');
+			. " ORDER BY " . $this->getParam('sort_parent');
 		$this->setParam('db_query', $db_query);
 	}
 


### PR DESCRIPTION
`e_tree_model::prepareSimulatedCustomOrdering()` performed an `ORDER BY` second sort that doesn't add any benefit at all and causes #3086.

This second sort has been removed.

Fixes: #3086