### PR TITLE
Fixes #3152 Download / Upload categories problem

### DIFF
--- a/e107_admin/upload.php
+++ b/e107_admin/upload.php
@@ -204,7 +204,18 @@ class upload_ui extends e_admin_ui
             $this->getModel()->addValidationError(UPLLAN_62);
 			$new_data['upload_active'] = 0;
             return $new_data;
-        }
+		}
+		// Make sure the upload_category contains only integers
+		if (substr($new_data['upload_category'], 0, 10) == 'download__')
+		{
+			$new_data['upload_category'] = intval(substr($new_data['upload_category'], 10));
+		}
+		// Make sure the owner is not empty
+		if (trim($new_data['upload_owner']) == '')
+		{
+			$new_data['upload_owner'] = 'download';
+		}
+		return $new_data;
     }
 
     /**
@@ -262,7 +273,8 @@ class upload_ui extends e_admin_ui
             return 0;
         }
 
-        $owner = varset($upload['upload_owner'], 'download');
+		// Make sure the owner is not empty
+        $owner = vartrue($upload['upload_owner'], 'download');
 
         $uploadObj = e107::getAddon($owner,'e_upload');
 
@@ -371,7 +383,9 @@ class upload_form_ui extends e_admin_form_ui
 
 	        case 'write':
 	            $owner =  $this->getController()->getModel()->get('upload_owner');
-                return $value."-- ".$owner; // $this->radio_switch('upload_active', $value, LAN_ACCEPT, LAN_PENDING, $options);
+				//return $value."-- ".$owner; // $this->radio_switch('upload_active', $value, LAN_ACCEPT, LAN_PENDING, $options);
+				// make category editable instead of just displaying data
+				return e107::getForm()->select('upload_category', $opts, $value);
             break;
 
             case 'batch':

--- a/e107_admin/upload.php
+++ b/e107_admin/upload.php
@@ -205,16 +205,13 @@ class upload_ui extends e_admin_ui
 			$new_data['upload_active'] = 0;
             return $new_data;
 		}
+
 		// Make sure the upload_category contains only integers
-		if (substr($new_data['upload_category'], 0, 10) == 'download__')
-		{
-			$new_data['upload_category'] = intval(substr($new_data['upload_category'], 10));
-		}
-		// Make sure the owner is not empty
-		if (trim($new_data['upload_owner']) == '')
-		{
-			$new_data['upload_owner'] = 'download';
-		}
+		// Make sure the owner correspondents to the category id
+		list($catOwner, $catID) = explode("__", $new_data['upload_category'], 2);
+		$new_data['upload_category'] = intval($catID);
+		$new_data['upload_owner'] = $catOwner;
+
 		return $new_data;
     }
 

--- a/upload.php
+++ b/upload.php
@@ -107,7 +107,7 @@ class userUpload
 		$catID              = null;
 		$catOwner           = null;
 		$file               = null;
-		$image              = null;
+		$image              = '';
 		$filesize           = 0;
 
 						


### PR DESCRIPTION
### There were 2 issues:

- *e107_admin/upload.php*
On the edit public upload page, the category was only displayed as text and was obviously empty when trying to save. I've replaced it with a dropdown containing the categories.
Before save, the value of the category variable now get's splitted to the category id and owner and assigned to the proper fields. Saving now works as expected.
- *upload.php* (in root folder)
The screenshot isn't required on the upload form, but saving the entry failed, because the value for the screenshot was null and the table doesn't allow null values here. Unfortunatly, the script told the user the upload was fine, but it wasn't saved to the db.
Instead of a standard null value, i changed it to an empty string.
Now a public upload can be done without a screenshot attached and is properly added to the db.