### PR TITLE
fixes #3377 Enabled "preview" button on forum post edit

### DIFF
--- a/e107_plugins/forum/forum_post.php
+++ b/e107_plugins/forum/forum_post.php
@@ -155,6 +155,7 @@ class forum_post_handler
 				$forumInfo              = $this->forumObj->forumGet($postInfo['post_forum']);
 				$data                   = array_merge($postInfo ,$forumInfo);
 				$data['action']         = $this->action;
+				$data['initial_post']   = $this->forumObj->threadDetermineInitialPost($this->post);
 				$this->setPageTitle($data);
 				return $data;
 				break;
@@ -1025,6 +1026,11 @@ class forum_post_handler
 		$postdate = e107::getDate()->convert_date(time(), "forum");
 		$tsubject = $tp->post_toHTML($_POST['subject'], true);
 		$tpost = $tp->post_toHTML($_POST['post'], true);
+
+		if (empty($tsubject))
+		{
+			$tsubject = $this->data['thread_name'];
+		}
 
 		if ($_POST['poll_title'] != '' && check_class($this->forumObj->prefs->get('poll')))
 		{

--- a/e107_plugins/forum/shortcodes/batch/post_shortcodes.php
+++ b/e107_plugins/forum/shortcodes/batch/post_shortcodes.php
@@ -122,7 +122,7 @@ class plugin_forum_post_shortcodes extends e_shortcode
 		elseif($this->var['action'] == 'edit')
 		{
 			$_POST['subject'] = $this->var['thread_name'];
-			if($this->var['thread_user'] != USERID && !deftrue('MODERATOR'))
+			if($this->var['thread_user'] != USERID && !deftrue('MODERATOR') || !$this->var['initial_post'])
 			{
 				$opts['disabled'] = 1;
 			}
@@ -196,11 +196,11 @@ class plugin_forum_post_shortcodes extends e_shortcode
 			// This user created the thread and is editing the original post.
 			if($this->var['thread_datestamp'] == $this->var['post_datestamp'] && $this->var['thread_user'] == $this->var['post_user'])
 			{
-				return  "<input class='btn btn-primary button' type='submit' name='update_thread' value='".LAN_FORUM_3023."' />";
+				return $ret . "<input class='btn btn-primary button' type='submit' name='update_thread' value='".LAN_FORUM_3023."' />";
 			}
 			else // editing a reply.
 			{
-				return "<input class='btn btn-primary button' type='submit' name='update_reply' value='".LAN_FORUM_3024."' />";
+				return $ret . "<input class='btn btn-primary button' type='submit' name='update_reply' value='".LAN_FORUM_3024."' />";
 			}
 		}
 

--- a/e107_plugins/forum/templates/forum_preview_template.php
+++ b/e107_plugins/forum/templates/forum_preview_template.php
@@ -27,8 +27,9 @@ $FORUM_PREVIEW = "<div>
 
 //v2.x Bootstrap
 $FORUM_PREVIEW_TEMPLATE['item'] = "<div class='alert alert-warning alert-block'>
-									<div><b>{PREVIEW_SUBJECT}</b></div>
-										{PREVIEW_POST}
+									<div><h4>{PREVIEW_SUBJECT}</h4></div>
+									<br>
+									{PREVIEW_POST}
 									</div>";
 
 ?>


### PR DESCRIPTION
- Enabled "preview" button on forum post edit
- Disabled subject if edited post is not the first post of the thread (will display subject of the thread on preview)