### PR TITLE
Fix #3338 - marked more than one forum as read

### DIFF
--- a/e107_plugins/forum/forum_class.php
+++ b/e107_plugins/forum/forum_class.php
@@ -1586,6 +1586,7 @@ class e107forum
 		$tmp = array_unique($_tmp);
 		// issue #3338 fixed typo, that caused issue with not marking threads are read
 		$viewed = trim(implode(',', $tmp), ',');
+		$currentUser['user_plugin_forum_viewed'] =  $viewed;
 		return e107::getDb()->update('user_extended', "user_plugin_forum_viewed = '{$viewed}' WHERE user_extended_id = ".USERID);
 	}
 


### PR DESCRIPTION
Because $currentUser['user_plugin_forum_viewed'] is not refreshed after adding one thread,  it's still the same and only last thread is changed