### PR TITLE
Various changes to make it work on my side.

### DIFF
--- a/e107_plugins/user/e_user.php
+++ b/e107_plugins/user/e_user.php
@@ -31,6 +31,7 @@ class user_user // plugin-folder + '_user'
 	 */
 	function delete($uid)
 	{
+		$us = e107::getUserSession();
 
 		$config = array();
 
@@ -41,6 +42,7 @@ class user_user // plugin-folder + '_user'
 			'user_email'        => 'noreply-'.$uid.'@nowhere.com',
 			'user_ip'           => '',
 			'user_lastvisit'    => time(),
+			'user_password'     => $us->HashPassword($us->generateRandomString("#??????????#"), 'Deleted-Login-'.$uid),
 			'user_ban'          => 5, // 'deleted' status'
 			// etc.
 			'WHERE'             => 'user_id = '.$uid,

--- a/usersettings.php
+++ b/usersettings.php
@@ -39,7 +39,7 @@ if (!USER)
 	exit();
 }
 
-if ((!ADMIN || !getperms("4")) && e_QUERY && e_QUERY != "update" )
+if ((!ADMIN || !getperms("4")) && e_QUERY && e_QUERY != "update" && substr(e_QUERY, 0, 4) !== 'del=')
 {
 	header('location:'.e_BASE.'usersettings.php');
 	exit();
@@ -205,7 +205,7 @@ class usersettings_front // Begin Usersettings rewrite.
 
 	private function processUserDelete($hash)
 	{
-		if(!e107::getDb()->select('user',"user_id = ".USERID." AND user_sess=".$hash." LIMIT 1")) // user must be logged in AND have correct hash.
+		if(!e107::getDb()->select('user', '*',"user_id = ".USERID." AND user_sess='".$hash."' LIMIT 1")) // user must be logged in AND have correct hash.
 		{
 			return false;
 		}
@@ -227,13 +227,13 @@ class usersettings_front // Begin Usersettings rewrite.
 				{
 					//echo "<h3>UPDATE ".$table."</h3>";
 				//	print_a($query);
-					$sql->update($table,$query); // todo check query ran successfully.
+					$sql->update($table, $query); // todo check query ran successfully.
 				}
 				elseif($mode === 'delete')
 				{
 					//echo "<h3>DELETE ".$table."</h3>";
 					//print_a($query);
-					$sql->delete($table,$query); //  todo check query ran successfully.
+					$sql->delete($table, $query['WHERE']); //  todo check query ran successfully.
 				}
 
 			}
@@ -287,8 +287,11 @@ class usersettings_front // Begin Usersettings rewrite.
 
 		if(!empty($_GET['del'])) // delete account via confirmation email link.
 		{
+
 			echo $this->processUserDelete($_GET['del']);
-			e107::getSession()->destroy();
+			//e107::getSession()->destroy();
+			e107::getUser()->logout();
+			return null;
 		}
 
 		/* todo subject of removal */


### PR DESCRIPTION
As requested :wink: i tested your changes so far and came across the following issues:
- The button "Delete user" is only visible, when i open the page from the menu->settings and not when i first open my profile and click on "Click here to update your information". The button uses a legacy url to "settings.php" 
**OPEN**
- When clicking on the confirmation link, it doesn't work. At line 42 it does a redirect without the query string... 
**FIXED**
- Wrong argument 2 in select() statement on line 208. Resulting query string can not work...
**FIXED**
- Needed to run "Scan plugin directories", because he didn't know anything from user/e_user.php ...!? Can this be forced to be done automatically from time to time or triggered by such an event? Just to make sure all e_user.php's in the system are really "known"...?
**OPEN**
- Was able to login with the deleted user's login name and his old password...
**FIXED**
- After deleting was done, the user settings of the deleted user where displayed.
**FIXED**
- After deleting was done all menus, etc. look like the user is still logged in (which he isn't).
**OPEN**