### PR TITLE
Fixes #3450 – SITELINKS_ALT parent button fix

### DIFF
--- a/e107_core/shortcodes/single/sitelinks_alt.php
+++ b/e107_core/shortcodes/single/sitelinks_alt.php
@@ -68,7 +68,11 @@ class sitelinks_alt
 			}
 			else
 			{
-				$link_icon = $lk['link_button'] ? e_IMAGE_ABS.'icons/'.$lk['link_button'] : $icon;
+				$link_icon = $lk['link_button']
+					? (($lk['link_button'][0] == "{")
+						? $tp->replaceConstants($lk['link_button'],'abs')
+						: e_IMAGE_ABS.'icons/'.$lk['link_button'])
+					: $icon;
 			}
 			
 			$main_linkid = $lk['link_id'];


### PR DESCRIPTION
Parent links in `sitelinks_alt::sitelinks_alt_shortcode()` now have their button image URI parsed by `e_parse::replaceConstants()`, bringing it into consistency with the children, which are already parsed the same way.

There is no corresponding test for this in [e107-test](https://github.com/e107inc/e107-test) because hard-coded dependencies in `sitelinks_alt::sitelinks_alt_shortcode()` are difficult to monkey-patch without crippling the performance of e107-test.