### PR TITLE
Fix ampersand handling in the legacy rating method

### DIFF
--- a/rate.php
+++ b/rate.php
@@ -17,7 +17,7 @@ e107::includeLan(e_LANGUAGEDIR.e_LANGUAGE.'/lan_'.e_PAGE);
 
 if(!e_AJAX_REQUEST) // Legacy method. 
 {	
-	$qs = explode("^", e_QUERY);
+	$qs = explode("^", str_replace('&amp;', '&', e_QUERY));
 	
 	if (!$qs[0] || USER == FALSE || $qs[3] > 10 || $qs[3] < 1 || strpos($qs[2], '://') !== false)
 	{


### PR DESCRIPTION
There seems to be a problem with `e_QUERY` such that all the query ampersands (`&`) become `&amp;`s. It gets temporary fixes in many places, such as [the line 2946](https://github.com/e107inc/e107/blob/master/e107_admin/users.php#L2946) of `e107_admin/users.php`.

However, the legacy method contained in `rate.php`, still used by some of the otherwise working plugins, has never been patched, and possibly redirects users to URLs that don't work. This pull request aims to change that, hopefully for the better.