### PR TITLE
Fixes #3437 – e_form::inlineToken() performance

### DIFF
--- a/e107_handlers/form_handler.php
+++ b/e107_handlers/form_handler.php
@@ -67,7 +67,7 @@ class e_form
 	protected $_tabindex_enabled = true;
 	protected $_cached_attributes = array();
 	protected $_field_warnings = array();
-
+    protected $_inline_token = null;
 
 	/**
 	 * @var user_class
@@ -4420,7 +4420,9 @@ class e_form
 	 */
 	private function inlineToken()
 	{
-		return password_hash(session_id(), PASSWORD_DEFAULT);
+		$this->_inline_token = $this->_inline_token ?:
+			password_hash(session_id(), PASSWORD_DEFAULT, ['cost' => 04]);
+		return $this->_inline_token;
 	}
 
 	/**


### PR DESCRIPTION
This "inline token" is generated 30 times in my test, but it's the same `session_id()` being hashed. This is wasteful and can be mitigated in two ways:

* Reducing the time cost like so: `return password_hash(session_id(), PASSWORD_DEFAULT, ['cost' => 04]);`
* Storing the hash as an instance variable the first time it's generated

This pull request applies both mitigations.