### PR TITLE
Fixes #3126 & #3143 Backend used wrong field to hashword

### DIFF
--- a/e107_admin/users.php
+++ b/e107_admin/users.php
@@ -502,7 +502,13 @@ class users_admin_ui extends e_admin_ui
 		else 
 		{
 
-			$new_data['user_password']	= e107::getUserSession()->HashPassword($new_data['user_password'], $new_data['user_login']);
+			// issues #3126, #3143: Login not working after admin set a new password using the backend
+			// Backend used user_login instead of user_loginname (used in usersettings) and did't escape the password.
+			$savePassword = $new_data['user_password'];
+			$loginname = $new_data['user_loginname'] ? $new_data['user_loginname'] : $old_data['user_loginname'];
+			$email = (isset($new_data['user_email']) && $new_data['user_email']) ? $new_data['user_email'] : $old_data['user_email'];
+			$new_data['user_password'] = e107::getDb()->escape(e107::getUserSession()->HashPassword($savePassword, $loginname), false);
+
 			e107::getMessage()->addDebug("Password Hash: ".$new_data['user_password']);
 		}
 		

--- a/e107_core/shortcodes/batch/usersettings_shortcodes.php
+++ b/e107_core/shortcodes/batch/usersettings_shortcodes.php
@@ -462,7 +462,7 @@ class usersettings_shortcodes extends e_shortcode
 		$ue = e107::getUserExt();
 
 
-		if(THEME_LEGACY === true)
+		if(THEME_LEGACY === true || !deftrue('BOOTSTRAP'))
 		{
 			$USEREXTENDED_FIELD = $this->legacyTemplate['USEREXTENDED_FIELD'];
 			$REQUIRED_FIELD = $this->legacyTemplate['REQUIRED_FIELD'];


### PR DESCRIPTION
The backend page to change a users password used wrong field to hash the password.
Instead of user_loginname (as used in usersettings), the backend used user_login and didn't escape the result.
This made the login impossible.

Fix 3228 is included in this branch only by mistake ...