### PR TITLE
issue #3619: Missing moderator ids on forum move

### DIFF
--- a/e107_plugins/forum/forum_post.php
+++ b/e107_plugins/forum/forum_post.php
@@ -69,7 +69,7 @@ class forum_post_handler
 
 		// issue #3619: In case the post id is not set
 		// use the thread id to look for the moderator ids
-		if (isset($this->post))
+		if (!empty($this->post))
 		{
 			$moderatorUserIds = $forum->getModeratorUserIdsByPostId($this->post);
 		}

--- a/e107_plugins/forum/forum_post.php
+++ b/e107_plugins/forum/forum_post.php
@@ -820,9 +820,8 @@ class forum_post_handler
 
 		if(!deftrue('MODERATOR'))
 		{
-			// todo: LAN for new error message
 			$mes = e107::getMessage();
-			echo $mes->addWarning('You do not have access to this area!')->render();
+			echo $mes->addWarning(LAN_NO_PERMISSIONS)->render();
 			return;
 		}
 

--- a/e107_plugins/forum/forum_post.php
+++ b/e107_plugins/forum/forum_post.php
@@ -67,7 +67,17 @@ class forum_post_handler
 		$this->post     = (int) $_GET['post']; // post ID if needed.
 
 
-		$moderatorUserIds = $forum->getModeratorUserIdsByPostId($this->post);
+		// issue #3619: In case the post id is not set
+		// use the thread id to look for the moderator ids
+		if (isset($this->post))
+		{
+			$moderatorUserIds = $forum->getModeratorUserIdsByPostId($this->post);
+		}
+		else
+		{
+			$moderatorUserIds = $forum->getModeratorUserIdsByThreadId($this->id);
+		}
+
 		define('MODERATOR', (USER && in_array(USERID, $moderatorUserIds)));
 
 
@@ -802,8 +812,17 @@ class forum_post_handler
 	 */
 	private function renderFormMove()
 	{
+		if (isset($_POST['forum_move']))
+		{
+			// Forum just moved. No need to display the forum move form again.
+			return;
+		}
+
 		if(!deftrue('MODERATOR'))
 		{
+			// todo: LAN for new error message
+			$mes = e107::getMessage();
+			echo $mes->addWarning('You do not have access to this area!')->render();
 			return;
 		}
 


### PR DESCRIPTION
In case the post id is not set use the thread id to look for the moderator ids