### PR TITLE
fixes #3049 Realname was always shown and marked required,

### DIFF
--- a/e107_core/shortcodes/batch/usersettings_shortcodes.php
+++ b/e107_core/shortcodes/batch/usersettings_shortcodes.php
@@ -81,16 +81,40 @@ class usersettings_shortcodes extends e_shortcode
 	
 	function sc_customtitle($parm)
 	{ 	
-		if (e107::getPref('signup_option_customtitle'))
+		$pref = e107::getPref();
+		if ($pref['signup_option_customtitle'])
 		{		
-			$options = array('title'=> '', 'size' => 40);	
+			$options = array(
+				'title'=> '', 
+				'size' => 40,
+				'required' => ($pref['signup_option_customtitle'] == 2));	
 			return e107::getForm()->text('customtitle', $this->var['user_customtitle'], 100, $options);
 		}
 	}
 
-
-
+	
 	function sc_realname($parm)
+	{ 	
+		$pref = e107::getPref();
+		if ($pref['signup_option_realname'])
+		{		
+			$sc = e107::getScBatch('usersettings');
+			$options = array(
+				'title'    => '',
+				'size'     => 40,
+				'required' => ($pref['signup_option_realname'] == 2),
+			);
+			if(!empty($sc->var['user_login']) && !empty($sc->var['user_xup'])) // social login active.
+			{
+				$options['readonly'] = true;
+			}
+
+			return e107::getForm()->text('realname', $sc->var['user_login'], 100, $options);
+		}
+	}
+
+/*
+	function sc_realname2($parm)
 	{
 		$pref = e107::getPref();
 		$sc = e107::getScBatch('usersettings');
@@ -108,7 +132,7 @@ class usersettings_shortcodes extends e_shortcode
 
 		return e107::getForm()->text('realname', $sc->var['user_login'], 100, $options);
 	}
-	
+*/	
 	
 	
 	function sc_password1($parm)

--- a/e107_core/templates/usersettings_template.php
+++ b/e107_core/templates/usersettings_template.php
@@ -46,7 +46,7 @@ $sc_style['PASSWORD_LEN']['pre'] 		= "<br /><span class='smalltext'>  (".LAN_USE
 $sc_style['PASSWORD_LEN']['post'] 		= " ".LAN_USER_79.")</span>";
 
 $sc_style['USERCLASSES']['pre'] 		= "<tr>
-											<td style='width:40%;vertical-align:top' class='forumheader3'>".LAN_USER_76.":".req(varset(e107::getPref('signup_option_class')))."
+											<td style='width:40%;vertical-align:top' class='forumheader3'>".LAN_USER_76.":".req(e107::getPref('signup_option_class'))."
 											<br /><span class='smalltext'>".LAN_USER_73."</span>
 											</td>
 											<td style='width:60%' class='forumheader2'>";										
@@ -77,7 +77,7 @@ $sc_style['LOGINNAME']['pre'] 			= "<tr>
 $sc_style['LOGINNAME']['post'] 			= "</td></tr>\n";	
 	
 
-$sc_style['SIGNATURE']['pre']			= "<tr><td style='width:40%;vertical-align:top' class='forumheader3'>".LAN_USER_71.req(varset(e107::getPref('signup_option_signature')))."</td>
+$sc_style['SIGNATURE']['pre']			= "<tr><td style='width:40%;vertical-align:top' class='forumheader3'>".LAN_USER_71.req(e107::getPref('signup_option_signature'))."</td>
 											<td style='width:60%' class='forumheader2'>";
 
 //$sc_style['SIGNATURE']['pre']			= "<tr><td style='width:40%;vertical-align:top' class='forumheader3'></td>
@@ -125,7 +125,7 @@ $USERSETTINGS_EDIT = "
 	{LOGINNAME}
 
 	<tr>
-	<td style='width:40%' class='forumheader3'>".LAN_USER_60.req(!varset(e107::getPref('disable_emailcheck')))."</td>
+	<td style='width:40%' class='forumheader3'>".LAN_USER_60.req(!e107::getPref('disable_emailcheck'))."</td>
 	<td style='width:60%' class='forumheader2'>
 	{EMAIL}
 	</td>
@@ -149,7 +149,7 @@ $USERSETTINGS_EDIT = "
 	</tr>
 	
 	<tr>
-	<td style='width:40%; vertical-align:top' class='forumheader3'>".LAN_USER_07.req(varset(e107::getPref('signup_option_image')))."</td>
+	<td style='width:40%; vertical-align:top' class='forumheader3'>".LAN_USER_07.req(e107::getPref('signup_option_image'))."</td>
 	<td style='width:60%' class='forumheader2'>
 	{AVATAR_REMOTE}
 	</td>
@@ -204,19 +204,19 @@ $USERSETTINGS_WRAPPER['edit']['PASSWORD2'] =			"<div class='form-group'>
 														";
 
 $USERSETTINGS_WRAPPER['edit']['REALNAME'] =			"<div class='form-group'>
