### PR TITLE
Truly disable a button on FormSubmit

### DIFF
--- a/e107_web/js/core/all.jquery.js
+++ b/e107_web/js/core/all.jquery.js
@@ -373,6 +373,7 @@ var e107 = e107 || {'settings': {}, 'behaviors': {}};
 							if($button.attr('data-disable') == 'true')
 							{
 								$button.addClass('disabled');
+								$button.prop("disabled", true);
 							}
 						});
 


### PR DESCRIPTION
We need to add attribute disabled to the button to truly disable it, otherwise the click event is fired up again and again causing form submissions