### PR TITLE
fixes #3179 "Redirect to System not found page" didn't work

### DIFF
--- a/e107_handlers/redirection_class.php
+++ b/e107_handlers/redirection_class.php
@@ -391,7 +391,8 @@ class redirection
 			header('Cache-Control: no-store, no-cache, must-revalidate, post-check=0, pre-check=0', true);
 			header('Expires: Sat, 26 Jul 1997 05:00:00 GMT', true); 
 		}
-		if(null === $http_response_code)
+		// issue #3179 redirect with response code >= 400 doesn't work. Only response codes below 400.
+		if(null === $http_response_code || $http_response_code >= 400)
 		{
 			header('Location: '.$url, $replace);
 		}


### PR DESCRIPTION
"Redirect to System not found page" didn't work because the response code of 404 made the redirect fail. It looks like, that response codes >= 400 are not supported by the header() function together with 'location:'.