-															<label for='realname' class='col-sm-3 control-label'>".LAN_USER_63.req(varset(e107::getPref('signup_option_realname')))."</label>
+															<label for='realname' class='col-sm-3 control-label'>".LAN_USER_63.req(e107::getPref('signup_option_realname'))."</label>
 														       	<div class='col-sm-9'>{---}</div>
 														   </div>
 														";
 
 $USERSETTINGS_WRAPPER['edit']['CUSTOMTITLE'] =			"<div class='form-group'>
-															<label for='customtitle' class='col-sm-3 control-label'>".LAN_USER_04.':'.req(varset(e107::getPref('signup_option_customtitle')))."</label>
+															<label for='customtitle' class='col-sm-3 control-label'>".LAN_USER_04.':'.req(e107::getPref('signup_option_customtitle'))."</label>
 														       	<div class='col-sm-9'>{---}</div>
 														   </div>
 														";
 
 $USERSETTINGS_WRAPPER['edit']['USERCLASSES'] = 			"<div class='form-group'>
-															<label  class='col-sm-3 control-label'>".LAN_USER_76.":".req(varset(e107::getPref('signup_option_class')))."</label>
+															<label  class='col-sm-3 control-label'>".LAN_USER_76.":".req(e107::getPref('signup_option_class'))."</label>
 														       	<div class='col-sm-9'>{---}</div>
 														   </div>
 														";
@@ -235,7 +235,7 @@ $USERSETTINGS_WRAPPER['edit']['PHOTO_UPLOAD'] = 		"<div class='form-group'>
 														
 
 $USERSETTINGS_WRAPPER['edit']['SIGNATURE']			= "<div class='form-group'>
-														<label for='signature' class='col-sm-3 control-label'>".LAN_USER_71.req(varset(e107::getPref('signup_option_signature')))."</label>
+														<label for='signature' class='col-sm-3 control-label'>".LAN_USER_71.req(e107::getPref('signup_option_signature'))."</label>
 												       	<div class='col-sm-9'>{---}</div>
 													   	</div>
 													 ";
@@ -258,7 +258,7 @@ $USERSETTINGS_TEMPLATE['edit'] = "
 
 
 	<div class='form-group'>
-	<label for='email' class='col-sm-3 control-label'>".LAN_USER_60.req(!varset(e107::getPref('disable_emailcheck')))."</label>
+	<label for='email' class='col-sm-3 control-label'>".LAN_USER_60.req(!e107::getPref('disable_emailcheck'))."</label>
 	<div class='col-sm-9'>
 		{EMAIL}
 	</div>
@@ -281,7 +281,7 @@ $USERSETTINGS_TEMPLATE['edit'] = "
 	</div>
 
 	<div class='form-group'>
-	<label class='col-sm-3 control-label'>".LAN_USER_07.req(varset(e107::getPref('signup_option_image')))."</label>
+	<label class='col-sm-3 control-label'>".LAN_USER_07.req(e107::getPref('signup_option_image'))."</label>
 	<div class='col-sm-9'>
 	{AVATAR_REMOTE}
 	</div>

--- a/e107_core/templates/usersettings_template.php
+++ b/e107_core/templates/usersettings_template.php
@@ -46,7 +46,7 @@ $sc_style['PASSWORD_LEN']['pre'] 		= "<br /><span class='smalltext'>  (".LAN_USE
 $sc_style['PASSWORD_LEN']['post'] 		= " ".LAN_USER_79.")</span>";
 
 $sc_style['USERCLASSES']['pre'] 		= "<tr>
-											<td style='width:40%;vertical-align:top' class='forumheader3'>".LAN_USER_76.":".req(varset($pref['signup_option_class']))."
+											<td style='width:40%;vertical-align:top' class='forumheader3'>".LAN_USER_76.":".req(varset(e107::getPref('signup_option_class')))."
 											<br /><span class='smalltext'>".LAN_USER_73."</span>
 											</td>
 											<td style='width:60%' class='forumheader2'>";										
@@ -77,7 +77,7 @@ $sc_style['LOGINNAME']['pre'] 			= "<tr>
 $sc_style['LOGINNAME']['post'] 			= "</td></tr>\n";	
 	
 
-$sc_style['SIGNATURE']['pre']			= "<tr><td style='width:40%;vertical-align:top' class='forumheader3'>".LAN_USER_71.req(varset($pref['signup_option_signature']))."</td>
+$sc_style['SIGNATURE']['pre']			= "<tr><td style='width:40%;vertical-align:top' class='forumheader3'>".LAN_USER_71.req(varset(e107::getPref('signup_option_signature')))."</td>
 											<td style='width:60%' class='forumheader2'>";
 
 //$sc_style['SIGNATURE']['pre']			= "<tr><td style='width:40%;vertical-align:top' class='forumheader3'></td>
@@ -125,18 +125,13 @@ $USERSETTINGS_EDIT = "
 	{LOGINNAME}
 
 	<tr>
