### PR TITLE
Fixes #2938 Added missing e_PAGETITLE in case of default url

### DIFF
--- a/e107_plugins/gallery/gallery.php
+++ b/e107_plugins/gallery/gallery.php
@@ -29,6 +29,12 @@ e107::css('gallery', 'css/gallery.css');
 // Load prettyPhoto settings and files.
 gallery_load_prettyphoto();
 
+// @see: Issue #2938 Missing pagetitle in case of default urls.
+if (!class_exists('plugin_gallery_index_controller') && !deftrue('e_PAGETITLE'))
+{
+	define('e_PAGETITLE', LAN_PLUGIN_GALLERY_TITLE);
+}
+
 require_once(HEADERF);
 
 


### PR DESCRIPTION
In case the SEF Url configuration was set to "Default", the constant e_PAGETITLE wasn't set.
