### PR TITLE
fixes #3051 broken image links

### DIFF
--- a/e107_admin/image.php
+++ b/e107_admin/image.php
@@ -41,6 +41,10 @@ e107::js('core', 'plupload/plupload.full.js', 'jquery', 2);
 e107::css('core', 'plupload/jquery.plupload.queue/css/jquery.plupload.queue.css', 'jquery');
 e107::js('core', 'plupload/jquery.plupload.queue/jquery.plupload.queue.min.js', 'jquery', 2);
 e107::js('core', 'core/mediaManager.js',"jquery",5);
+// issue #3051 Preview url is wrong when target page is a plugin
+// Using this variable to check for the plugins directory and replace with empty space in case of...
+// see mediaManager.js (line ~399ff)
+e107::js('inline', 'var e107_plugins_directory = "' . str_replace('../', '', e_PLUGIN) . '";');
 e107::wysiwyg(true);
 /*
  * CLOSE - GO TO MAIN SCREEN

--- a/e107_web/js/core/mediaManager.js
+++ b/e107_web/js/core/mediaManager.js
@@ -395,6 +395,14 @@ var e107 = e107 || {'settings': {}, 'behaviors': {}};
 			{
 				preview = $htmlHolder.val();
 			}
+
+			// issue #3051 Preview url is wrong when target page is a plugin
+			var s = new RegExp('/' + e107_plugins_directory + '[\\w]+/', 'gmi');
+			if (window.top.document.URL.match(s))
+			{
+				preview = preview.replace(e107_plugins_directory, '');
+			}
+
 		}
 
 		$('div#' + target + "_prev", window.top.document).html(preview); // set new value


### PR DESCRIPTION
The image browser always returns image preview path relative to admin directory, which doesn't work in case the target is a plugin.
Added a check for the target and to modify the preview url in case it is a plugin (just for the preview url!)