### PR TITLE
A new approach to choose wysiwyg editor

### DIFF
--- a/e107_handlers/e107_class.php
+++ b/e107_handlers/e107_class.php
@@ -3627,56 +3627,52 @@ class e107
 
 	/**
 	 * Set or Retrieve WYSIWYG active status. (replaces constant  e_WYSIWYG)
+	 *
 	 * @param bool/string $val if null, return current value, otherwise define editor to use
 	 * @param bool $returnEditor true = return name of active editor, false = return "false" for non wysiwyg editor, return "true" if wysiwyg editor should be used
-	 * @return bool|mixed|void
+	 * @return bool|mixed
 	 */
 	public static function wysiwyg($val=null, $returnEditor=false)
 	{
-		static $editor;
+		static $editor = 'bbcode';
 		static $availEditors;
 		$fallbackEditor = 'bbcode';
-		// Check the general wysiwyg setting
+
 		if (self::getPref('wysiwyg',false) != true)
 		{
+			// wysiwyg disabled by global pref
 			$editor = $fallbackEditor;
-			return $returnEditor ? $editor : false;
 		}
-		if (!isset($editor)) $editor = true;
-		if (!is_null($val))
+		else
 		{
-			$editor = empty($val) ? $fallbackEditor : ($val === 'default' ? true : $val);
-		}
-		// get list of installed wysiwyg editors
-		if (!isset($availEditors))
-		{
-			$availEditors = e107::getPlug()->getInstalledWysiwygEditors();
-			if (count($availEditors)>0) $availEditors = array_keys($availEditors);
-		}
-		// check if choosen editor is installed,
-		// if not, but a different editor is available use that one (e.g. tinymce4 choosen, but only simplemde available available, use simplemde)
-		// if no wysiwyg editor available, use fallback editor (bbcode)
-		if (is_bool($editor) || ($editor !== $fallbackEditor && !in_array($editor, $availEditors)))
-		{
-			$editor = count($availEditors)>0 ? $availEditors[0] : $fallbackEditor;
+			if(!isset($availEditors))
+			{
+				// init list of installed wysiwyg editors
+				$availEditors = array_keys(e107::getPlug()->getInstalledWysiwygEditors());
+			}
+
+			if(!is_null($val))
+			{
+				// set editor if value given
+				$editor = empty($val) ? $fallbackEditor : ($val === 'default' ? true : $val);
+			}
+
+
+			// check if choosen editor is installed,
+			// if not, but a different editor is available use that one (e.g. tinymce4 choosen, but only simplemde available available, use simplemde)
+			// if no wysiwyg editor available, use fallback editor (bbcode)
+			if(is_bool($editor) || ($editor !== $fallbackEditor && !in_array($editor, $availEditors)))
+			{
+				$editor = count($availEditors) > 0 ? $availEditors[0] : $fallbackEditor;
+			}
 		}
 		// $returnEditor => false:
 		// false => fallback editor (bbcode)
 		// true => default wysiwyg editor
 		// $returnEditor => true:
 		// return name of the editor
-		return $returnEditor ? $editor : ($editor === $fallbackEditor || $editor === false ? false : true);
-		/*
-		if(is_null($val))
-		{
-			return self::getRegistry('core/e107/wysiwyg');
-		}
-		else
-		{
-			self::setRegistry('core/e107/wysiwyg',$val);
-			return true;
-		}
-		*/
+		//return $returnEditor ? $editor : ($editor === $fallbackEditor || $editor === false ? false : true);
+		return $returnEditor ? $editor : ($editor !== $fallbackEditor);
 	}
 
 

--- a/e107_handlers/e107_class.php
+++ b/e107_handlers/e107_class.php
@@ -3627,17 +3627,46 @@ class e107
 
 	/**
 	 * Set or Retrieve WYSIWYG active status. (replaces constant  e_WYSIWYG)
-	 * @param bool $val if null, return current value, otherwise set value to registry
-	 * @return bool|mixed
+	 * @param bool/string $val if null, return current value, otherwise define editor to use
+	 * @param bool $returnEditor true = return name of active editor, false = return "false" for non wysiwyg editor, return "true" if wysiwyg editor should be used
+	 * @return bool|mixed|void
 	 */
