### PR TITLE
Fixed issue with legacy url (goto settings) on user profile page

### DIFF
--- a/e107_core/shortcodes/batch/user_shortcodes.php
+++ b/e107_core/shortcodes/batch/user_shortcodes.php
@@ -525,7 +525,8 @@ class user_shortcodes extends e_shortcode
 		if (USERID == $this->var['user_id']) 
 		{
 			//return "<a href='".$url->create('user/myprofile/edit')."'>".LAN_USER_38."</a>";
-			return "<a class='btn btn-default' href='".e_HTTP."usersettings.php'>".LAN_USER_38."</a>"; // TODO: repair dirty fix for usersettings
+			//return "<a class='btn btn-default' href='".e_HTTP."usersettings.php'>".LAN_USER_38."</a>"; // TODO: repair dirty fix for usersettings
+			return "<a class='btn btn-default' href='".$url->create('user/myprofile/edit')."'>".LAN_USER_38."</a>"; // TODO: repair dirty fix for usersettings
 		}
 		else if(ADMIN && getperms("4") && !$this->var['user_admin']) 
 		{
@@ -534,6 +535,7 @@ class user_shortcodes extends e_shortcode
 			return "<a class='btn btn-default' href='".$editUrl."'>".LAN_USER_39."</a>";
 
 			//	return "<a class='btn btn-default' href='".$url->create('user/profile/edit', array('id' => $this->var['user_id'], 'name' => $this->var['user_name']))."'>".LAN_USER_39."</a>";
+
 		}
 	}
 	

--- a/e107_core/url/user/url.php
+++ b/e107_core/url/user/url.php
@@ -42,7 +42,8 @@ class core_user_url extends eUrlConfig
 	 */
 	public function create($route, $params = array(), $options = array())
 	{
-		if(!$params) return 'user.php';
+		// Some routes require no params
+		//if(!$params) return 'user.php';
 		
 		if(is_string($route)) $route = explode('/', $route, 2);
 		if(!varset($route[1])) $route[1] = 'index';
@@ -56,6 +57,9 @@ class core_user_url extends eUrlConfig
 		
 		if($route[0] == 'profile')
 		{
+			// Params required for user view, list & edit
+			if(!$params) return 'user.php';
+
 			switch ($route[1]) 
 			{
 				case '':
@@ -68,7 +72,8 @@ class core_user_url extends eUrlConfig
 				break;
 				
 				case 'edit':
-					$url = e_ADMIN_ABS."user.php?mode=main&action=edit&id=".$params['id'];// 'usersettings.php?'.$params['id'];
+					//$url = e_ADMIN_ABS."user.php?mode=main&action=edit&id=".$params['id'];// 'usersettings.php?'.$params['id'];
+					$url = e_ADMIN."users.php?mode=main&action=edit&id=".$params['id'];// 'usersettings.php?'.$params['id'];
 				break;
 			}
 		}


### PR DESCRIPTION
The user profile contained a button at the end to jump to the users settings page.
This button used a legacy url.