### PR TITLE
Fixes #3056 Fixes the fatal error in case no records were found

### DIFF
--- a/e107_plugins/download/handlers/download_class.php
+++ b/e107_plugins/download/handlers/download_class.php
@@ -563,7 +563,8 @@ class download
 		$ns = e107::getRender();
 		$sc = $this->sc;
 
-		$count = $sc->getVars();
+		// @see: #3056 fixes fatal error in case $sc is empty (what happens, if no record was found)
+		$count = empty($sc) ? 0 : $sc->getVars();
 
 		if(empty($count))
 		{


### PR DESCRIPTION
It could happen, that the $this->sc variable was empty, in case no records were found. This fix makes sure that this doesn't throw an exception by testing if the var is not empty.