-	public static function wysiwyg($val=null)
+	public static function wysiwyg($val=null, $returnEditor=false)
 	{
+		static $editor;
+		static $availEditors;
+		$fallbackEditor = 'bbcode';
 		// Check the general wysiwyg setting
 		if (self::getPref('wysiwyg',false) != true)
 		{
-			return false; 	
+			$editor = $fallbackEditor;
+			return $returnEditor ? $editor : false;
 		}
-
+		if (!isset($editor)) $editor = true;
+		if (!is_null($val))
+		{
+			$editor = empty($val) ? $fallbackEditor : ($val === 'default' ? true : $val);
+		}
+		// get list of installed wysiwyg editors
+		if (!isset($availEditors))
+		{
+			$availEditors = e107::getPlug()->getInstalledWysiwygEditors();
+			if (count($availEditors)>0) $availEditors = array_keys($availEditors);
+		}
+		// check if choosen editor is installed,
+		// if not, but a different editor is available use that one (e.g. tinymce4 choosen, but only simplemde available available, use simplemde)
+		// if no wysiwyg editor available, use fallback editor (bbcode)
+		if (is_bool($editor) || ($editor !== $fallbackEditor && !in_array($editor, $availEditors)))
+		{
+			$editor = count($availEditors)>0 ? $availEditors[0] : $fallbackEditor;
+		}
+		// $returnEditor => false:
+		// false => fallback editor (bbcode)
+		// true => default wysiwyg editor
+		// $returnEditor => true:
+		// return name of the editor
+		return $returnEditor ? $editor : ($editor === $fallbackEditor || $editor === false ? false : true);
+		/*
 		if(is_null($val))
 		{
 			return self::getRegistry('core/e107/wysiwyg');
@@ -3646,8 +3675,8 @@ class e107
 		{
 			self::setRegistry('core/e107/wysiwyg',$val);
 			return true;
-		}	
-		
+		}
+		*/
 	}
 
 

--- a/e107_handlers/form_handler.php
+++ b/e107_handlers/form_handler.php
@@ -2352,7 +2352,7 @@ class e_form
 		}
 
 		// auto-height support
-
+/*
 		$bbbar 				= '';
 		$wysiwyg = null;
 		$wysiwygClass = ' e-wysiwyg';
@@ -2368,7 +2368,8 @@ class e_form
 		}
 
 		$options['class'] 	= 'tbox bbarea '.($size ? ' '.$size : '').$wysiwygClass.' e-autoheight form-control';
-
+*/
+		$options['class'] 	= 'tbox bbarea '.($size ? ' '.$size : '').' e-wysiwyg e-autoheight form-control';
 
 		if (isset($options['id']) && !empty($options['id']))
 		{
@@ -2379,8 +2380,13 @@ class e_form
 			$help_tagid 		= $this->name2id($name)."--preview";
 		}
 
+		if (!isset($options['wysiwyg']))
+		{
+			$options['wysiwyg'] = true;
+		}
 
-		if(e107::wysiwyg(true) === false || $wysiwyg === false) // bbarea loaded, so activate wysiwyg (if enabled in preferences)
+		//if(e107::wysiwyg(true) === false || $wysiwyg === false) // bbarea loaded, so activate wysiwyg (if enabled in preferences)
+		if(e107::wysiwyg($options['wysiwyg'],true) === 'bbcode') // bbarea loaded, so activate wysiwyg (if enabled in preferences)
 		{
 			$options['other'] 	= "onselect='storeCaret(this);' onclick='storeCaret(this);' onkeyup='storeCaret(this);' {$height}";
 		}
@@ -2396,7 +2402,7 @@ class e_form
 		<div class='field-spacer'><!-- --></div>\n";
 
 
-		if(e107::wysiwyg() === true && $wysiwyg !== false)
+		if(e107::wysiwyg() === true) // && $wysiwyg !== false)
 		{
 			$eParseList = e107::getConfig()->get('e_parse_list');
 

--- a/e107_handlers/plugin_class.php
+++ b/e107_handlers/plugin_class.php
@@ -127,6 +127,34 @@ class e_plugin
 		return $this;
 	}
 
+	public function getInstalledWysiwygEditors()
+	{
+		$result = array();
+
+		foreach($this->getInstalled() as $k=>$v)
+		{
+			$pl = new e_plugin();
+			$pl->load($k);
+			$keys = $pl->getKeywords();
+			if (is_array($keys))
+			{
+				if (in_array('wysiwyg', $keys['word']))
+				{
+					if (in_array('default', $keys['word']))
+					{
+						$result = array_merge(array($k => $pl->getName()), $result);
+					}
+					else
+					{
+						$result[$k] = $pl->getName();
+					}
+				}
+			}
+
+		}
+		return $result;
+	}
+
 	public function getInstalled()
 	{
 		return $this->_installed;
@@ -226,6 +254,17 @@ class e_plugin
 		}
 
 		return (string) $this->_data[$this->_plugdir]['category'];
+
+	}
+
+	public function getKeywords()
+	{
+		if(!isset($this->_data[$this->_plugdir]['keywords']))
+		{
+			return false;
+		}
+
+		return $this->_data[$this->_plugdir]['keywords'];
 
 	}
 

