### PR TITLE
Fixes #3239 The array merge didn't work correctly by using the + operator

### DIFF
--- a/e107_plugins/user/e_dashboard.php
+++ b/e107_plugins/user/e_dashboard.php
@@ -422,8 +422,9 @@ class user_dashboard // plugin-folder + '_url'
 				<tbody>";
 
 
-
-		$online = $ol->userList() + $ol->guestList();
+		// Fixes #3239: The array merge didn't work correctly by using the + operator
+		$online = $ol->userList();
+		$online = array_merge($online, $ol->guestList());
 
 		if($data == 'count')
 		{


### PR DESCRIPTION
The array merge didn't work correctly by using the + operator. The contents of the guest array was just dicarded.