### PR TITLE
Fixed smaller issues in date_handler.php

### DIFF
--- a/e107_handlers/date_handler.php
+++ b/e107_handlers/date_handler.php
@@ -173,7 +173,7 @@ class convert
 			break;
 			
 			case 'inputtime': 
-				$mask .= e107::getPref('inputtime', '%H:%M');
+				$mask = e107::getPref('inputtime', '%H:%M');
 			break;
 
 			case 'forum': // DEPRECATED - temporary here from BC reasons only

--- a/e107_handlers/date_handler.php
+++ b/e107_handlers/date_handler.php
@@ -791,7 +791,7 @@ class convert
 			
 			$unxTimestamp = mktime($vals['tm_hour'], $vals['tm_min'], $vals['tm_sec'], ($vals['tm_mon'] + 1), $vals['tm_mday'], ($vals['tm_year'] + 1900));
 			
-			$vals['tm_fmon'] = strftime('%B', mktime($vals['tm_hour'], $vals['tm_min'], $vals['tm_sec'], $vals['tm_mon']));
+			$vals['tm_fmon'] = strftime('%B', mktime($vals['tm_hour'], $vals['tm_min'], $vals['tm_sec'], $vals['tm_mon'] + 1));
 			$vals['tm_wday'] = (int) strftime('%w', $unxTimestamp); // Days since Sunday (0-6)
 			$vals['tm_yday'] = (strftime('%j', $unxTimestamp) - 1); // Days since January 1 (0-365)
 			

--- a/e107_handlers/form_handler.php
+++ b/e107_handlers/form_handler.php
@@ -820,7 +820,22 @@ class e_form
 	}
 
 
-	
+	/**
+	 * Create a input [type number]
+	 *
+	 * Additional options:
+	 *   - decimals: default 0; defines the number of decimals allowed in this field (0 = only integers; 1 = integers & floats with 1 decimal e.g. 4.1, etc.)
+	 *   - step: default 1; defines the step for the spinner and the max. number of decimals. If decimals is given, step will be ignored
+	 *   - min: default 0; minimum value allowed
+	 *   - max: default empty; maximum value allowed
+	 *   - pattern: default empty; allows to define an complex input pattern
+	 * 
+	 * @param string $name
+	 * @param integer $value
+	 * @param integer $maxlength
+	 * @param array $options decimals, step, min, max, pattern
+	 * @return string
+	 */
 	function number($name, $value=0, $maxlength = 200, $options = array())
 	{
 		if(is_string($options)) parse_str($options, $options);
@@ -852,15 +867,64 @@ class e_form
 		
 		$mlength = vartrue($maxlength) ? "maxlength=".$maxlength : "";
 
-		$min = isset($options['min']) ? 'min="'.$options['min'].'"' : '';
-		$max = isset($options['max']) ? 'max="'.$options['max'].'"' : '';
+		// Always define the min. parameter
+		// defaults to 0
+		// setting the min option to a negative value allows negative inputs
+		$min = " min='".varsettrue($options['min'], '0')."'";
+		$max = isset($options['max']) ? " max='".$options['max']."'" : '';
 
+		if (varsettrue($options['pattern']))
+		{
+			$pattern = ' pattern="'.trim($options['pattern']).'"';
+		}
+		else
+		{
+			$options['pattern'] = '^';
+			// ^\-?[0-9]*\.?[0-9]{0,2}
+			if (varset($options['min'], 0) < 0)
+			{
+				$options['pattern'] .= '\-?';
+			}
+			$options['pattern'] .= '[0-9]*';
+
+			// Integer & Floaat/Double value handling
+			if (isset($options['decimals']))
+			{
+				if (intval($options['decimals']) > 0)
+				{
+					$options['pattern'] .= '\.?[0-9]{0,'.intval($options['decimals']).'}';
+				}
+
+				// defined the step based on number of decimals 
+				// 2 = 0.01 > allows integers and float numbers with up to 2 decimals (3.1 = OK; 3.12 = OK; 3.123 = NOK)
+				// 1 = 0.1 > allows integers and float numbers with up to 2 decimals (3.1 = OK; 3.12 = NOK)
+				// 0 = 1 > allows only integers, no float values
+				if (intval($options['decimals']) <= 0)
+				{
+					$step = "step='1'";
+				}
+				else
+				{
+					$step = "step='0." . str_pad(1, intval($options['decimals']), 0, STR_PAD_LEFT)  . "'";
+				}
+			}
+			else
+			{
+				// decimal option not defined
+				// check for step option (1, 0.1, 0.01, and so on)
+				// or set default step 1 (integers only)
+				$step = "step='" . varsettrue($options['step'], '1') . "'";
+			}
+
+			$pattern = ' pattern="'.$options['pattern'].'"';
+		}
 		$options = $this->format_options('text', $name, $options);
 
 		//never allow id in format name-value for text fields
 		if(THEME_LEGACY === false)
 		{
-			return "<input pattern='[0-9]*' type='number' name='{$name}' value='{$value}' {$mlength}  {$min} {$max} ".$this->get_attributes($options, $name)." />";
+			// return "<input pattern='[0-9]*' type='number' name='{$name}' value='{$value}' {$mlength} {$step} {$min} {$max} ".$this->get_attributes($options, $name)." />";
+			return "<input type='number' name='{$name}' {$min} {$max} {$step} value='{$value}' {$pattern}".$this->get_attributes($options, $name)." />";
 		}
 		
 		return $this->text($name, $value, $maxlength, $options);	

--- a/e107_handlers/form_handler.php
+++ b/e107_handlers/form_handler.php
@@ -865,7 +865,8 @@ class e_form
 		$options['class'] .= " form-control";
 		$options['type'] ='number';
 		
-		$mlength = vartrue($maxlength) ? "maxlength=".$maxlength : "";
+		// Not used anymore
+		//$mlength = vartrue($maxlength) ? "maxlength=".$maxlength : "";
 
 		// Always define the min. parameter
 		// defaults to 0


### PR DESCRIPTION
### convert_date()
- removed an orphaned . (dot)

### strptime()
- fixed issue with wrong monthname on windows. e.g. it returned "April" where it should be "May"

### e_form::number()
Implemented additional options to be able to define the number of decimals allowed, the step (of the spinners), min and max value and a custom regex.
Unfortunatly, some browser do not respect the min/max boundaries and you can enter (manually) values that are bigger or smaller than allowed. My regex skills are not good enough to dynamically create a regex to limit the input to a certain range.

If you don't set any of the new options, the behaviour is the same as before (only positive integers).
Setting the "decimals" option to 0 dynamically creates a regex to allow only integers and sets the "step" (if not defined) to 1.
Setting the "decimals" option to 1 (or higher) dynamically creates a regex to allow float values with the given number of decimals and sets the "step" (if not defined) to "0.1", "0.01", etc. (depending on the number of decimals).
Setting the "step" option works only if the "decimals" option is **not** set.
Setting the "min" option to a value smaller than "0", dynamically defines the regex to accept negative values. 
Setting the "max" opton, defines the max value which can be entered. Unfortunatly, some browser don't respect the min/max setting and you can enter values that are larger or bigger than the given boundaries.
The "pattern" option allows the usage of a custom regex. When set, the decimals and step options will be ignored.
