### PR TITLE
fixes #3228 show extended user field also in non bootstrap themes

### DIFF
--- a/e107_core/shortcodes/batch/usersettings_shortcodes.php
+++ b/e107_core/shortcodes/batch/usersettings_shortcodes.php
@@ -462,7 +462,7 @@ class usersettings_shortcodes extends e_shortcode
 		$ue = e107::getUserExt();
 
 
-		if(THEME_LEGACY === true)
+		if(THEME_LEGACY === true || !deftrue('BOOTSTRAP'))
 		{
 			$USEREXTENDED_FIELD = $this->legacyTemplate['USEREXTENDED_FIELD'];
 			$REQUIRED_FIELD = $this->legacyTemplate['REQUIRED_FIELD'];


### PR DESCRIPTION
Fixes an issue where the user extended fields didn't display on non-bootstrap themes if THEME_LEGACY was  false.