### PR TITLE
Fixes #3198 Legacy prefs, Missing forums; Fixes #3204 Filter/search forums

### DIFF
--- a/e107_handlers/admin_ui.php
+++ b/e107_handlers/admin_ui.php
@@ -3934,7 +3934,7 @@ class e_admin_controller_ui extends e_admin_controller
 			$keys = array();
 			foreach($matches[1] AS $k=>$v)
 			{
-				if(varset($matches[3][$k]))
+				if(varset($matches[3][$k]) && !array_key_exists($v, $this->joinAlias))
 				{
 					$this->joinAlias[$v] = $matches[3][$k]; // array. eg $this->joinAlias['core_media'] = 'm';
 				}

--- a/e107_handlers/model_class.php
+++ b/e107_handlers/model_class.php
@@ -3458,7 +3458,10 @@ class e_tree_model extends e_front_model
 			// Note: This optimization only works if the SQL query executed was ordered by the sort parent.
 			if($nodeID !== $rowParentID)
 			{
-				break;
+				// workaround in case the rows are not in the expected order
+				// for some reason e.g. if one sort column is not enough.
+				continue;
+				//break;
 			}
 
 			$node['_children'][] = &$row;

--- a/e107_plugins/forum/forum_admin.php
+++ b/e107_plugins/forum/forum_admin.php
@@ -137,7 +137,7 @@ if(!deftrue('OLD_FORUMADMIN'))
 		protected $fields 		= array (
 			'checkboxes'                =>   array ( 'title' => '', 'type' => null, 'data' => null, 'width' => '5%', 'thclass' => 'center', 'forced' => '1', 'class' => 'center', 'toggle' => 'e-multiselect',  ),
 		    'forum_id'                  =>   array ( 'title' => LAN_ID, 'data' => 'int', 'width' => '5%', 'help' => '', 'readParms' => '', 'writeParms' => '', 'class' => 'left', 'thclass' => 'left',  ),
-		    'forum_name'                =>   array ( 'title' => LAN_TITLE, 'type' => 'method', 'inline'=>true,  'data' => 'str', 'width' => '40%', 'help' => '', 'readParms' => '', 'writeParms' => '', 'class' => 'left', 'thclass' => 'left',  ),
+		    'forum_name'                =>   array ( 'title' => LAN_TITLE, 'type' => 'method', 'inline'=>true,  'data' => 'str', 'width' => '40%', 'help' => '', 'filter'=>true, 'readParms' => '', 'writeParms' => '', 'class' => 'left', 'thclass' => 'left',  ),
 		    'forum_sef'                 =>   array ( 'title' => LAN_SEFURL, 'type' => 'text', 'batch'=>true, 'inline'=>true, 'noedit'=>false, 'data' => 'str', 'width' => 'auto', 'help' => 'Leave blank to auto-generate it from the title above.', 'readParms' => '', 'writeParms' => 'sef=forum_name&size=xxlarge', 'class' => 'left', 'thclass' => 'left',  ),
             'forum_description'         =>   array ( 'title' => LAN_DESCRIPTION, 'type' => 'textarea', 'data' => 'str', 'width' => '30%', 'help' => '', 'readParms' => '', 'writeParms' => '', 'class' => 'left', 'thclass' => 'left',  ),
 			'forum_parent'              =>   array ( 'title' => FORLAN_75, 'type' => 'dropdown', 'data' => 'int', 'width' => '10%', 'help' => '', 'readParms' => '', 'writeParms' => '', 'class' => 'left', 'thclass' => 'left',  ),
@@ -222,6 +222,20 @@ if(!deftrue('OLD_FORUMADMIN'))
 
 		public function init()
 		{
+
+			// Search
+			if (!empty($_GET['searchquery']))
+			{
+				$searchquery = e107::getParser()->toDB($_GET['searchquery']);
+				$aWhere = array();
+				foreach(array('forum_name', 'forum_description', 'forum_sef') as $field)
+				{
+					$aWhere[] = sprintf("a.%s LIKE '%%%s%%'", $field, $searchquery);
+				}
+				$this->filterQry = str_ireplace('SELECT ', 'SELECT 0 AS filterid, ', $this->listQry);
+				$this->filterQry .= " WHERE (". implode(' OR ', $aWhere).")";
+				$this->sortParent = 'filterid';
+			}
 
 			$this->checkOrder();
 
@@ -837,7 +851,7 @@ if(!deftrue('OLD_FORUMADMIN'))
 
 			if($mode == 'filter')
 			{
-				return;
+				return null;
 			}
 			if($mode == 'batch')
 			{

--- a/e107_plugins/forum/forum_class.php
+++ b/e107_plugins/forum/forum_class.php
@@ -2430,7 +2430,8 @@ class e107forum
 	public function upgradeLegacyPrefs()
 	{
 
-			e107::getMessage()->addDebug("Legacy Forum Menu Pref Detected. Upgrading..");
+			// Commented out as it is irritating to get this message and nothing is done or has to be done.
+			//e107::getMessage()->addDebug("Legacy Forum Menu Pref Detected. Upgrading..");
 
 			$legacyMenuPrefs = array(
 				'newforumposts_caption'     => 'caption',


### PR DESCRIPTION
**Fixes #3198**
- Removed the orphaned debug message concerning "legacy forum menu prefs detected. Upgrading ..." as it actually doesn't detect or upgrade anything.
- Added a workaround to the e_tree_model::moveRowsToTreeNodes() method to make sure all data is displayed, even if the row order isn't as expected (e.g. if 1 sort field isn't enough to presort the data)
- Added a fix to the admin_ui::joinAlias() method for the case that 2 or more aliases point to the same table and to make sure the first found alias isn't overwritten by the following.

**Fixes #3204**
- Added a workaround to the forum_admin.php to filter the list by a search word, because the tree model doesn't support this at the moment.

@Deltik Could you please check my changes, especially those to the e_tree_model::moveRowsToTreeNodes() method? It is only a small one and once you're into it... could you think about a method to filter the list without requiring the parent nodes in the result? See my workaround in the forum_admin.php ...