### PR TITLE
Removed problematic cache from e107plugin::getinfo() and fixed regression in e_core_pref::__construct()

### DIFF
--- a/e107_admin/plugin.php
+++ b/e107_admin/plugin.php
@@ -631,7 +631,7 @@ class plugin_ui extends e_admin_ui
 
 				$eplug_addons = $plugin -> getAddons($eplug_folder);
 
-				$info = $plugin->getinfo($this->id);
+				$info = e107plugin::getPluginRecord($this->id);
 
 				$name = deftrue($info['plugin_name'],$info['plugin_name']). " v".$eplug_version. "({e_PLUGIN}".$info['plugin_path'].")";
 

--- a/e107_handlers/plugin_class.php
+++ b/e107_handlers/plugin_class.php
@@ -1631,32 +1631,21 @@ class e107plugin
 	 * @param int $id
 	 * @return array plugin info
 	 */
-	function getinfo($id, $force = false)
+	static function getPluginRecord($id)
 	{
 		$sql = e107::getDb();
-		static $getinfo_results;
-		if (!is_array($getinfo_results))
-		{
-			$getinfo_results = array();
+		$getinfo_results = array();
+
+		$path = (!is_numeric($id)) ? $id : false;
+		$id = (int)$id;
+
+		$qry = "plugin_id = " . $id;
+		$qry .= ($path != false) ? " OR plugin_path = '" . $path . "' " : "";
+
+		if ($sql->select('plugin', '*', $qry)) {
+			$getinfo_results[$id] = $sql->fetch();
 		}
 
-		$path = (!is_numeric($id)) ?  $id : false;
-		$id = (int) $id;
-		
-		$qry = "plugin_id = ".$id;
-		$qry .= ($path != false) ? " OR plugin_path = '".$path."' " : "";
-		
-		if (!isset($getinfo_results[$id]) || $force == true)
-		{
-			if ($sql->select('plugin', '*', $qry))
-			{
-				$getinfo_results[$id] = $sql->fetch();
-			}
-			else
-			{
-				return false;
-			}
-		}
 		return $getinfo_results[$id];
 	}
 	
@@ -1945,7 +1934,7 @@ class e107plugin
 	function manage_userclass($action, $class_name, $class_description='')
 	{
 		$this->log("Running ".__FUNCTION__);
-		global $e107;
+		$e107 = e107::getInstance();
 		$tp = e107::getParser();
 		$sql = e107::getDb();
 		$mes = e107::getMessage();
@@ -2501,12 +2490,12 @@ class e107plugin
 		elseif(is_numeric($id)) // plugin database id
 		{
 			$id = (int) $id;
-			$plug = $this->getinfo($id); // Get plugin info from DB	
+			$plug = e107plugin::getPluginRecord($id); // Get plugin info from DB
 		}
 		else // Plugin Path.
 		{
 			$id = $this->getId($id);
-			$plug = $this->getinfo($id); // Get plugin info from DB
+			$plug = e107plugin::getPluginRecord($id); // Get plugin info from DB
 		}
 				
 		$this->current_plug = $plug;
@@ -3885,7 +3874,7 @@ class e107plugin
 		}
 		else
 		{	
-			$plug = $this->getinfo($id);
+			$plug = e107plugin::getPluginRecord($id);
 		}
 		
 		$_path = e_PLUGIN.$plug['plugin_path'].'/';
@@ -4018,7 +4007,7 @@ class e107plugin
 		$sql = e107::getDb();
 		$tp = e107::getParser();		
 		
-		$plug = $this->getinfo($dir);
+		$plug = e107plugin::getPluginRecord($dir);
 		
 		$this->options = array('nolinks'=>true);
 		
@@ -4071,7 +4060,7 @@ class e107plugin
 		$text = '';
 
 		// install plugin ...
-		$plug = $this->getinfo($id);
+		$plug = e107plugin::getPluginRecord($id);
 		
 		if(!is_array($plug))
 		{
@@ -4119,7 +4108,7 @@ class e107plugin
 		$tp = e107::getParser();
 
 		$sql = e107::getDb();
-		$plug = $this->getinfo($id);
+		$plug = e107plugin::getPluginRecord($id);
 
 		$this->log("Uninstalling :".$plug['plugin_path']." with options: ".print_r($options, true));
 

--- a/e107_handlers/pref_class.php
+++ b/e107_handlers/pref_class.php
@@ -845,7 +845,7 @@ final class e_core_pref extends e_pref
 		parent::__construct($pref_id, $pref_alias);
 		if($load && $pref_id)
 		{
-			$this->load();
+			$this->load($pref_id, $load);
 		}
 
 

--- a/e107_handlers/pref_class.php
+++ b/e107_handlers/pref_class.php
@@ -845,7 +845,7 @@ final class e_core_pref extends e_pref
 		parent::__construct($pref_id, $pref_alias);
 		if($load && $pref_id)
 		{
-			$this->load($pref_id, $load);
+			$this->load();
 		}
 
 


### PR DESCRIPTION
Reimplements #3301 and turns off "force" loading in the `e_core_pref` constructor, which caused a regression in `thumb.php`, which somehow depends on core preferences but mustn't connect to the database.  "Force" loading makes a query to the database.