### PR TITLE
Revert "Truly disable a button on FormSubmit"

### DIFF
--- a/e107_web/js/core/all.jquery.js
+++ b/e107_web/js/core/all.jquery.js
@@ -373,7 +373,6 @@ var e107 = e107 || {'settings': {}, 'behaviors': {}};
 							if($button.attr('data-disable') == 'true')
 							{
 								$button.addClass('disabled');
-								$button.prop("disabled", true);
 							}
 						});
 


### PR DESCRIPTION
Reverts e107inc/e107#3100
@CaMer0n  I can confirm what @Alex-e107nl mentioned. Just reproduced it. The issue is that if attribute disabled is set, the DOM element doesn't get included in the POST, therefore if in PHP we are checking for this element name to be posted it fails and the logic within too. 