### PR TITLE
fixes #3244 "&amp;" in url definition was broken during parse_str()

### DIFF
--- a/e107_plugins/forum/e_url.php
+++ b/e107_plugins/forum/e_url.php
@@ -46,8 +46,8 @@ class forum_url // plugin-folder + '_url'
 		$config['markread']  = array(
 			'sef'           => '^forum/markread/{forum_id}',
 			'regex'			=> 'forum/markread/([\d]*)',
-			'redirect'      => '{e_PLUGIN}forum/forum.php?f=mfar&amp;id=$1',
-			'legacy'        => '{e_PLUGIN}forum/forum.php?f=mfar&amp;id={forum_id}'
+			'redirect'      => '{e_PLUGIN}forum/forum.php?f=mfar&id=$1',
+			'legacy'        => '{e_PLUGIN}forum/forum.php?f=mfar&id={forum_id}'
 		);
 
 		$config['post'] = array(
@@ -58,15 +58,15 @@ class forum_url // plugin-folder + '_url'
 
 		// only create url  - parsed above.
 		$config['move'] = array(
-			'sef'           => 'forum/post/?f=move&amp;id={thread_id}',
-			'legacy'        => '{e_PLUGIN}forum/forum_post.php?f=move&amp;id={thread_id}'
+			'sef'           => 'forum/post/?f=move&id={thread_id}',
+			'legacy'        => '{e_PLUGIN}forum/forum_post.php?f=move&id={thread_id}'
 		);
 
 
 
 		$config['split'] = array(
-			'sef'           => 'forum/post/?f=split&amp;id={thread_id}&amp;post={post_id}',
-			'legacy'        => '{e_PLUGIN}forum/forum_post.php?f=split&amp;id={thread_id}&amp;post={post_id}'
+			'sef'           => 'forum/post/?f=split&id={thread_id}&post={post_id}',
+			'legacy'        => '{e_PLUGIN}forum/forum_post.php?f=split&id={thread_id}&post={post_id}'
 		);
 
 		$config['topic'] = array(


### PR DESCRIPTION
The url definition contained the string "&amp;", which was replaced during the url creation with "&;". That broke the function of the url.