### PR TITLE
Matching scope for e_form::$_inline_token

### DIFF
--- a/e107_handlers/form_handler.php
+++ b/e107_handlers/form_handler.php
@@ -67,7 +67,7 @@ class e_form
 	protected $_tabindex_enabled = true;
 	protected $_cached_attributes = array();
 	protected $_field_warnings = array();
-    protected $_inline_token = null;
+	private $_inline_token = null;
 
 	/**
 	 * @var user_class


### PR DESCRIPTION
Should be private to match `private function inlineToken()`