### PR TITLE
fixes #3579 shortcodes, lans for GDPR links on signup page.

### DIFF
--- a/e107_core/shortcodes/batch/signup_shortcodes.php
+++ b/e107_core/shortcodes/batch/signup_shortcodes.php
@@ -609,6 +609,53 @@ class signup_shortcodes extends e_shortcode
 
 	}
 
+	/**
+	 * Create Privacy policy link
+	 * @example {SIGNUP_GDPR_PRIVACYPOLICY_LINK}
+	 * @example {SIGNUP_GDPR_PRIVACYPOLICY_LINK: class=label label-info}
+	 */
+	function sc_signup_gdpr_privacypolicy_link($parm='')
+	{
+		$pp = e107::getPref('gdpr_privacypolicy', '');
+		if (!$pp)
+		{
+			return '';
+		}
+		$pp = e107::getParser()->replaceConstants($pp, 'full');
+		$class = (!empty($parm['class'])) ? $parm['class'] : '';
+		$text = sprintf('<span class="%s"><a href="%s" target="_blank">%s</a></span>', $class, $pp, LAN_SIGNUP_122);
+		return $text;
+	}
+
+	/**
+	 * Create Terms and conditions link
+	 * @example {SIGNUP_GDPR_TERMSANDCONDITIONS_LINK}
+	 * @example {SIGNUP_GDPR_TERMSANDCONDITIONS_LINK: class=label label-info}
+	 */
+	function sc_signup_gdpr_termsandconditions_link($parm='')
+	{
+		$pp = e107::getPref('gdpr_termsandconditions', '');
+		if (!$pp)
+		{
+			return '';
+		}
+		$pp = e107::getParser()->replaceConstants($pp, 'full');
+		$class = (!empty($parm['class'])) ? $parm['class'] : '';
+		$text = sprintf('<span class="%s"><a href="%s" target="_blank">%s</a></span>', $class, $pp, LAN_SIGNUP_123);
+		return $text;
+	}
+
+	/**
+	 * Print message "By signing up you agree to our Privacy policy and our Terms and conditions."
+	 * @example {SIGNUP_GDPR_INFO}
+	 */
+	function sc_signup_gdpr_info()
+	{
+		$text = e107::getParser()->lanVars(LAN_SIGNUP_124,
+			array($this->sc_signup_gdpr_privacypolicy_link(), $this->sc_signup_gdpr_termsandconditions_link()));
+		return $text;
+	}
+
 }
 
 ?>

--- a/e107_core/templates/signup_template.php
+++ b/e107_core/templates/signup_template.php
@@ -243,6 +243,13 @@ if(!defined($SIGNUP_BODY))
 			{SIGNUP_SIGNATURE}
 			{SIGNUP_IMAGES}
 			{SIGNUP_IMAGECODE}
+			
+			<tr style='vertical-align:top'>
+				<td class='forumheader' colspan='2'  style='text-align:center'>
+					{SIGNUP_GDPR_INFO}
+				</td>
+			</tr>
+			
 			<tr style='vertical-align:top'>
 				<td class='forumheader' colspan='2'  style='text-align:center'>
 					<input class='button btn btn-success' type='submit' name='register' value=\"".LAN_SIGNUP_79."\" />

--- a/e107_languages/English/lan_signup.php
+++ b/e107_languages/English/lan_signup.php
@@ -161,3 +161,7 @@ define("LAN_SIGNUP_118", "To [x]");
 define("LAN_SIGNUP_119", "Don't send email");
 define("LAN_SIGNUP_120", "OR");
 define("LAN_SIGNUP_121", "Use a different email address");
+
+define("LAN_SIGNUP_122", "Privacy Policy");
+define("LAN_SIGNUP_123", "Terms and conditions");
+define("LAN_SIGNUP_124", "By signing up you agree to our [x] and our [y].");


### PR DESCRIPTION
Added shortcodes and lans to display GDPR links on signup page.
Updated signup template

![grafik](https://user-images.githubusercontent.com/7572616/51076185-6f044600-1695-11e9-958f-86060ee84cd0.png)
