### PR TITLE
Disable tree format if model has filters

### DIFF
--- a/e107_handlers/admin_ui.php
+++ b/e107_handlers/admin_ui.php
@@ -4314,6 +4314,11 @@ class e_admin_controller_ui extends e_admin_controller
 			// add more where details on the fly via $this->listQrySql['db_where'];
 			$qry .= (strripos($qry, 'where')==FALSE) ? " WHERE " : " AND "; // Allow 'where' in custom listqry
 			$qry .= implode(" AND ", $searchQry);
+
+			// Disable tree (use flat list instead) when filters are applied
+			// Implemented out of necessity under https://github.com/e107inc/e107/issues/3204
+			// Horrible hack, but only needs this one line of additional code
+			$this->getTreeModel()->setParam('sort_parent', null);
 		}
 
 		// GROUP BY if needed


### PR DESCRIPTION
Parent-child relationship tables (trees) can only be constructed if the entire table is loaded. When WHERE filters are applied to the table, the tree cannot be made, which causes #3204.

When a filter is active, a tree representation is no longer appropriate because the filter can filter out parents of a matched row, which breaks the concept of a tree.

To resolve this and restore search functionality, this commit disables the `sort_parent` of the tree model in order to activate the `e_tree_model::getRowsList()` method and avoid the tree logic entirely.

Fixes: #3204
Supersedes: #3208