### PR TITLE
Fixes #3198 - Legacy prefs, missing forums

### DIFF
--- a/e107_handlers/admin_ui.php
+++ b/e107_handlers/admin_ui.php
@@ -3934,7 +3934,7 @@ class e_admin_controller_ui extends e_admin_controller
 			$keys = array();
 			foreach($matches[1] AS $k=>$v)
 			{
-				if(varset($matches[3][$k]))
+				if(varset($matches[3][$k]) && !array_key_exists($v, $this->joinAlias))
 				{
 					$this->joinAlias[$v] = $matches[3][$k]; // array. eg $this->joinAlias['core_media'] = 'm';
 				}

--- a/e107_handlers/model_class.php
+++ b/e107_handlers/model_class.php
@@ -3456,10 +3456,7 @@ class e_tree_model extends e_front_model
 			$rowParentID = (int) $row[$sort_parent];
 
 			// Note: This optimization only works if the SQL query executed was ordered by the sort parent.
-			if($nodeID !== $rowParentID)
-			{
-				break;
-			}
+			if($rowParentID > $nodeID) break;
 
 			$node['_children'][] = &$row;
 			unset($rows[$key]);
@@ -3620,7 +3617,7 @@ class e_tree_model extends e_front_model
 				return "";
 			}, $db_query)
 			// Optimization goes with e_tree_model::moveRowsToTreeNodes()
-			. " ORDER BY " . $this->getParam('sort_parent');
+			. " ORDER BY " . $this->getParam('sort_parent') . "," . $this->getParam('primary_field');
 		$this->setParam('db_query', $db_query);
 	}
 

--- a/e107_plugins/forum/forum_class.php
+++ b/e107_plugins/forum/forum_class.php
@@ -2430,7 +2430,8 @@ class e107forum
 	public function upgradeLegacyPrefs()
 	{
 
-			e107::getMessage()->addDebug("Legacy Forum Menu Pref Detected. Upgrading..");
+			// Commented out as it is irritating to get this message and nothing is done or has to be done.
+			//e107::getMessage()->addDebug("Legacy Forum Menu Pref Detected. Upgrading..");
 
 			$legacyMenuPrefs = array(
 				'newforumposts_caption'     => 'caption',

--- a/e107_plugins/forum/forum_class.php
+++ b/e107_plugins/forum/forum_class.php
@@ -2430,9 +2430,6 @@ class e107forum
 	public function upgradeLegacyPrefs()
 	{
 
-			// Commented out as it is irritating to get this message and nothing is done or has to be done.
-			//e107::getMessage()->addDebug("Legacy Forum Menu Pref Detected. Upgrading..");
-
 			$legacyMenuPrefs = array(
 				'newforumposts_caption'     => 'caption',
 				'newforumposts_display'     => 'display',
@@ -2446,11 +2443,11 @@ class e107forum
 			{
 				if(e107::getMenu()->setParms('forum','newforumposts_menu', $newPrefs) !== false)
 				{
-					e107::getMessage()->addDebug("Sucessfully Migrated newforumposts prefs from core to menu table. ");
+					e107::getMessage()->addDebug("Successfully migrated newforumposts prefs from core to menu table.");
 				}
 				else
 				{
-					e107::getMessage()->addDebug("Legacy Forum Menu Pref Detected. Upgrading..");
+					e107::getMessage()->addDebug("Legacy Forum menu pref detected. Upgrading...");
 				}
 			}
 


### PR DESCRIPTION
Supersedes: #3208
Fixes: #3198

Cherry-picked these changes from #3208:

- Removed the orphaned debug message concerning "Legacy Forum Menu Pref Detected. Upgrading.." as it actually doesn't detect or upgrade anything.
- Some tree model branches were going missing due to a logical error in `e_tree_model::moveRowsToTreeNodes()` that was skipping over entire branches if another branch appeared in between the raw rows output.
- More tree model branches could have gone missing if the primary field did not sort in ascending order after the sort parent field sorts in ascending order.  This is corrected in `e_tree_model::prepareSimulatedCustomOrdering()`.
- Added a fix to the admin_ui::joinAlias() method for the case that 2 or more aliases point to the same table and to make sure the first found alias isn't overwritten by the following.