### PR TITLE
Fixes #3162 Fixes double encoding of the param values.

### DIFF
--- a/e107_core/shortcodes/batch/news_shortcodes.php
+++ b/e107_core/shortcodes/batch/news_shortcodes.php
@@ -1153,7 +1153,9 @@ class news_shortcodes extends e_shortcode
 		{
 			if(trim($val))
 			{
-				$url = e107::getUrl()->create('news/list/tag',array('tag'=>rawurlencode($val))); // e_BASE."news.php?tag=".$val
+				//$url = e107::getUrl()->create('news/list/tag',array('tag'=>rawurlencode($val))); // e_BASE."news.php?tag=".$val
+				// will be encoded during create()
+				$url = e107::getUrl()->create('news/list/tag',array('tag'=>$val)); // e_BASE."news.php?tag=".$val
 				$words[] = "<a class='".$class."' href='".$url."'>".$start.$val.$end."</a>";
 			}
 		}


### PR DESCRIPTION
Fixes double encoding of the param values.
e.g.:
old:
`$url = e107::getUrl()->create('news/list/tag',array('tag'=>rawurlencode($val)));`
new:
`$url = e107::getUrl()->create('news/list/tag',array('tag'=>$val));`