### PR TITLE
Fix #3249 uc_select() didn't recognize comma separated values

### DIFF
--- a/e107_handlers/e_parse_class.php
+++ b/e107_handlers/e_parse_class.php
@@ -487,7 +487,7 @@ class e_parse extends e_parser
 	 * 				the save_prefs() function has been called by a non admin user / user without html posting permissions.
 	 * @param boolean|string $mod [optional] model = admin-ui usage. The 'no_html' and 'no_php' modifiers blanket prevent HTML and PHP posting regardless of posting permissions. (used in logging)
 	 *		The 'pReFs' value is for internal use only, when saving prefs, to prevent sanitisation of HTML.
-	 * @param boolean $original_author [optional]
+	 * @param mixed $parm [optional]
 	 * @return string
 	 * @todo complete the documentation of this essential method
 	 */
@@ -501,7 +501,7 @@ class e_parse extends e_parser
 			foreach ($data as $key => $var)
 			{
 				//Fix - sanitize keys as well
-				$ret[$this->toDB($key, $nostrip, $no_encode, $mod, $original_author)] = $this->toDB($var, $nostrip, $no_encode, $mod, $original_author);
+				$ret[$this->toDB($key, $nostrip, $no_encode, $mod, $parm)] = $this->toDB($var, $nostrip, $no_encode, $mod, $parm);
 			}
 			return $ret;
 		}

--- a/e107_handlers/form_handler.php
+++ b/e107_handlers/form_handler.php
@@ -3036,7 +3036,22 @@ class e_form
 
 		if(!empty($current_value) && !is_numeric($current_value)) // convert name to id.
 		{
-			$current_value = $this->_uc->getID($current_value);
+			//$current_value = $this->_uc->getID($current_value);
+			// issue #3249 Accept also comma separated values
+			if (!is_array($current_value))
+			{
+				$current_value = explode(',', $current_value);
+			}
+			$tmp = array();
+			foreach($current_value as $val)
+			{
+				if (!empty($val))
+				{
+					$tmp[] = !is_numeric($val) ? $this->_uc->getID(trim($val)) : (int) $val;
+				}
+			}
+			$current_value = implode(',', $tmp);
+			unset($tmp);
 		}
 
 		return $this->select_open($name, $select_options)."\n".$this->_uc->vetted_tree($name, array($this, '_uc_select_cb'), $current_value, $uc_options, $opt_options)."\n".$this->select_close();


### PR DESCRIPTION
**Fix #3249**
- uc_select() didn't recognize comma separated values
- added a check for such values

** Other changes **
- fixed typo in e_parse_class::toDB(): Renamed parameter `$original_author` to `$parm`