### PR TITLE
fixes #3384 added read/unread status to outbox

### DIFF
--- a/e107_plugins/pm/pm.css
+++ b/e107_plugins/pm/pm.css
@@ -1,5 +1,5 @@
 
-tr.pm-unread  { font-weight: bold }
+tr.pm-unread  { font-weight: bold; border-left: 4px solid; }
 
 .pm-show h3 { margin-top:5px }
 .pm-show h3 small { margin-top:5px }

--- a/e107_plugins/pm/templates/pm_template.php
+++ b/e107_plugins/pm/templates/pm_template.php
@@ -185,7 +185,7 @@ $PM_TEMPLATE['outbox']['start'] = "
 
 //$PM_OUTBOX_TABLE = "
 $PM_TEMPLATE['outbox']['item'] = "
-<tr>
+<tr class='{PM_STATUS_CLASS}'>
 	<td class='forumheader3'>{PM_SELECT}</td>
 	<td class='forumheader3'>{PM_ATTACHMENT_ICON}</td>
 	<td class='forumheader3'>{PM_SUBJECT=link,outbox}</td>


### PR DESCRIPTION
- Added read/unread status to outbox
- Updated pm-unread css class to show a thick border on the left side. 
The color for this border may be defined in the theme (default: black)
