### PR TITLE
fixes #3087 Missing forum id prevented pagination

### DIFF
--- a/e107_plugins/forum/forum_viewforum.php
+++ b/e107_plugins/forum/forum_viewforum.php
@@ -270,11 +270,14 @@ if ($pages)
 {
 	if(strpos($FORUM_VIEW_START, 'THREADPAGES') !== false || strpos($FORUM_VIEW_END, 'THREADPAGES') !== false)
 	{
-		$url = e107::url('forum','forum',$forumInfo, array('query'=>array('p'=>'[FROM]')));
-/*--
+		// issue #3087 url need to be decoded first (because the [FROM] get's encoded in url())
+		// and to encode the full url to not loose the id param when being used in the $forumSCvars['parms']
+		$url = rawurlencode(rawurldecode(e107::url('forum','forum',$forumInfo, array('query'=>array('p'=>'[FROM]')))));
+
+		/*--
 		$parms = "total={$pages}&type=page&current={$page}&url=".$url."&caption=off";
 		$fVars->THREADPAGES = $tp->parseTemplate("{NEXTPREV={$parms}}");
---*/
+		--*/
 		$forumSCvars['parms'] = "total={$pages}&type=page&current={$page}&url=".$url."&caption=off";
 //-- ?????????? unset $ulrparms????
 		unset($urlparms);


### PR DESCRIPTION
Because the parameters for the NEXTPREV shortcode where defined as query parameters, the id parameter from the generated forum url was truncated and interpreted as a single parameter and not as parameter of the url.
Needed to encode the url to make sure that the url stays intact.