### PR TITLE
Fixed an issue in iphandler::checkBan() 

### DIFF
--- a/e107_handlers/iphandler_class.php
+++ b/e107_handlers/iphandler_class.php
@@ -991,6 +991,11 @@ class eIPHandler
 				echo "\nBanned</pre>";
 			}
 
+			// added missing if clause
+			if ($do_return)
+			{
+				return false;
+			}
 			exit();
 		}
 


### PR DESCRIPTION
Fixed an issue in iphandler::checkBan() which caused the script to stop without any message instead of returning a value (true or false) in case the submitted email adress is blocked.
That resulted in an empty page (e.g. during signup), leaving the user with no message of what happend.