### PR TITLE
Don't wipe out shortcodes discovered earlier

### DIFF
--- a/e107_handlers/shortcode_handler.php
+++ b/e107_handlers/shortcode_handler.php
@@ -763,8 +763,7 @@ class e_parse_shortcode
 		$saveVars = $this->eVars; // In case of nested call
 		$saveCodes = $this->addedCodes;
 		$this->eVars = $eVars;
-		$this->addedCodes = NULL;
-		
+
 		// former $sc_style - do it once here and not on every doCode loop - performance
 
 		$this->sc_style = e107::scStyle(); 	//FIXME - BC Problems and conflicts.


### PR DESCRIPTION
## Issues Fixed

Anyone calling `e_parse::parseTemplate()` or `e_parse_shortcode::parseCodes()` can now use the "`e_parse_shortcode::$addedCodes`" already registered globally without passing in a shortcode object.

## Regression Potential

[e107-test](https://github.com/e107inc/e107-test) only has two tests covering the affected areas of this pull request:

- [`e_formTest::testRenderElement()`](https://github.com/e107inc/e107-test/blob/e9e9f6288ea6b2226e22efbff302a25b5f0623cd/tests/unit/e_formTest.php#L813)
- [`pluginsTest::testBanner()`](https://github.com/e107inc/e107-test/blob/e9e9f6288ea6b2226e22efbff302a25b5f0623cd/tests/unit/pluginsTest.php#L121)

The tests still pass after applying this pull request, but it is not known what this 7.627-year old regression could impact.

Only calls to `e_parse::parseTemplate()` and `e_parse_shortcode::parseCodes()` that do **not** specify a third argument, the optional `$extraCodes`, or specify `$extraCodes` as not an array or an object have regression potential.

Regression behavior is hard to determine or predict.  I advise monitoring new issues with reproduction steps and bisecting to determine if this change caused the new issues.

It is unknown why `e_parse_shortcode::$addedCodes` was wiped out (pointed to `NULL`) in `e_parse_shortcode::parseCodes()`, but it seems to have forced most calls to `e_parse::parseTemplate()` and `e_parse_shortcode::parseCodes()` to specify the `$extraCodes` argument.

----

Fixes: #3547