### PR TITLE
 Fixes #3163 Strip the title "News" if page is the frontpage 

### DIFF
--- a/e107_core/templates/header_default.php
+++ b/e107_core/templates/header_default.php
@@ -165,7 +165,15 @@ unset($e_headers);
 // echo e107::getUrl()->response()->renderMeta()."\n"; // render all the e107::meta() entries.
 echo e107::getSingleton('eResponse')->renderMeta()."\n";
 
-echo "<title>".(defined('e_PAGETITLE') ? e_PAGETITLE.' - ' : (defined('PAGE_NAME') ? PAGE_NAME.' - ' : "")).SITENAME."</title>\n\n";
+if (deftrue('e_FRONTPAGE'))
+{
+	// Ignore any additional title when current page is the frontpage
+	echo "<title>".SITENAME."</title>\n\n";
+}
+else
+{
+	echo "<title>".(defined('e_PAGETITLE') ? e_PAGETITLE.' - ' : (defined('PAGE_NAME') ? PAGE_NAME.' - ' : "")).SITENAME."</title>\n\n";
+}
 
 
 //


### PR DESCRIPTION
Removes any additional title (like "News - ") when current page is the frontpage.
e.g. `<title>News - My great website</title>` will become `<title>My great website</title>` if the page is opened as frontpage (Admin -> Settings -> Frontpage)