### PR TITLE
Fixes #2930 Added errormessage if request fails

### DIFF
--- a/e107_languages/English/English.php
+++ b/e107_languages/English/English.php
@@ -115,6 +115,7 @@ define("LAN_FILES","Files");
 define("LAN_SIZE", "Size");
 define("LAN_VERSION", "Version");
 define("LAN_DOWNLOAD", "Download");
+define("LAN_DOWNLOAD_NO_PERMISSION", "File not found or you have no permission to download this file!");
 define("LAN_WEBSITE", "Website");
 define("LAN_COMMENTS", "Comments");
 define("LAN_LOCATION", "Location");

--- a/request.php
+++ b/request.php
@@ -53,7 +53,14 @@ if(!empty($_GET['file'])) // eg. request.php?file=1
 		$row = $sql->fetch();
 		// $file = $tp->replaceConstants($row['media_url'],'rel');
 		e107::getFile()->send($row['media_url']);
-	} 	
+	}
+	else
+	{
+		require_once(HEADERF);
+		echo e107::getMessage()->addError(LAN_DOWNLOAD_NO_PERMISSION)->render();
+		require_once(FOOTERF);
+	}
+
 }
 elseif(e107::isInstalled('download')) //BC Legacy Support. (Downloads Plugin)
 {


### PR DESCRIPTION
In case of a failed request, only a blank page was returned.
I've added a error message and also a LAN.