### PR TITLE
News Carousel Title Url

### DIFF
--- a/e107_core/shortcodes/batch/news_shortcodes.php
+++ b/e107_core/shortcodes/batch/news_shortcodes.php
@@ -300,6 +300,11 @@ class news_shortcodes extends e_shortcode
 	{
 		return (!empty($parm['link'])) ? $this->sc_newstitlelink($parm) : $this->sc_newstitle($parm);
 	}
+	
+	public function sc_news_title_url($parm=null)
+	{
+		return (!empty($parm['link'])) ? $this->sc_newstitlelink($parm) : $this->sc_newsurltitle($parm);
+	}
 
 	public function sc_news_body($parm=null)
 	{

--- a/e107_plugins/news/templates/news_menu_template.php
+++ b/e107_plugins/news/templates/news_menu_template.php
@@ -116,7 +116,7 @@ $NEWS_MENU_TEMPLATE['carousel']['item'] = '<!-- Start Item -->
 									          {NEWS_IMAGE: class=img-responsive img-fluid}
 									           <div class="carousel-caption">
 									            <small>{NEWS_DATE=dd MM, yyyy}</small>
-									            <h1>{NEWS_TITLE}</h1>
+									            <h1>{NEWS_TITLE_URL}</h1>
 
 									          </div>
 									        </div><!-- End Item -->';


### PR DESCRIPTION
Modify news batch, added sc_news_title_url - then changed in e107plugins>news>templates>news_menu carousel - from using {NEWS_TITLE} to {NEWS_TITLE_URL} - this is to give the title of the news a link(url) for people to click on to go to the news item