### PR TITLE
Fixes #3132 after adding the menu to the menu area, the wrong

### DIFF
--- a/e107_plugins/forum/newforumposts_menu.php
+++ b/e107_plugins/forum/newforumposts_menu.php
@@ -56,6 +56,7 @@ if(!class_exists('forum_newforumposts_menu'))
 
 			$qry = '';
 
+			$this->menuPref['layout'] = vartrue($this->menuPref['layout'], 'default');
 			switch($this->menuPref['layout'])
 			{
 				case "minimal":


### PR DESCRIPTION
After adding the menu to the menu area, the wrong query was executed because no layout was defined. Setting "default" as default layout if nothing is defined.