### PR TITLE
FIX check if user has moderator permissions for the thread/forum

### DIFF
--- a/e107_plugins/forum/languages/English/English_front.php
+++ b/e107_plugins/forum/languages/English/English_front.php
@@ -345,6 +345,7 @@ define("LAN_FORUM_8026", "Failed to unstick thread");
 define("LAN_FORUM_8027", "No action selected");
 define("LAN_FORUM_8028", "Return"); 
 define("LAN_FORUM_8029", "New topic created!");
+define("LAN_FORUM_8030", "Couldn't delete post (moderator permission needed)");
 
 /*  THIS WILL BE DELETED ONCE THE REWRITE IS DONE
 ==================================================

--- a/e107_plugins/forum/shortcodes/batch/view_shortcodes.php
+++ b/e107_plugins/forum/shortcodes/batch/view_shortcodes.php
@@ -889,7 +889,7 @@
 				//	if(!$this->forum->threadDetermineInitialPost($this->postInfo['post_id']))
 				if(empty($this->postInfo['thread_start']))
 				{
-					$text .= "<li class='text-right'><a href='" . e_REQUEST_URI . "' data-forum-action='deletepost' data-forum-post='" . $this->postInfo['post_id'] . "'>" . LAN_DELETE . " " . $tp->toGlyph('trash') . "</a></li>";
+					$text .= "<li class='text-right'><a href='" . e_REQUEST_URI . "' data-forum-action='deletepost' data-forum-thread='" . $this->postInfo['post_thread'] . "' data-forum-post='" . $this->postInfo['post_id'] . "'>" . LAN_DELETE . " " . $tp->toGlyph('trash') . "</a></li>";
 				}
 
 				if($type == 'thread')


### PR DESCRIPTION
Without admin permissions (member of user class 254) it was not possible
to delete a post in the forum. This fix add the threadId to the ajax query
and fetchs the forum-moderator for the thread which will then checked
against the user permissions/classes.

I added also an additional error message, if something goes wrong.