### PR TITLE
Fixes #3275 Added support for legacy urls of type request.php?download.4

### DIFF
--- a/e107_handlers/e107_class.php
+++ b/e107_handlers/e107_class.php
@@ -3486,14 +3486,26 @@ class e107
 
 				if(!empty($tmp))
 				{
-					parse_str($tmp,$qry);
-
-					foreach($qry as $k=>$v)
+					if (strpos($tmp, '=') === false)
 					{
-						if(!isset($options['query'][$k])) // $options['query'] overrides any in the original URL.
+						// required for legacy urls of type "request.php?download.43"
+						// @see: issue #3275
+						$legacyUrl .= '?' . $tmp;
+						$options['query'] = null;
+					}
+					else
+					{
+
+						parse_str($tmp,$qry);
+
+						foreach($qry as $k=>$v)
 						{
-							$options['query'][$k] = $v;
+							if(!isset($options['query'][$k])) // $options['query'] overrides any in the original URL.
+							{
+								$options['query'][$k] = $v;
+							}
 						}
+
 					}
 				}
 


### PR DESCRIPTION
The current function malformed the address to request.php?download_4= while trying to build the query.