### PR TITLE
Forum editor2

### DIFF
--- a/e107_handlers/e107_class.php
+++ b/e107_handlers/e107_class.php
@@ -3627,16 +3627,37 @@ class e107
 
 	/**
 	 * Set or Retrieve WYSIWYG active status. (replaces constant  e_WYSIWYG)
-	 * @param null $val
+	 * @param bool $val if null, return current value, otherwise set value to registry
 	 * @return bool|mixed|void
 	 */
 	public static function wysiwyg($val=null)
 	{
-		
+		// Check the general wysiwyg setting
 		if (self::getPref('wysiwyg',false) != true)
 		{
 			return false; 	
 		}
+
+
+		if (defined('e_CURRENT_PLUGIN') && e_CURRENT_PLUGIN != '')
+		{
+			$editor = e107::getPlugPref(e_CURRENT_PLUGIN, 'editor', 'default');
+			if ($editor != 'default' && $editor != 'bbcode' && !e107::isInstalled($editor))
+			{
+				$editor = 'default';
+			}
+			switch ($editor)
+			{
+				case 'bbcode':
+					return false;
+				case 'tinymce4':
+					return true;
+				default:
+					break;
+			}
+
+		}
+
 
 		if(is_null($val))
 		{

--- a/e107_handlers/form_handler.php
+++ b/e107_handlers/form_handler.php
@@ -2311,8 +2311,13 @@ class e_form
 			$help_tagid 		= $this->name2id($name)."--preview";
 		}
 
+		if (!isset($options['editor']))
+		{
+			$options['editor'] = true;
+		}
 
-		if(e107::wysiwyg(true) === false) // bbarea loaded, so activate wysiwyg (if enabled in preferences)
+		//if(e107::wysiwyg(true) === false) // bbarea loaded, so activate wysiwyg (if enabled in preferences)
+		if(e107::wysiwyg($options['editor'], true) === 'bbcode') // bbarea loaded, so activate wysiwyg (if enabled in preferences)
 		{
 			$options['other'] 	= "onselect='storeCaret(this);' onclick='storeCaret(this);' onkeyup='storeCaret(this);' {$height}";
 		}

--- a/e107_handlers/form_handler.php
+++ b/e107_handlers/form_handler.php
@@ -2300,9 +2300,16 @@ class e_form
 		// auto-height support
 	   	$options['class'] 	= 'tbox bbarea '.($size ? ' '.$size : '').' e-wysiwyg e-autoheight form-control';
 		$bbbar 				= '';
-		
 
-		$help_tagid 		= $this->name2id($name)."--preview";
+
+		if (isset($options['id']) && !empty($options['id']))
+		{
+			$help_tagid 		= $this->name2id($options['id'])."--preview";
+		}
+		else
+		{
+			$help_tagid 		= $this->name2id($name)."--preview";
+		}
 
 
 		if(e107::wysiwyg(true) === false) // bbarea loaded, so activate wysiwyg (if enabled in preferences)

--- a/e107_plugins/forum/forum_admin.php
+++ b/e107_plugins/forum/forum_admin.php
@@ -183,6 +183,9 @@ if(!deftrue('OLD_FORUMADMIN'))
 			'popular'	            => array('title' => FORLAN_55, 'type'=>'number', 'data' => 'int','help'=>FORLAN_56),
 			'postspage'	            => array('title' => FORLAN_57, 'type'=>'number', 'data' => 'int','help'=>FORLAN_58),
 			'threadspage'	        => array('title' => FORLAN_186, 'type'=>'number', 'data' => 'int','help'=>FORLAN_187),
+
+			'editor'                => array('title' => 'Post editor', 'type' => 'dropdown', 'data' => 'str', 'readParms' => array(), 'writeParms' => array('optArray' => array(), 'defaultValue' => 'default'), 'help' => 'Which editor should be used to create/edit posts?'),
+			'quickreply'            => array('title' => 'Quick replay editor', 'type' => 'dropdown', 'data' => 'str', 'readParms' => array(), 'writeParms' => array('optArray' => array(), 'defaultValue' => 'default'), 'help' => '')
 		);
 
 		public $forumParents = array();
