### PR TITLE
Downloads plugin compatibility with PHP 5.4, 5.5

### DIFF
--- a/e107_plugins/download/handlers/NginxSecureLinkMd5Decorator.php
+++ b/e107_plugins/download/handlers/NginxSecureLinkMd5Decorator.php
@@ -6,14 +6,14 @@ class NginxSecureLinkMd5Decorator implements SecureLinkDecorator
 	protected $url = null;
 	protected $prefs = array();
 
-	const SUPPORTED_VARIABLES = array(
+	public static $SUPPORTED_VARIABLES = array(
 		'$secure_link_expires',
 		'$uri',
 		'$remote_addr'
 	);
 
 	static function supported_variables() {
-		return self::SUPPORTED_VARIABLES;
+		return self::$SUPPORTED_VARIABLES;
 	}
 
 	function __construct($url, $preferences)


### PR DESCRIPTION
Avoided use of PHP 5.6 feature in Downloads plugin's `NginxSecureLinkMd5Decorator`

Fixes: #3135