### PR TITLE
fixes #3245 eHelper::title2sef() now strips any html or bbcode

### DIFF
--- a/e107_handlers/application.php
+++ b/e107_handlers/application.php
@@ -4690,6 +4690,9 @@ class eHelper
 
 		$tp = e107::getParser();
 
+		// issue #3245: strip all html and bbcode before processing
+		$title = $tp->toText($title);
+
 		$title = $tp->toASCII($title);
 
 		$title = str_replace(array('/',' ',","),' ',$title);

--- a/e107_plugins/forum/forum_admin.php
+++ b/e107_plugins/forum/forum_admin.php
@@ -137,7 +137,7 @@ if(!deftrue('OLD_FORUMADMIN'))
 		protected $fields 		= array (
 			'checkboxes'                =>   array ( 'title' => '', 'type' => null, 'data' => null, 'width' => '5%', 'thclass' => 'center', 'forced' => '1', 'class' => 'center', 'toggle' => 'e-multiselect',  ),
 		    'forum_id'                  =>   array ( 'title' => LAN_ID, 'data' => 'int', 'width' => '5%', 'help' => '', 'readParms' => '', 'writeParms' => '', 'class' => 'left', 'thclass' => 'left',  ),
-		    'forum_name'                =>   array ( 'title' => LAN_TITLE, 'type' => 'method', 'inline'=>true,  'data' => 'str', 'width' => '40%', 'help' => '', 'readParms' => '', 'writeParms' => '', 'class' => 'left', 'thclass' => 'left',  ),
+		    'forum_name'                =>   array ( 'title' => LAN_TITLE, 'type' => 'method', 'inline'=>true,  'data' => 'str', 'width' => '40%', 'help' => FORLAN_223, 'readParms' => '', 'writeParms' => '', 'class' => 'left', 'thclass' => 'left',  ),
 		    'forum_sef'                 =>   array ( 'title' => LAN_SEFURL, 'type' => 'text', 'batch'=>true, 'inline'=>true, 'noedit'=>false, 'data' => 'str', 'width' => 'auto', 'help' => 'Leave blank to auto-generate it from the title above.', 'readParms' => '', 'writeParms' => 'sef=forum_name&size=xxlarge', 'class' => 'left', 'thclass' => 'left',  ),
             'forum_description'         =>   array ( 'title' => LAN_DESCRIPTION, 'type' => 'textarea', 'data' => 'str', 'width' => '30%', 'help' => '', 'readParms' => '', 'writeParms' => '', 'class' => 'left', 'thclass' => 'left',  ),
 			'forum_parent'              =>   array ( 'title' => FORLAN_75, 'type' => 'dropdown', 'data' => 'int', 'width' => '10%', 'help' => '', 'readParms' => '', 'writeParms' => '', 'class' => 'left', 'thclass' => 'left',  ),
@@ -354,9 +354,20 @@ if(!deftrue('OLD_FORUMADMIN'))
 
 			$new_data['forum_order'] = $parentOrder + 50;
 
+			if (!empty($new_data['forum_name']))
+			{
+				// make sure the forum_name contains only plain text, no bbcode or html
+				$new_data['forum_name'] = trim(e107::getParser()->toText($new_data['forum_name']));
+			}
+
 			if(empty($new_data['forum_sef']))
 			{
 				$new_data['forum_sef'] = eHelper::title2sef($new_data['forum_name']);
+			}
+			else
+			{
+				// issue #3245 correct any possible errors/misformatting in the forum_sef
+				$new_data['forum_sef'] = eHelper::title2sef($new_data['forum_sef']);
 			}
 
 			return $new_data;
@@ -378,9 +389,19 @@ if(!deftrue('OLD_FORUMADMIN'))
 
 		public function beforeUpdate($new_data, $old_data, $id)
 		{
+			if (!empty($new_data['forum_name']))
+			{
+				// make sure the forum_name contains only plain text, no bbcode or html
+				$new_data['forum_name'] = trim(e107::getParser()->toText($new_data['forum_name']));
+			}
 			if(empty($new_data['forum_sef']) && !empty($new_data['forum_name']))
 			{
 				$new_data['forum_sef'] = eHelper::title2sef($new_data['forum_name']);
+			}
+			elseif(!empty($new_data['forum_sef']))
+			{
+				// issue #3245 correct any possible errors/misformatting in the forum_sef
+				$new_data['forum_sef'] = eHelper::title2sef($new_data['forum_sef']);
 			}
 
 			return $new_data;

--- a/e107_plugins/forum/languages/English/English_admin.php
+++ b/e107_plugins/forum/languages/English/English_admin.php
@@ -237,5 +237,5 @@ define("FORLAN_219", "Rich Text Editor");
 define("FORLAN_220", "Post editor");
 define("FORLAN_221", "Which editor should be used to create/edit posts?");
 define("FORLAN_222", "Quick reply editor");
-
+define("FORLAN_223", "Use only plain text (no bbcode or html allowed!)")
 ?>


### PR DESCRIPTION
- eHelper::title2sef() now strips any html or bbcode
- forum_admin.php: make sure to strip bbcode and html from forum_name
- forum_admin.php: make sure forum_sef doesn't contain bbcode or html and is properly formatted
- English_admin.php: Added FORLAN_223 = forum_name help text