-	<td style='width:40%' class='forumheader3'>".LAN_USER_60.req(!varset($pref['disable_emailcheck']))."</td>
+	<td style='width:40%' class='forumheader3'>".LAN_USER_60.req(!varset(e107::getPref('disable_emailcheck')))."</td>
 	<td style='width:60%' class='forumheader2'>
 	{EMAIL}
 	</td>
 	</tr>
 
-	<tr>
-	<td style='width:40%' class='forumheader3'>".LAN_USER_63.req(varset($pref['signup_option_realname']))."</td>
-	<td style='width:60%' class='forumheader2'>
 	{REALNAME}
-	</td>
-	</tr>
 
 	{CUSTOMTITLE}
 
@@ -154,7 +149,7 @@ $USERSETTINGS_EDIT = "
 	</tr>
 	
 	<tr>
-	<td style='width:40%; vertical-align:top' class='forumheader3'>".LAN_USER_07.req(varset($pref['signup_option_image']))."</td>
+	<td style='width:40%; vertical-align:top' class='forumheader3'>".LAN_USER_07.req(varset(e107::getPref('signup_option_image')))."</td>
 	<td style='width:60%' class='forumheader2'>
 	{AVATAR_REMOTE}
 	</td>
@@ -208,14 +203,20 @@ $USERSETTINGS_WRAPPER['edit']['PASSWORD2'] =			"<div class='form-group'>
 														   </div>
 														";
 
+$USERSETTINGS_WRAPPER['edit']['REALNAME'] =			"<div class='form-group'>
+															<label for='realname' class='col-sm-3 control-label'>".LAN_USER_63.req(varset(e107::getPref('signup_option_realname')))."</label>
+														       	<div class='col-sm-9'>{---}</div>
+														   </div>
+														";
+
 $USERSETTINGS_WRAPPER['edit']['CUSTOMTITLE'] =			"<div class='form-group'>
-															<label for='customtitle' class='col-sm-3 control-label'>".LAN_USER_04."</label>
+															<label for='customtitle' class='col-sm-3 control-label'>".LAN_USER_04.':'.req(varset(e107::getPref('signup_option_customtitle')))."</label>
 														       	<div class='col-sm-9'>{---}</div>
 														   </div>
 														";
 
 $USERSETTINGS_WRAPPER['edit']['USERCLASSES'] = 			"<div class='form-group'>
-															<label  class='col-sm-3 control-label'>".LAN_USER_76.":".req(varset($pref['signup_option_class']))."</label>
+															<label  class='col-sm-3 control-label'>".LAN_USER_76.":".req(varset(e107::getPref('signup_option_class')))."</label>
 														       	<div class='col-sm-9'>{---}</div>
 														   </div>
 														";
@@ -234,7 +235,7 @@ $USERSETTINGS_WRAPPER['edit']['PHOTO_UPLOAD'] = 		"<div class='form-group'>
 														
 
 $USERSETTINGS_WRAPPER['edit']['SIGNATURE']			= "<div class='form-group'>
-														<label for='signature' class='col-sm-3 control-label'>".LAN_USER_71.req(varset($pref['signup_option_signature']))."</label>
+														<label for='signature' class='col-sm-3 control-label'>".LAN_USER_71.req(varset(e107::getPref('signup_option_signature')))."</label>
 												       	<div class='col-sm-9'>{---}</div>
 													   	</div>
 													 ";
@@ -257,18 +258,13 @@ $USERSETTINGS_TEMPLATE['edit'] = "
 
 
 	<div class='form-group'>
-	<label for='email' class='col-sm-3 control-label'>".LAN_USER_60.req(!varset($pref['disable_emailcheck']))."</label>
+	<label for='email' class='col-sm-3 control-label'>".LAN_USER_60.req(!varset(e107::getPref('disable_emailcheck')))."</label>
 	<div class='col-sm-9'>
 		{EMAIL}
 	</div>
 	</div>
 
-	<div class='form-group'>
-	<label for='realname' class='col-sm-3 control-label'>".LAN_USER_63.req(varset($pref['signup_option_realname']))."</label>
-	<div class='col-sm-9'>
-		{REALNAME}
-	</div>
-	</div>
+	{REALNAME}
 
 	{CUSTOMTITLE}
 
@@ -285,7 +281,7 @@ $USERSETTINGS_TEMPLATE['edit'] = "
 	</div>
 
 	<div class='form-group'>
-	<label class='col-sm-3 control-label'>".LAN_USER_07.req(varset($pref['signup_option_image']))."</label>
+	<label class='col-sm-3 control-label'>".LAN_USER_07.req(varset(e107::getPref('signup_option_image')))."</label>
 	<div class='col-sm-9'>
 	{AVATAR_REMOTE}
 	</div>


### PR DESCRIPTION
Realname was always shown and marked required, even if it was configured differently.
The template needed to get modified to make this work and the {REALNAME} shortcode had to be rewritten as it didn't took the settings into account.
The customtitle field had a similar issue.