### PR TITLE
Fix for missing entries in strptime result array on Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ e107_core/override
 # Ignore Vim swap files
 *.swp
 *.swo
+e107.htaccess
+e107InstallLog.log

--- a/e107_handlers/date_handler.php
+++ b/e107_handlers/date_handler.php
@@ -840,10 +840,31 @@ class e_date
 			
 			#-- calculate wday/yday
 			//$vals['tm_mon'] = $vals['tm_mon'] + 1; // returns months from 0 - 11 so we need to +1 
-			
-			
+
+			if (!isset($vals['tm_sec']))
+			{
+				$vals['tm_sec'] = 0;
+			}
+
+			if (!isset($vals['tm_min']))
+			{
+				$vals['tm_min'] = 0;
+			}
+
+			if (!isset($vals['tm_hour']))
+			{
+				$vals['tm_hour'] = 0;
+			}
+
+
+			if (!isset($vals['unparsed']))
+			{
+				$vals['unparsed'] = '';
+			}
+
 			$unxTimestamp = mktime($vals['tm_hour'], $vals['tm_min'], $vals['tm_sec'], ($vals['tm_mon'] + 1), $vals['tm_mday'], ($vals['tm_year'] + 1900));
-			
+
+			$vals['tm_amon'] = strftime('%b', mktime($vals['tm_hour'], $vals['tm_min'], $vals['tm_sec'], $vals['tm_mon'] + 1));
 			$vals['tm_fmon'] = strftime('%B', mktime($vals['tm_hour'], $vals['tm_min'], $vals['tm_sec'], $vals['tm_mon'] + 1));
 			$vals['tm_wday'] = (int) strftime('%w', $unxTimestamp); // Days since Sunday (0-6)
 			$vals['tm_yday'] = (strftime('%j', $unxTimestamp) - 1); // Days since January 1 (0-365)


### PR DESCRIPTION
There were differences between the output of e_date::strptime() on Linux/Mac and Windows.
I've added missing entries of the result array, to make sure the result is equal.