### PR TITLE
Reduce reliance on global var $db_ConnectionID

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -3,7 +3,7 @@ version: "2"
 plugins:
   csslint:
     enabled: false
-    duplication:
+  duplication:
     enabled: true
     checks:
       Identical code:
@@ -51,6 +51,7 @@ exclude_patterns:
 - "**/*.d.ts"
 - "e107_admin/core_image.php"
 - "e107_plugins/log/js/awesomechart.js"
+- "e107_core/**/*.sc"
 - "e107_docs/**/*"
 - "e107_images/**/*"
 - "e107_handlers/hybridauth/**/*"

--- a/e107_handlers/mysql_class.php
+++ b/e107_handlers/mysql_class.php
@@ -483,11 +483,7 @@ class e_db_mysql
 			$this->db_Write_log($log_type, $log_remark, $query);
 		}
 
-		if(!$this->mySQLaccess)
-		{
-			global $db_ConnectionID;
-        	$this->mySQLaccess = $db_ConnectionID;
-		}
+		$this->provide_mySQLaccess();
 
 		$b = microtime();
 		
@@ -978,11 +974,7 @@ class e_db_mysql
 			$query = 'INSERT INTO '.$this->mySQLPrefix."{$table} VALUES ({$arg})";
 		}
 
-		if(!$this->mySQLaccess)
-		{
-			global $db_ConnectionID;
-			$this->mySQLaccess = $db_ConnectionID;
-		}
+		$this->provide_mySQLaccess();
 
 		$this->mySQLresult = $this->db_Query($query, NULL, 'db_Insert', $debug, $log_type, $log_remark);
 
@@ -1197,11 +1189,7 @@ class e_db_mysql
 		$table = $this->db_IsLang($tableName);
 		$this->mySQLcurTable = $table;
 
-		if(!$this->mySQLaccess)
-		{
-			global $db_ConnectionID;
-			$this->mySQLaccess = $db_ConnectionID;
-		}
+		$this->provide_mySQLaccess();
 
 		$arg = $this->_prepareUpdateArg($tableName, $arg);
 
@@ -1459,11 +1447,7 @@ class e_db_mysql
 	  $table = $this->db_IsLang($table);
 	  $this->mySQLcurTable = $table;
 
-	  if(!$this->mySQLaccess)
-	  {
-		global $db_ConnectionID;
-        $this->mySQLaccess = $db_ConnectionID;
-	  }
+		$this->provide_mySQLaccess();
 
 	  $new_data = '';
 	  if (is_array($vars))
@@ -1665,11 +1649,7 @@ class e_db_mysql
 	 */
 	function close()
 	{
-		if(!$this->mySQLaccess)
-		{
-			global $db_ConnectionID;
-			$this->mySQLaccess = $db_ConnectionID;
-		}
+		$this->provide_mySQLaccess();
 		e107::getSingleton('e107_traffic')->BumpWho('db Close', 1);
 		$this->mySQLaccess = NULL; // correct way to do it when using shared links.
 		$this->dbError('dbClose');
@@ -1701,11 +1681,7 @@ class e_db_mysql
 		$table = $this->db_IsLang($table);
 		$this->mySQLcurTable = $table;
 
-		if(!$this->mySQLaccess)
-		{
-			global $db_ConnectionID;
-        	$this->mySQLaccess = $db_ConnectionID;
-		}
+		$this->provide_mySQLaccess();
 
 
 		if (!$arg)
@@ -1907,11 +1883,7 @@ class e_db_mysql
 		  	return $table;
 		}
 
-		if(!$this->mySQLaccess)
-		{
-			global $db_ConnectionID;
-        	$this->mySQLaccess = $db_ConnectionID;
-		}
+		$this->provide_mySQLaccess();
 
 		if($multiple == FALSE)
 		{
@@ -2249,11 +2221,7 @@ class e_db_mysql
 			$this->mySQLdefaultdb = $mySQLdefaultdb;
 		}
 
-		if(!$this->mySQLaccess)
-		{
-			global $db_ConnectionID;
-			$this->mySQLaccess = $db_ConnectionID;
-		}
+		$this->provide_mySQLaccess();
 
 		if ($prefix == '') $prefix = $this->mySQLPrefix;
 
@@ -2321,11 +2289,7 @@ class e_db_mysql
 		$convert = array("PRIMARY"=>"PRI","INDEX"=>"MUL","UNIQUE"=>"UNI");
 		$key = (isset($convert[$key])) ? $convert[$key] : "OFF";
 
-		if(!$this->mySQLaccess)
-		{
-			global $db_ConnectionID;
-			$this->mySQLaccess = $db_ConnectionID;
-		}
+		$this->provide_mySQLaccess();
 
         $result = $this->gen("SHOW COLUMNS FROM ".$this->mySQLPrefix.$table);
         if ($result && ($this->rowCount() > 0))
@@ -2373,11 +2337,7 @@ class e_db_mysql
 			$this->mySQLdefaultdb = $mySQLdefaultdb;
 		}
 
-		if(!$this->mySQLaccess)
-		{
-			global $db_ConnectionID;
-			$this->mySQLaccess = $db_ConnectionID;
-		}
+		$this->provide_mySQLaccess();
 
 		if (!empty($fields) && !is_array($fields))
 		{
@@ -2441,11 +2401,7 @@ class e_db_mysql
 			$data = strip_if_magic($data);
 		}
 
-		if(!$this->mySQLaccess)
-		{
-			global $db_ConnectionID;
-        	$this->mySQLaccess = $db_ConnectionID;
-		}
+		$this->provide_mySQLaccess();
 		
 		if($this->pdo)
 		{
@@ -3141,10 +3097,38 @@ class e_db_mysql
 
 	}
 
+	/**
+	 * In case e_db_mysql::$mySQLaccess is not set, set it.
+	 *
+	 * Uses the global variable $db_ConnectionID if available.
+	 *
+	 * When the global variable has been unset like in https://github.com/e107inc/e107-test/issues/6 ,
+	 * use the "mySQLaccess" from the default e_db_mysql instance singleton.
+	 */
+	private function provide_mySQLaccess()
+	{
+		if (!$this->mySQLaccess) {
+			global $db_ConnectionID;
+			$this->mySQLaccess = $db_ConnectionID;
+		}
+		if (!$this->mySQLaccess) {
+			$this->mySQLaccess = e107::getDb()->get_mySQLaccess();
+		}
+	}
+
+	/**
+	 * @deprecated 2.1.9 Used only to provide $mySQLaccess to other instances of e_db_mysql scattered around
+	 * @return PDO
+	 */
+	public function get_mySQLaccess()
+	{
+		return $this->mySQLaccess;
+	}
+
 }
 
 /**
- * BC
+ * Backwards compatibility
  */
 class db extends e_db_mysql
 {


### PR DESCRIPTION
When one of 11 methods in `e_db_mysql` look for a PDO object in `e_db_mysql::$mySQLaccess`, `global $db_ConnectionID` can be `NULL` in some cases, so it's more reliable to get the singleton `e_db_mysql` and use the `e_db_mysql::$mySQLaccess` from that singleton.

This change still allows `global $db_ConnectionID` to be used, but if `$db_ConnectionID` is `NULL`, the singleton fallback is used.

Fixes: e107inc/e107-test#6