### PR TITLE
Fix language editor wrongly parsing HTML entities

### DIFF
--- a/e107_admin/lancheck.php
+++ b/e107_admin/lancheck.php
@@ -1849,7 +1849,7 @@ class lancheck
 			<td style='width:40%;vertical-align:top'>".htmlentities(str_replace("ndef++","",$trans['orig'][$sk])) ."</td>";
 			$text .= "<td class='forumheader3' style='width:50%;vertical-align:top'>";
 			$text .= ($writable) ? "<textarea  class='input-xxlarge' name='newlang[]' rows='$rowamount' cols='45' style='height:100%'>" : "";
-			$text .= str_replace("ndef++","",$trans['tran'][$sk]);
+			$text .= htmlentities(str_replace("ndef++","",$trans['tran'][$sk]));
 			$text .= ($writable) ? "</textarea>" : "";
 			//echo "orig --> ".$trans['orig'][$sk]."<br />";
 			if (strpos($trans['orig'][$sk],"ndef++") !== False)


### PR DESCRIPTION
Quite counterintuitively, when a HTML text area receives HTML entities, it converts them to the corresponding characters. At the same time, when it is a part of a form, said corresponding characters get submitted, and not the entities.

The language editor built into the e107 admin panel has however omitted this fact. Because of that, a problem involving `&amp;lt;whatever&amp;gt;` getting converted to `&lt;whatever&gt;`, which is correct, and on the next edit `&lt;whatever&gt;` getting converted to `<whatever>`, which is obviously incorrect, may occur. I believe this to be the direct cause of [this rather problematic mistake](https://github.com/e107translations/Polish/blob/3b0c26ced5553306e76c8786f2d69e08a479b52a/e107_languages/Polish/admin/lan_prefs.php#L201) slipping into the Polish e107 language pack.

This pull request should hopefully fix that issue.