### PR TITLE
Prevent form from multiply submission

### DIFF
--- a/e107_web/js/core/all.jquery.js
+++ b/e107_web/js/core/all.jquery.js
@@ -351,7 +351,7 @@ var e107 = e107 || {'settings': {}, 'behaviors': {}};
 					{
 						var $button = $(this);
 						var $form = $button.closest('form');
-
+						var form_submited = false;
 						var type = $button.data('loading-icon');
 
 						if(type === undefined || $form.length === 0)
@@ -365,6 +365,10 @@ var e107 = e107 || {'settings': {}, 'behaviors': {}};
 								return false;
 							}
 
+							if (form_submited) {
+								return false;
+							}
+							
 							var caption = "<i class='fa fa-spin " + type + " fa-fw'></i>";
 							caption += "<span>" + $button.text() + "</span>";
 
@@ -373,6 +377,7 @@ var e107 = e107 || {'settings': {}, 'behaviors': {}};
 							if($button.attr('data-disable') == 'true')
 							{
 								$button.addClass('disabled');
+								form_submited = true;
 							}
 						});
 


### PR DESCRIPTION
This change will set var value to true when form is submitted, then if we click submit button again will prevent it from another submission. Adding attribute disabled to form button prevents its name to get trough POST call, thus breaking the logic if we checking for form button submission trough PHP.