--- a/e107_handlers/plugin_class.php
+++ b/e107_handlers/plugin_class.php
@@ -131,23 +131,23 @@ class e_plugin
 	{
 		$result = array();
 
-		foreach($this->getInstalled() as $k=>$v)
+		foreach(array_keys($this->_installed) as $k)
 		{
 			$pl = new e_plugin();
 			$pl->load($k);
 			$keys = $pl->getKeywords();
-			if (is_array($keys))
+			// check the keywords
+			if (is_array($keys) && in_array('wysiwyg', $keys['word']))
 			{
-				if (in_array('wysiwyg', $keys['word']))
+				if (in_array('default', $keys['word']))
 				{
-					if (in_array('default', $keys['word']))
-					{
-						$result = array_merge(array($k => $pl->getName()), $result);
-					}
-					else
-					{
-						$result[$k] = $pl->getName();
-					}
+					// add "default" editor to the beginning of the array
+					$result = array_merge(array($k => $pl->getName()), $result);
+				}
+				else
+				{
+					// add all "wysiwyg" editors to the array
+					$result[$k] = $pl->getName();
 				}
 			}
 

--- a/e107_plugins/forum/forum_admin.php
+++ b/e107_plugins/forum/forum_admin.php
@@ -232,12 +232,11 @@ if(!deftrue('OLD_FORUMADMIN'))
 			$this->prefs['editor']['writeParms']['optArray']['default'] = 'System default'; //todo LAN
 			$this->prefs['editor']['writeParms']['optArray']['bbcode'] = 'BBCode';
 
-			//@ global pref should override plugins due to security considerations and allowance of posting html.
-			/*
-			if (e107::isInstalled('tinymce4'))
+			$editors = e107::getPlug()->getInstalledWysiwygEditors();
+			if (!empty($editors))
 			{
-				$this->prefs['editor']['writeParms']['optArray']['tinymce4'] = 'TinyMCE';
-			}*/
+				$this->prefs['editor']['writeParms']['optArray'] = array_merge($this->prefs['editor']['writeParms']['optArray'], $editors);
+			}
 
 			$this->prefs['quickreply']['writeParms']['optArray'] = array(
 				'default' => 'Textarea', //todo LAN

--- a/e107_plugins/forum/shortcodes/batch/post_shortcodes.php
+++ b/e107_plugins/forum/shortcodes/batch/post_shortcodes.php
@@ -179,7 +179,8 @@ class plugin_forum_post_shortcodes extends e_shortcode
 
 		$editor = $this->forum->prefs->get('editor');
 
-		$wysiwyg = ($editor === 'bbcode') ? false : null;
+		//$wysiwyg = ($editor === 'bbcode') ? false : null;
+		$wysiwyg = is_null($editor) ? 'default' : $editor;
 
 		return e107::getForm()->bbarea('post',$text,'forum','_common','large', array('wysiwyg' => $wysiwyg));
 

--- a/e107_plugins/forum/shortcodes/batch/view_shortcodes.php
+++ b/e107_plugins/forum/shortcodes/batch/view_shortcodes.php
@@ -1214,10 +1214,12 @@
 					}
 					else
 					{
+						$editor = $this->forum->prefs->get('editor');
+						$editor = is_null($editor) ? 'default' : $editor;
 						$text = "
 						<form action='" . $url . "' method='post'>
 						<div class='form-group'>" .
-						e107::getForm()->bbarea('post','','forum', '_common', 'small', array('id' => 'forum-quickreply-text')) .
+						e107::getForm()->bbarea('post','','forum', '_common', 'small', array('id' => 'forum-quickreply-text', 'wysiwyg' => $editor)) .
 						"</div>
 						<div class='center text-center form-group'>
 							<input type='submit' data-token='" . e_TOKEN . "' data-forum-insert='" . $ajaxInsert . "' data-forum-post='" . $this->var['thread_forum_id'] . "' data-forum-thread='" . $this->var['thread_id'] . "' data-forum-action='quickreply' name='reply' value='" . LAN_FORUM_2006 . "' class='btn btn-success button' />

--- a/e107_plugins/tinymce4/e_footer.php
+++ b/e107_plugins/tinymce4/e_footer.php
@@ -13,7 +13,7 @@ if (!defined('e107_INIT')) { exit; }
 $pref = e107::getPref();
 
 
-if((e107::wysiwyg() === true && check_class($pref['post_html'])) || strpos(e_SELF,"tinymce4/admin_config.php") )
+if((e107::wysiwyg(null, true) === 'tinymce4' && check_class($pref['post_html'])) || strpos(e_SELF,"tinymce4/admin_config.php") )
 {
 	if(e_PAGE != 'image.php')
 	{

--- a/e107_plugins/tinymce4/plugin.xml
+++ b/e107_plugins/tinymce4/plugin.xml
@@ -3,6 +3,11 @@
 	<author name="e107 Inc." url="http://e107.org" />
 	<description>TinyMce4 CDN version</description>
 	<category>misc</category>
+    <keywords>
+        <word>default</word>
+        <word>editor</word>
+        <word>wysiwyg</word>
+    </keywords>
     <adminLinks>
         <link url='admin_config.php' description='Configure' icon='images/icon_32.png' iconSmall='images/icon_16.png' primary='true' >Configure</link>
     </adminLinks>


### PR DESCRIPTION
Now it is possible to have TinyMCE in the backend and SimpleMDE on the forum pages.
wysiwyg() got a new parameter $returnEditor to return the name of the editor.
wysiwyg() now checks if the choosen editor is installed.
wysiwyg() setting a value is not systemwide anymore (static var instead of registry)
Use the bbarea() $options array to define the editor to use e.g. $options['wysiwyg'] = 'tinymce4';
Updated forum_admin.php to support SimpleMDE.
Updated tinymce4/e_footer.php to support the new return value (editor name)