@@ -224,6 +227,19 @@ if(!deftrue('OLD_FORUMADMIN'))
 		{
 
 			$this->checkOrder();
+
+
+			$this->prefs['editor']['writeParms']['optArray']['default'] = 'System editor';
+			$this->prefs['editor']['writeParms']['optArray']['bbcode'] = 'BBCode';
+			if (e107::isInstalled('tinymce4'))
+			{
+				$this->prefs['editor']['writeParms']['optArray']['tinymce4'] = 'TinyMCE';
+			}
+
+			$this->prefs['quickreply']['writeParms']['optArray'] = array(
+				'default' => 'Textarea',
+				'wysiwyg' => 'Editor'
+			);
 
 			if(e107::isInstalled('poll') == false)
 			{

--- a/e107_plugins/forum/forum_admin.php
+++ b/e107_plugins/forum/forum_admin.php
@@ -235,6 +235,10 @@ if(!deftrue('OLD_FORUMADMIN'))
 			{
 				$this->prefs['editor']['writeParms']['optArray']['tinymce4'] = 'TinyMCE';
 			}
+			if (e107::isInstalled('simplemde'))
+			{
+				$this->prefs['editor']['writeParms']['optArray']['simplemde'] = 'Simple MDE';
+			}
 
 			$this->prefs['quickreply']['writeParms']['optArray'] = array(
 				'default' => 'Textarea',

--- a/e107_plugins/forum/js/forum.js
+++ b/e107_plugins/forum/js/forum.js
@@ -27,7 +27,14 @@ var e107 = e107 || {'settings': {}, 'behaviors': {}};
 					var action = $this.attr('data-forum-action');
 					var thread = $this.attr('data-forum-thread');
 					var post = $this.attr('data-forum-post');
-					var text = $('#forum-quickreply-text').val();
+					if (typeof tinymce == 'undefined')
+					{
+                        var text = $('#forum-quickreply-text').val();
+					}
+                    else
+					{
+                        var text = tinymce.get('forum-quickreply-text').getContent();
+					}
 					var insert = $this.attr('data-forum-insert');
 					var token = $this.attr('data-token');
 					var script = $this.attr("src");
@@ -109,7 +116,14 @@ var e107 = e107 || {'settings': {}, 'behaviors': {}};
 									e107.attachBehaviors();
 								}
 
-								$('#forum-quickreply-text').val('');
+                                if (typeof tinymce == 'undefined')
+                                {
+                                    $('#forum-quickreply-text').val('');
+                                }
+                                else
+                                {
+                                    tinymce.get('forum-quickreply-text').setContent('');
+                                }
 								return;
 							}
 

--- a/e107_plugins/forum/shortcodes/batch/post_shortcodes.php
+++ b/e107_plugins/forum/shortcodes/batch/post_shortcodes.php
@@ -177,7 +177,8 @@ class plugin_forum_post_shortcodes extends e_shortcode
 			$text = '';
 		}
 
-		return e107::getForm()->bbarea('post',$text,'forum');
+		$editor = e107::getPlugPref('forum', 'editor', 'default');
+		return e107::getForm()->bbarea('post',$text,'forum','_common', 'large', array('editor' => $editor));
 
 	}
 

