### PR TITLE
Enhance 'user_forum_post_report' event data set & Fix 'user_forum_post_report' notification email not sent bug.

### DIFF
--- a/e107_plugins/forum/e_notify.php
+++ b/e107_plugins/forum/e_notify.php
@@ -358,10 +358,11 @@ class forum_notify extends notify
 		}
 		else
 		{
-			$message = $data;
+			$message = $data['notify_message'];
 		}
 
-		$this->send('forum_post_rep', LAN_FORUM_NT_11, $message);
+		$this->send('user_forum_post_report', LAN_FORUM_NT_11, $message);
+		return true;
 	}
 	
 }

--- a/e107_plugins/forum/forum_post.php
+++ b/e107_plugins/forum/forum_post.php
@@ -314,10 +314,18 @@ class forum_post_handler
 
 		$report = LAN_FORUM_2018." ".SITENAME." : ".$link . "\n
 					".LAN_FORUM_2019.": ".USERNAME. "\n" . $report_add;
-		//$subject = LAN_FORUM_2020." ". SITENAME;
 
-		//e107::getNotify()->send('forum_post_rep', $subject, $report);
-		e107::getEvent()->trigger('user_forum_post_report', $report);
+		$eventData = array(
+			'reporter_id' => USERID,
+			'reporter_name' => USERNAME,
+			'report_time' => $insert['gen_datestamp'],
+			'thread_id' => $insert['gen_intdata'],
+			'thread_name' => $insert['gen_ip'],
+			'report_message' => $report_add,
+			'notify_message' => $report
+		);
+
+		e107::getEvent()->trigger('user_forum_post_report', $eventData);
 		e107::getRender()->tablerender(LAN_FORUM_2023, $text, 'forum-post-report');
 	}
 


### PR DESCRIPTION
This pull request makes the following changes:
- Enrich 'user_forum_post_report' event data set with useful data.
- Fix a bug which prevented 'user_forum_post_report' notification email being sent successfully by e107 'notify' handler.