### PR TITLE
fixes #3394 Moved loading of e_bb after the loading of the templates

### DIFF
--- a/e107_handlers/bbcode_handler.php
+++ b/e107_handlers/bbcode_handler.php
@@ -551,18 +551,18 @@ class e_bbcode
 
 		require(e107::coreTemplatePath('bbcode')); //correct way to load a core template.
 
-		$pref = e107::getPref('e_bb_list');
-		    
-		if (!empty($pref)) // Load the Plugin bbcode AFTER the templates, so they can modify or replace.
-		{
-			foreach($pref as $val)
-			{
-				if(is_readable(e_PLUGIN.$val."/e_bb.php"))
-				{
-					require(e_PLUGIN.$val."/e_bb.php");
-				}
-			}
-		}
+//		$pref = e107::getPref('e_bb_list');
+//
+//		if (!empty($pref)) // Load the Plugin bbcode AFTER the templates, so they can modify or replace.
+//		{
+//			foreach($pref as $val)
+//			{
+//				if(is_readable(e_PLUGIN.$val."/e_bb.php"))
+//				{
+//					require(e_PLUGIN.$val."/e_bb.php");
+//				}
+//			}
+//		}
 	
 		$temp = array();
 	    $temp['news'] 		= $BBCODE_TEMPLATE_NEWSPOST;
@@ -606,8 +606,21 @@ class e_bbcode
 	//	{
 		//	$BBCODE_TEMPLATE = $BBCODE_TEMPLATE;
 	//	}
-	
-		
+
+
+		$pref = e107::getPref('e_bb_list');
+
+		if (!empty($pref)) // Load the Plugin bbcode AFTER the templates, so they can modify or replace.
+		{
+			foreach($pref as $val)
+			{
+				if(is_readable(e_PLUGIN.$val."/e_bb.php"))
+				{
+					require(e_PLUGIN.$val."/e_bb.php");
+				}
+			}
+		}
+
 		$bbcode_shortcodes = e107::getScBatch('bbcode');	
 				
 		$data = array(


### PR DESCRIPTION
e_bb was loaded before the final template was assigned, which eventually overwrote the e_bb contents.
Now this works again, but the only template that can be manipulated is `$BBCODE_TEMPLATE`, because this is the name of the final template var that get's assigned. All others will be ignored.