### PR TITLE
Fixes #3161 Fixes htmlized shortcode parameters

### DIFF
--- a/e107_handlers/shortcode_handler.php
+++ b/e107_handlers/shortcode_handler.php
@@ -1021,6 +1021,8 @@ class e_parse_shortcode
 			$fullShortcodeKey = $newMatch[0];
 			$code = $newMatch[1];
 			$parmStr = trim($newMatch[2]);
+			// fix for #3161: htmlized shortcode parameters ...
+			$parmStr = str_ireplace('&amp;', '&', $parmStr);
 			$debugParm = $parmStr;
 			parse_str($parmStr,$parm);
 			$parmArray = true;

--- a/e107_plugins/forum/newforumposts_menu.php
+++ b/e107_plugins/forum/newforumposts_menu.php
@@ -56,6 +56,7 @@ if(!class_exists('forum_newforumposts_menu'))
 
 			$qry = '';
 
+			$this->menuPref['layout'] = vartrue($this->menuPref['layout'], 'default');
 			switch($this->menuPref['layout'])
 			{
 				case "minimal":


### PR DESCRIPTION
**Fixes htmlized shortcode parameters**
When entering shortcodes via TinyMCE, the "&" sign will be converted automatically to "&amp;" without any chance to prevent this behaviour. The fix just corrects this error right before running the shortcode.

**Just saw that i entered the wrong issue number** 
It's **#3161** instead of **#3162**