### PR TITLE
Closes #2265 User Extended Field for Date does not allow entry

### DIFF
--- a/e107_web/js/password/jquery.pwdMeter.js
+++ b/e107_web/js/password/jquery.pwdMeter.js
@@ -201,5 +201,9 @@ jQuery.fn.pwdMeter = function(options){
 	});
 
 }
-
-})(jQuery)
+/**
+ * ALLWAYS add a semicolon at the end, otherwise 
+ * it may cause issues when js is cached! 
+ * see issue e107inc/e107#2265
+ */
+})(jQuery);


### PR DESCRIPTION
This fix closes issue e107inc/e107#2265 which pops up only when the JS files are cached (compressed).
There was a ";" missing at the end of the file after (jQuery).