### PR TITLE
Fixes #3264 Switched url generation to v2 method

### DIFF
--- a/e107_plugins/forum/shortcodes/batch/forum_shortcodes.php
+++ b/e107_plugins/forum/shortcodes/batch/forum_shortcodes.php
@@ -64,7 +64,7 @@ class forum_shortcodes extends e_shortcode
 
 	function sc_statlink()
 	{
-		 return "<a href='".e_PLUGIN."forum/forum_stats.php'>".LAN_FORUM_0017."</a>\n";
+		return "<a href='".e107::url('forum','stats')."'>".LAN_FORUM_0017."</a>\n";
 	}
 
 	function sc_iconkey()


### PR DESCRIPTION
Shortcode still used the v1 method of url creattion (fixed string).
Switched to v2 url() method.