### PR TITLE
Fixes #2887 added missing "sent()" method

### DIFF
--- a/e107_plugins/user/e_mailout.php
+++ b/e107_plugins/user/e_mailout.php
@@ -369,7 +369,22 @@ class user_mailout
 		return $var;
 	}
 
-
+	/**
+	 * Manage Sent. 
+	 */
+	public function sent($data) // trigerred when email sent from queue.
+	{
+		if($data['status'] == 1) // Successfully sent
+		{
+			// e107::getLog()->add($this->mailerSource . ' email sent', $data, E_LOG_INFORMATIVE, 'SENT');		
+			return true;
+		}
+		else // Failed 
+		{
+			// e107::getLog()->add($this->mailerSource . ' email not sent', $data, E_LOG_FATAL, 'SENT');		
+			return false;
+		}
+	}
 
 
 


### PR DESCRIPTION
The missing sent() method has triggered an error entry in the admin error log, everytime an email was send, regardless if the email was sent or not.