### PR TITLE
Do not trim language editor translation whitespaces

### DIFF
--- a/e107_admin/lancheck.php
+++ b/e107_admin/lancheck.php
@@ -1922,7 +1922,7 @@ class lancheck
 			$retloc[$type][$locale[1]]= $locale[2];	
 		}
 				
-		if(preg_match_all('/^\s*?define\s*?\(\s*?(\'|\")([\w]+)(\'|\")\s*?,\s*?(\'|\")([\s\S]*?)\s*?(\'|\")\s*?\)\s*?;/im',$data,$matches))
+		if(preg_match_all('/^\s*?define\s*?\(\s*?(\'|\")([\w]+)(\'|\")\s*?,\s*?(\'|\")([\s\S]*?)(\'|\")\s*?\)\s*?;/im',$data,$matches))
 		{
 			$def = $matches[2];
 			$values = $matches[5];	


### PR DESCRIPTION
Currently, when there are whitespaces at the ends of translations, e.g. `define("LAN_ONLINE_1", "Guests: ");`, they get trimmed in the language editor. This causes two kinds of problems: one about the original translations not getting accurately presented when they actually do contain whitespaces at the trimmed location, and the other about the translations added by translators getting the whitespaces removed the second time they are saved.

As far as I'm aware, this issue might be the cause of [that](https://github.com/e107inc/e107/blob/3a74aea669f41abf11f1270e1439443af65b1454/e107_plugins/online/languages/English.php#L22) [discrepancy](https://github.com/e107translations/Polish/blob/dc5d73fef5a8bffe436fc046a6fea5573d8fb3c7/e107_plugins/online/languages/Polish.php#L16) in the Polish e107 language pack, and sure slowed down my ~still awfully slow~ efforts in order to get the pack up to date somewhat. :slightly_smiling_face:

This change should hopefully fix that.