--- a/e107_plugins/forum/shortcodes/batch/view_shortcodes.php
+++ b/e107_plugins/forum/shortcodes/batch/view_shortcodes.php
@@ -1214,10 +1214,11 @@
 					}
 					else
 					{
+						$editor = e107::getPlugPref('forum', 'editor', 'default');
 						$text = "
 						<form action='" . $url . "' method='post'>
 						<div class='form-group'>" .
-						e107::getForm()->bbarea('post','','forum', '_common', 'small', array('id' => 'forum-quickreply-text')) .
+						e107::getForm()->bbarea('post','','forum', '_common', 'small', array('id' => 'forum-quickreply-text', 'editor' => $editor)) .
 						"</div>
 						<div class='center text-center form-group'>
 							<input type='submit' data-token='" . e_TOKEN . "' data-forum-insert='" . $ajaxInsert . "' data-forum-post='" . $this->var['thread_forum_id'] . "' data-forum-thread='" . $this->var['thread_id'] . "' data-forum-action='quickreply' name='reply' value='" . LAN_FORUM_2006 . "' class='btn btn-success button' />

--- a/e107_plugins/forum/shortcodes/batch/view_shortcodes.php
+++ b/e107_plugins/forum/shortcodes/batch/view_shortcodes.php
@@ -1196,17 +1196,38 @@
 					$urlParms = array('f' => 'rp', 'id' => $this->var['thread_id'], 'post' => $this->var['thread_id']);
 					$url = e107::url('forum', 'post', null, array('query' => $urlParms));; // ."?f=rp&amp;id=".$thread->threadInfo['thread_id']."&amp;post=".$thread->threadInfo['thread_id'];
 
-					return "
-					<form action='" . $url . "' method='post'>
-					<div class='form-group'>
-						<textarea cols='80' placeholder='" . LAN_FORUM_2007 . "' rows='4' id='forum-quickreply-text' class='tbox input-xxlarge form-control' name='post' onselect='storeCaret(this);' onclick='storeCaret(this);' onkeyup='storeCaret(this);'></textarea>
-					</div>
-					<div class='center text-center form-group'>
-						<input type='submit' data-token='" . e_TOKEN . "' data-forum-insert='" . $ajaxInsert . "' data-forum-post='" . $this->var['thread_forum_id'] . "' data-forum-thread='" . $this->var['thread_id'] . "' data-forum-action='quickreply' name='reply' value='" . LAN_FORUM_2006 . "' class='btn btn-success button' />
-						<input type='hidden' name='thread_id' value='" . $this->var['thread_id'] . "' />
-					</div>
+					$qr = e107::getPlugPref('forum', 'quickreply', 'default');
+					if ($qr == 'default')
+					{
 
-					</form>";
+						return "
+						<form action='" . $url . "' method='post'>
+						<div class='form-group'>
+							<textarea cols='80' placeholder='" . LAN_FORUM_2007 . "' rows='4' id='forum-quickreply-text' class='tbox input-xxlarge form-control' name='post' onselect='storeCaret(this);' onclick='storeCaret(this);' onkeyup='storeCaret(this);'></textarea>
+						</div>
+						<div class='center text-center form-group'>
+							<input type='submit' data-token='" . e_TOKEN . "' data-forum-insert='" . $ajaxInsert . "' data-forum-post='" . $this->var['thread_forum_id'] . "' data-forum-thread='" . $this->var['thread_id'] . "' data-forum-action='quickreply' name='reply' value='" . LAN_FORUM_2006 . "' class='btn btn-success button' />
+							<input type='hidden' name='thread_id' value='" . $this->var['thread_id'] . "' />
+						</div>
+	
+						</form>";
+					}
+					else
+					{
+						$text = "
+						<form action='" . $url . "' method='post'>
+						<div class='form-group'>" .
+						e107::getForm()->bbarea('post','','forum', '_common', 'small', array('id' => 'forum-quickreply-text')) .
+						"</div>
+						<div class='center text-center form-group'>
+							<input type='submit' data-token='" . e_TOKEN . "' data-forum-insert='" . $ajaxInsert . "' data-forum-post='" . $this->var['thread_forum_id'] . "' data-forum-thread='" . $this->var['thread_id'] . "' data-forum-action='quickreply' name='reply' value='" . LAN_FORUM_2006 . "' class='btn btn-success button' />
+							<input type='hidden' name='thread_id' value='" . $this->var['thread_id'] . "' />
+						</div>
+	
+						</form>";
+
+						return $text;
+					}
 
 					if(E107_DEBUG_LEVEL > 0)
 					{

--- a/e107_plugins/forum/templates/forum_viewtopic_template.php
+++ b/e107_plugins/forum/templates/forum_viewtopic_template.php
@@ -402,7 +402,7 @@ $FORUM_VIEWTOPIC_TEMPLATE['end'] = "</ul>
 	</div>
 </div>
 <div class='row'>
-	<div class='col-xs-12 col-md-6 col-md-offset-3'>
+	<div class='col-xs-12 col-md-8 col-md-offset-2'>
 		{QUICKREPLY}
 	</div>
 </div>

--- a/e107_plugins/tinymce4/e_footer.php
+++ b/e107_plugins/tinymce4/e_footer.php
@@ -13,7 +13,8 @@ if (!defined('e107_INIT')) { exit; }
 $pref = e107::getPref();
 
 
-if((e107::wysiwyg() === true && check_class($pref['post_html'])) || strpos(e_SELF,"tinymce4/admin_config.php") )
+//if((e107::wysiwyg() === true && check_class($pref['post_html'])) || strpos(e_SELF,"tinymce4/admin_config.php") )
+if((e107::wysiwyg(null, true) === 'tinymce4' && check_class($pref['post_html'])) || strpos(e_SELF,"tinymce4/admin_config.php") )
 {
 	if(e_PAGE != 'image.php')
 	{


### PR DESCRIPTION
Now it is possible to have TinyMCE in the backend and SimpleMDE on the forum pages.
wysiwyg() got a new parameter $returnEditor to return the name of the editor.
wysiwyg() now checks if the choosen editor is installed.
Use the bbarea() $options array to define the editor to use e.g. $options['editor'] = 'tinymce4';
Updated forum_admin.php to support SimpleMDE.
Updated tinymce4/e_footer.php to support the new return value (editor name)