### PR TITLE
fixes #3059 Language list was empty, even if languages were available

### DIFF
--- a/e107_admin/lancheck.php
+++ b/e107_admin/lancheck.php
@@ -913,11 +913,22 @@ class lancheck
 				return false;
 			}
 
-			foreach($rawData['language'] as $val)
+			foreach($rawData['language'] as $key => $att)
 			{
-				$att = $val['@attributes'];
+				// issue #3059 Language list didn't load
+				if ($key != '@attributes') continue;
 
 				$id = $att['name'];
+
+				// fix github double url bug...
+				if (stripos($att['url'], 'https://github.comhttps://github.com') !== false)
+				{
+					$att['url'] = str_ireplace('https://github.comhttps://github.com', 'https://github.com', $att['url']);
+				}
+				if (stripos($att['infourl'], 'https://github.comhttps://github.com') !== false)
+				{
+					$att['infourl'] = str_ireplace('https://github.comhttps://github.com', 'https://github.com', $att['infourl']);
+				}
 
 				$languages[$id] = array(
 					'name'          => $att['name'],


### PR DESCRIPTION
**Language list was empty, even if languages were available**
Looks like the array structure changed over the time without adapting this part of the sourcecode.

**Download and info link returned from languagepacks.xml contain wrong links**
For some reason, the urls in the "languagepacks.xml" contains for some reason malformed urls. The urls start with `https://github.comhttps://github.com` instead of just `https://github.com`.
@CaMer0n Implemented a workaround to fix this urls, but they need to get fixed in the "languagepacks.xml" as well.