### PR TITLE
Fixes #3132 Fixes issue with new forum posts menu

### DIFF
--- a/e107_plugins/forum/e_menu.php
+++ b/e107_plugins/forum/e_menu.php
@@ -31,10 +31,10 @@ class forum_menu
 
 		$fields = array();
 		$fields['caption']      = array('title'=> LAN_FORUM_MENU_004, 'type'=>'text', 'multilan'=>true, 'writeParms'=>array('size'=>'xxlarge'));
-		$fields['display']      = array('title'=> LAN_FORUM_MENU_005, 'type'=>'text',  'writeParms'=>array('size'=>'mini','pattern'=>'[0-9]*'));
-		$fields['maxage']       = array('title'=> LAN_FORUM_MENU_012, 'type'=>'text', 'help'=>LAN_FORUM_MENU_013, 'writeParms'=>array('size'=>'mini','pattern'=>'[0-9]*'));
-		$fields['characters']   = array('title'=> LAN_FORUM_MENU_006, 'type'=>'text', 'writeParms'=>array('size'=>'mini','pattern'=>'[0-9]*'));
-		$fields['postfix']      = array('title'=> LAN_FORUM_MENU_007, 'type'=>'text', 'writeParms'=>array('size'=>'mini'));
+		$fields['display']      = array('title'=> LAN_FORUM_MENU_005, 'type'=>'text',  'writeParms'=>array('size'=>'mini','pattern'=>'[0-9]*','default' => 10));
+		$fields['maxage']       = array('title'=> LAN_FORUM_MENU_012, 'type'=>'text', 'help'=>LAN_FORUM_MENU_013, 'writeParms'=>array('size'=>'mini','pattern'=>'[0-9]*','default' => 0));
+		$fields['characters']   = array('title'=> LAN_FORUM_MENU_006, 'type'=>'text', 'writeParms'=>array('size'=>'mini','pattern'=>'[0-9]*','default' => 120));
+		$fields['postfix']      = array('title'=> LAN_FORUM_MENU_007, 'type'=>'text', 'writeParms'=>array('size'=>'mini','default' => '...'));
 		$fields['scroll']        = array('title'=> LAN_FORUM_MENU_014, 'type'=>'text', 'writeParms'=>array('size'=>'mini','pattern'=>'[0-9]*'), 'help'=>LAN_FORUM_MENU_015);
 		$fields['layout']       = array('title'=> LAN_TEMPLATE, 'type'=>'dropdown', 'writeParms'=>array('optArray'=>$layouts[0]));
 		

--- a/e107_plugins/forum/newforumposts_menu.php
+++ b/e107_plugins/forum/newforumposts_menu.php
@@ -30,6 +30,16 @@ if(!class_exists('forum_newforumposts_menu'))
 			$this->plugPref = e107::pref('forum'); // general forum preferences.
 			$this->menuPref = e107::getMenu()->pref();// ie. popup config details from within menu-manager.
 
+			// Set some defaults ...
+			if (!isset($this->menuPref['title'])) $this->menuPref['title'] = "";
+			if (empty($this->menuPref['display'])) $this->menuPref['display'] = 10;
+			if (empty($this->menuPref['maxage'])) $this->menuPref['maxage'] = 0;
+			if (empty($this->menuPref['characters'])) $this->menuPref['characters'] = 120;
+			if (empty($this->menuPref['postfix'])) $this->menuPref['postfix'] = '...';
+			if (!isset($this->menuPref['scroll'])) $this->menuPref['scroll'] = "";
+			if (empty($this->menuPref['layout'])) $this->menuPref['layout'] = 'default';
+
+
 			$sql = e107::getDb();
 
 			$this->total['topics'] = $sql->count("forum_thread");
@@ -249,7 +259,24 @@ if(!class_exists('forum_newforumposts_menu'))
 
 			if(!empty($this->menuPref['caption']))
 			{
-				$caption = !empty($this->menuPref['caption'][e_LANGUAGE])  ? $this->menuPref['caption'][e_LANGUAGE] : $this->menuPref['caption'];
+				if (array_key_exists(e_LANGUAGE, $this->menuPref['caption']))
+				{
+					// Language key exists
+					$caption = vartrue($this->menuPref['caption'][e_LANGUAGE], LAN_PLUGIN_FORUM_LATESTPOSTS);
+				}
+				elseif (is_array($this->menuPref['caption']))
+				{
+					// Language key not found
+					$keys = array_keys($caption = $this->menuPref['caption']);
+					// Just first language key from the list
+					$caption = vartrue($this->menuPref['caption'][$keys[0]], LAN_PLUGIN_FORUM_LATESTPOSTS);
+				}
+				else
+				{
+					// No multilan array, just plain text
+					$caption = vartrue($this->menuPref['caption'], LAN_PLUGIN_FORUM_LATESTPOSTS);
+				}
+				//$caption = !empty($this->menuPref['caption'][e_LANGUAGE])  ? $this->menuPref['caption'][e_LANGUAGE] : $this->menuPref['caption'];
 			}
 
 


### PR DESCRIPTION
Fixes issue with new forum posts menu not displaying caption and post excerpt properly.
- Added menu config default values, in case some are not properly defined.
- Added default values to the new forum posts config menu.
- Fixed issue with menu caption in case the caption is not set or not set in the current language.