### PR TITLE
Add chatbox_menu_template.php and chatbox_menu_shortcodes.php for chatbox_menu plugin.

### DIFF
--- a/e107_plugins/chatbox_menu/chat.php
+++ b/e107_plugins/chatbox_menu/chat.php
@@ -6,67 +6,79 @@
  * Released under the terms and conditions of the
  * GNU General Public License (http://www.gnu.org/licenses/gpl.txt)
  *
- */
-
+ * e107 chatbox_menu Plugin
+ *
+*/
 require_once('../../class2.php');
-if (!e107::isInstalled('chatbox_menu')) 
-{
+if ( ! e107::isInstalled('chatbox_menu')) {
 	e107::redirect();
 	exit;
 }
 
-e107::lan('chatbox_menu',e_LANGUAGE);
+e107::lan('chatbox_menu', e_LANGUAGE);
 
 require_once(HEADERF);
 $mes = e107::getMessage();
-$sql->select("menus", "*", "menu_name='chatbox_menu'");
+$sql->select('menus', "*", "menu_name='chatbox_menu'");
 $row = $sql->fetch();
 
-if (!check_class(intval($row['menu_class'])))
-{
-	$mes->addError(CHATBOX_L24); 
+if ( ! check_class((int)$row['menu_class'])) {
+	$mes->addError(CHATBOX_L24);
 	$ns->tablerender(LAN_ERROR, $mes->render());
 	require_once(FOOTERF);
 	exit;
 }
 
-if(!isset($pref['cb_mod']))
-{
+if ( ! isset($pref['cb_mod'])) {
 	$pref['cb_mod'] = e_UC_ADMIN;
 }
 
+define('CB_MOD', check_class($pref['cb_mod']));
 
-define("CB_MOD", check_class($pref['cb_mod']));
+if ( ! empty($_POST['moderate']) && CB_MOD) {
 
+	if (isset($_POST['block'])) {
 
-if(!empty($_POST['moderate']) && CB_MOD)
-{
-	if(isset($_POST['block']))
-	{
-		foreach(array_keys($_POST['block']) as $k){ $kk[] = intval($k); }
+		foreach (array_keys($_POST['block']) as $k) {
+			$kk[] = intval($k);
+		}
+
 		$blocklist = implode(",", $kk);
 		$sql->gen("UPDATE #chatbox SET cb_blocked=1 WHERE cb_id IN ({$blocklist})");
 	}
 
-	if(isset($_POST['unblock']))
-	{
-		foreach(array_keys($_POST['unblock']) as $k){ $kk[] = intval($k); }
+
+	if (isset($_POST['unblock'])) {
+
+		foreach (array_keys($_POST['unblock']) as $k) {
+			$kk[] = intval($k);
+		}
+
 		$unblocklist = implode(",", $kk);
 		$sql->gen("UPDATE #chatbox SET cb_blocked=0 WHERE cb_id IN ({$unblocklist})");
 	}
 
-	if(isset($_POST['delete']))
-	{
+
+	if (isset($_POST['delete'])) {
+
 		$deletelist = implode(",", array_keys($_POST['delete']));
-		$sql -> db_Select_gen("SELECT c.cb_id, u.user_id FROM #chatbox AS c
+
+		$query = "SELECT c.cb_id, u.user_id FROM #chatbox AS c
 		LEFT JOIN #user AS u ON SUBSTRING_INDEX(c.cb_nick,'.',1) = u.user_id
-		WHERE c.cb_id IN (".$deletelist.")");
-		$rowlist = $sql -> db_getList();
+		WHERE c.cb_id IN (" . $deletelist . ")";
+
+		$sql->gen($query);
+
+		$rowlist = $sql->rows();
+
 		foreach ($rowlist as $row) {
-			$sql->gen("UPDATE #user SET user_chats=user_chats-1 where user_id = ".intval($row['user_id']));
+		    $userId = (int)$row['user_id'];
+			$sql->gen("UPDATE #user SET user_chats=user_chats-1 WHERE user_id = {$userId} ");
 		}
+
 		$sql->gen("DELETE FROM #chatbox WHERE cb_id IN ({$deletelist})");
 	}
+
 	e107::getCache()->clear("nq_chatbox");
 	$mes->addSuccess(CHATBOX_L18);
 }
@@ -75,127 +87,98 @@ if(!empty($_POST['moderate']) && CB_MOD)
 
 $fs = false;
 
-if (strstr(e_QUERY, "fs")) 
-{
+if (strstr(e_QUERY, "fs")) {
 	$cgtm = intval(str_replace(".fs", "", e_QUERY));
 	$fs = true;
 }
 // end search
 
-if (e_QUERY ? $from = intval(e_QUERY) : $from = 0);
+if (e_QUERY ? $from = intval(e_QUERY) : $from = 0) {
+	;
+}
 
 $chat_total = $sql->count('chatbox');
 
 $qry_where = (CB_MOD ? "1" : "cb_blocked=0");
 
+
+
 // when coming from search.php calculate page number
-if ($fs) 
-{
+if ($fs) {
+
 	$page_count = 0;
 	$row_count = 0;
+
 	$sql->select("chatbox", "*", "{$qry_where} ORDER BY cb_datestamp DESC");
-	while ($row = $sql->fetch()) 
-	{
-		if ($row['cb_id'] == $cgtm) 
-		{
+
+	while ($row = $sql->fetch()) {
+
+		if ($row['cb_id'] == $cgtm) {
 			$from = $page_count;
 			break;
 		}
+
 		$row_count++;
-		if ($row_count == 30) 
-		{
+		if ($row_count == 30) {
 			$row_count = 0;
 			$page_count += 30;
 		}
+
 	}
 }
 // end search
 
-$sql->select("chatbox", "*", "{$qry_where} ORDER BY cb_datestamp DESC LIMIT ".intval($from).", 30");
+
+/** Render chat posts **/
+$sql->select("chatbox", "*",
+	"{$qry_where} ORDER BY cb_datestamp DESC LIMIT " . intval($from) . ", 30");
+
 $obj2 = new convert;
 
-$chatList = $sql->db_getList();
+$chatList = $sql->rows();
+
 $frm = e107::getForm();
-$vars = array();
+$vars = [];
 $flag = false;
 
-if (empty($CHAT_TABLE))
-{
-	if (file_exists(THEME."chat_template.php"))
-	{
-		require_once(THEME."chat_template.php");
-	}
-	else
-	{
-		require_once(e_PLUGIN."chatbox_menu/chat_template.php");
-	}
-}
+
+
+$CHATBOX_LIST_TEMPLATE =
+	e107::getTemplate('chatbox_menu', 'chatbox_menu', 'list');
+
+$sc = e107::getScBatch('chatbox_menu', true);
+
 
 $textstring = '';
 
-foreach ($chatList as $row)
-{
-	$vars['CHAT_TABLE_DATESTAMP'] = $tp->toDate($row['cb_datestamp'], "relative");
-	$vars['CHAT_TABLE_NICK'] = preg_replace("/[0-9]+\./", "", $row['cb_nick']);
+foreach ($chatList as $row) {
 
-	$cb_message = $tp->toHTML($row['cb_message'], TRUE,'USER_BODY');
+	$sc->setVars($row);
 
-	if($row['cb_blocked'])
-	{
-		$cb_message .= "<br />".CHATBOX_L25;
-	}
-
-	if(CB_MOD)
-	{
-		$id = $row['cb_id'];
-		$cb_message .= "<div class='checkbox'>";
-
-		$cb_message .= $frm->checkbox('delete['.$id.']',1, false, array('inline'=>true,'label'=>LAN_DELETE));
-
-		if($row['cb_blocked'])
-		{
-			$cb_message .= $frm->checkbox('unblock['.$id.']',1, false, array('inline'=>true, 'label'=> CHATBOX_L7));
-		}
-		else
-		{
-			$cb_message .= $frm->checkbox('block['.$id.']',1, false,  array('inline'=>true, 'label'=> CHATBOX_L9));
-		}
-
-		$cb_message .= "</div>";
-	}
-
-	$vars['CHAT_TABLE_MESSAGE'] = $cb_message;
-	$vars['CHAT_TABLE_FLAG'] = ($flag ? "forumheader3" : "forumheader4");
-
-
-//	$textstring .= preg_replace("/\{(.*?)\}/e", '$\1', $CHAT_TABLE);
-	$textstring .= $tp->parseTemplate($CHAT_TABLE, true, $vars);
-	$flag = (!$flag ? true : false);
+	$textstring .= $tp->parseTemplate($CHATBOX_LIST_TEMPLATE['item'], false, $sc);
 }
 
 
-//print_a($CHAT_TABLE);
+$textstart = $tp->parseTemplate($CHATBOX_LIST_TEMPLATE['start'], true, $sc);
+$textend = $tp->parseTemplate($CHATBOX_LIST_TEMPLATE['end'], true, $sc);
+
+$text = $textstart . $textstring . $textend;
 
 
-//$textstart = preg_replace("/\{(.*?)\}/e", '$\1', $CHAT_TABLE_START);
-//$textend = preg_replace("/\{(.*?)\}/e", '$\1', $CHAT_TABLE_END);
+if (CB_MOD) {
 
-$textstart = $tp->parseTemplate($CHAT_TABLE_START, true, $vars);
-$textend = $tp->parseTemplate($CHAT_TABLE_END, true, $vars);
-$text = $textstart.$textstring.$textend;
+	$text =
+		"<form method='post' action='" . e_SELF . "'>"
+		. $text .
+		"<input type='submit' class='btn btn-danger btn-secondary button pull-right' name='moderate' value='" . CHATBOX_L13 . "' />
+		</form>";
 
-if(CB_MOD)
-{
-	$text = "<form method='post' action='".e_SELF."'>".$text."<input type='submit' class='btn btn-default btn-secondary button' name='moderate' value='".CHATBOX_L13."' /></form>";
 }
 
-$parms = "{$chat_total},30,{$from},".e_SELF.'?[FROM]';
-$text .= "<div class='nextprev'>".$tp->parseTemplate("{NEXTPREV={$parms}}").'</div>';
+$parms = "{$chat_total},30,{$from}," . e_SELF . '?[FROM]';
 
+$text .= "<div class='nextprev'>" . $tp->parseTemplate("{NEXTPREV={$parms}}") . '</div>';
 
-$ns->tablerender(CHATBOX_L20, $mes->render().$text);
-
-
+$ns->tablerender(CHATBOX_L20, $mes->render() . $text);
 
 require_once(FOOTERF);
-?>

--- a/e107_plugins/chatbox_menu/chatbox_menu.php
+++ b/e107_plugins/chatbox_menu/chatbox_menu.php
@@ -6,380 +6,302 @@
  * Released under the terms and conditions of the
  * GNU General Public License (http://www.gnu.org/licenses/gpl.txt)
  *
- */
+ * e107 chatbox_menu Plugin
+ *
+*/
 
-if(isset($_POST['chatbox_ajax']))
-{
-	define('e_MINIMAL',true);
-	if(!defined('e107_INIT')) require_once('../../class2.php');
+if (isset($_POST['chatbox_ajax'])) {
+	define('e_MINIMAL', true);
+	if ( ! defined('e107_INIT')) {
+		require_once('../../class2.php');
+	}
 }
 
 global $e107cache, $e_event, $e107;
 
 $tp = e107::getParser();
-$pref = e107::getPref(); 
+$pref = e107::getPref();
 
-
-if (!e107::isInstalled('chatbox_menu')) 
-{
+if ( ! e107::isInstalled('chatbox_menu')) {
 	return '';
 }
 
-
 e107::lan('chatbox_menu', e_LANGUAGE);
 
-// FIXME - start - LAN is not loaded
-/*
-if(($pref['cb_layer']==2) || isset($_POST['chatbox_ajax']))
-{
-	if(isset($_POST['chat_submit']))
-	{
-		
 
-		//Normally the menu.sc file will auto-load the language file, this is needed in case
-		//ajax is turned on and the menu is not loaded from the menu.sc
-		inclXXXude_lan(e_PLUGIN.'chatbox_menu/languages/'.e_LANGUAGE.'/'.e_LANGUAGE.'.php');
-	}
-}
-// FIXME - end
-*/
 
-// if(!defined('e_HANDLER')){ exit; }
-// require_once(e_HANDLER.'emote.php');
-
-$emessage='';
-
-/**
- * Chatbox Menu Shortcodes. 
- */
-if(!class_exists('chatbox_shortcodes'))
-{
-	class chatbox_shortcodes extends e_shortcode
-	{
-		
-		function sc_cb_username($parm='')
-		{
-			list($cb_uid, $cb_nick) = explode(".", $this->var['cb_nick'], 2);
-			if($this->var['user_name'])
-			{
-				//$cb_nick = "<a href='".e_HTTP."user.php?id.{$cb_uid}'>".$this->var['user_name']."</a>";
-				$uparams = array('id' => $cb_uid, 'name' => $this->var['user_name']);
-				$link = e107::getUrl()->create('user/profile/view', $uparams);
-				$cb_nick = "<a href='".$link."'>".$this->var['user_name']."</a>";
-			}
-			else
-			{
-				$tp = e107::getParser();
-				$cb_nick = $tp -> toHTML($cb_nick,FALSE,'USER_TITLE, emotes_off, no_make_clickable');
-				$cb_nick = str_replace("Anonymous", LAN_ANONYMOUS, $cb_nick);
-			}
-			
-			return $cb_nick;	
-		}	
-		
-		function sc_cb_timedate($parm='')
-		{
-			return  e107::getDate()->convert_date($this->var['cb_datestamp'], "relative");		
-		}
-			
-	
-		function sc_cb_message($parm = '')
-		{
-			if($this->var['cb_blocked'])
-			{
-				return CHATBOX_L6;	
-			}
-			
-			$pref 			= e107::getPref();
-			$emotes_active 	= $pref['cb_emote'] ? 'USER_BODY, emotes_on' : 'USER_BODY, emotes_off';
-			
-			list($cb_uid, $cb_nick) = explode(".", $this->var['cb_nick'], 2);
-			
-			$cb_message = e107::getParser()->toHTML($this->var['cb_message'], false, $emotes_active, $cb_uid, $pref['menu_wordwrap']);
-	
-			return $cb_message;
-			/*
-			$replace[0] = "["; $replace[1] = "]";
-			$search[0] = "&lsqb;"; $search[1] =  "&rsqb;";
-			$cb_message = str_replace($search, $replace, $cb_message);
-			*/
-		}
-	
-		function sc_cb_avatar($parm='')
-		{
-			return e107::getParser()->toAvatar($this->var); // parseTemplate("{USER_AVATAR=".vartrue($this->var['user_image'])."}");
-		}
-		
-		function sc_cb_bullet($parm = '')
-		{
-			$bullet = "";
-			
-			if(defined('BULLET'))
-			{
-				$bullet = '<img src="'.THEME_ABS.'images/'.BULLET.'" alt="" class="icon" />';
-			}
-			elseif(file_exists(THEME.'images/bullet2.gif'))
-			{
-				$bullet = '<img src="'.THEME_ABS.'images/bullet2.gif" alt="" class="icon" />';
-			}	
-			
-			return $bullet;
-		}
-	
-	}
-}
+$emessage = '';
 
 
 
-if((isset($_POST['chat_submit']) || e_AJAX_REQUEST) && $_POST['cmessage'] != '')
-{
-	if(!USER && !$pref['anon_post'])
-	{
+if ((isset($_POST['chat_submit']) || e_AJAX_REQUEST) && $_POST['cmessage'] !== '') {
+
+	if ( ! USER && ! $pref['anon_post']) {
 		// disallow post
-	}
-	else
-	{
-		$nick = trim(preg_replace("#\[.*\]#si", "", $tp -> toDB($_POST['nick'])));
+	} else {
+		$nick = trim(preg_replace("#\[.*\]#si", "", $tp->toDB($_POST['nick'])));
 
 		$cmessage = $_POST['cmessage'];
 		$cmessage = preg_replace("#\[.*?\](.*?)\[/.*?\]#s", "\\1", $cmessage);
 
+
 		$fp = new floodprotect;
-		if($fp -> flood("chatbox", "cb_datestamp"))
-		{
-			if((strlen(trim($cmessage)) < 1000) && trim($cmessage) != "")
-			{
-				$cmessage = $tp -> toDB($cmessage);
-				if($sql->select("chatbox", "*", "cb_message='$cmessage' AND cb_datestamp+84600>".time()))
-				{
+
+		if ($fp->flood('chatbox', 'cb_datestamp')) {
+			if ((strlen(trim($cmessage)) < 1000) && trim($cmessage) !== '') {
+
+				$cmessage = $tp->toDB($cmessage);
+
+				if ($sql->select('chatbox', '*',
+					"cb_message='{$cmessage}' AND cb_datestamp+84600>" . time())) {
+
 					$emessage = CHATBOX_L17;
-				}
-				else
-				{
+
+				} else {
+
 					$datestamp = time();
-					$ip = e107::getIPHandler()->getIP(FALSE);
-					if(USER)
-					{
-						$nick = USERID.".".USERNAME;
-						$sql -> db_Update("user", "user_chats=user_chats+1, user_lastpost='".time()."' WHERE user_id='".USERID."' ");
-					}
-					else if(!$nick)
-					{
-						$nick = "0.Anonymous";
-					}
-					else
-					{
-						if($sql->select("user", "*", "user_name='$nick' ")){
+					$ip = e107::getIPHandler()->getIP(false);
+
+					if (USER) {
+
+						$nick = USERID . "." . USERNAME;
+
+						$postTime = time();
+						$sql->update('user', "user_chats = user_chats + 1, user_lastpost = {$postTime} WHERE user_id = " . USERID);
+
+					} else if ( ! $nick) {
+
+						$nick = '0.Anonymous';
+
+					} else {
+
+						if ($sql->select('user', '*', "user_name='$nick' ")) {
+
 							$emessage = CHATBOX_L1;
+
+						} else {
+
+							$nick = "0." . $nick;
+
 						}
-						else
-						{
-							$nick = "0.".$nick;
-						}
+
 					}
-					if(!$emessage)
-					{
-						$insertId = $sql->insert("chatbox", "0, '{$nick}', '{$cmessage}', '{$datestamp}', '0' , '{$ip}' ");
-						
-						if($insertId)
-						{
-							$edata_cb = array("id" => $insertId, "nick" => $nick, "cmessage" => $cmessage, "datestamp" => $datestamp, "ip" => $ip);
+					if ( ! $emessage) {
+						$insertId = $sql->insert('chatbox',
+							"0, '{$nick}', '{$cmessage}', '{$datestamp}', 0, '{$ip}' ");
+
+						if ($insertId) {
+
+							$edata_cb = [
+								'id'        => $insertId,
+								'nick'      => $nick,
+								'cmessage'  => $cmessage,
+								'datestamp' => $datestamp,
+								'ip'        => $ip,
+							];
+
 							$e_event->trigger("cboxpost", $edata_cb); // deprecated
+
 							e107::getEvent()->trigger('user_chatbox_post_created', $edata_cb);
-							$e107cache->clear("nq_chatbox");
+							$e107cache->clear('nq_chatbox');
 						}
+
 					}
 				}
-			}
-			else
-			{
+			} else {
 				$emessage = CHATBOX_L15;
 			}
-		}
-		else
-		{
+		} else {
 			$emessage = CHATBOX_L19;
 		}
 	}
 }
 
-if(!USER && !$pref['anon_post']){
-	if($pref['user_reg'])
-	{
-		$text1 = str_replace(array('[',']'), array("<a href='".e_LOGIN."'>", "</a>"), CHATBOX_L3);
-		if($pref['user_reg'] == 1 ){
-		  $text1 .= str_replace(array('[',']'), array("<a href='".e_SIGNUP."'>", "</a>"), CHATBOX_L3b);		
-		}
-		$texta = "<div style='text-align:center'>".$text1."</div><br /><br />";
-	}
-}
-else
-{
-	$cb_width = (defined("CBWIDTH") ? CBWIDTH : "");
 
-	if($pref['cb_layer'] == 2)
-	{
-		$texta =  "\n<form id='chatbox' action='".e_SELF."?".e_QUERY."'  method='post' onsubmit='return(false);'>
-		<div><input type='hidden' name='chatbox_ajax' id='chatbox_ajax' value='1' /></div>
-		";
+if ( ! USER && ! $pref['anon_post']) {
+
+	if ($pref['user_reg']) {
+
+		$text1 = str_replace(['[', ']'], ["<a href='" . e_LOGIN . "'>", "</a>"],
+			CHATBOX_L3);
+
+		if ($pref['user_reg'] === 1) {
+			$text1 .= str_replace(['[', ']'],
+				["<a href='" . e_SIGNUP . "'>", "</a>"], CHATBOX_L3b);
+		}
+
+		$texta =
+			"<div style='text-align:center'>" . $text1 . "</div><br /><br />";
 	}
-	else
-	{
-		$texta =  (e_QUERY ? "\n<form id='chatbox' method='post' action='".e_SELF."?".e_QUERY."'>" : "\n<form id='chatbox' method='post' action='".e_SELF."'>");
+
+} else {
+	$cb_width = (defined('CBWIDTH') ? CBWIDTH : '');
+
+	if ($pref['cb_layer'] === 2) {
+
+		$texta = "\n<form id='chatbox' action='" . e_SELF . "?" . e_QUERY . "'  method='post' onsubmit='return(false);'>
+		<div>
+			<input type='hidden' name='chatbox_ajax' id='chatbox_ajax' value='1' />
+		</div>";
+
+	} else {
+
+		$texta = (e_QUERY
+			? "\n<form id='chatbox' method='post' action='" . e_SELF . "?" . e_QUERY . "'>"
+			: "\n<form id='chatbox' method='post' action='" . e_SELF . "'>");
 	}
+
 	$texta .= "<div class='control-group form-group' id='chatbox-input-block'>";
 
-	if(($pref['anon_post'] == "1" && USER == FALSE))
-	{
-		$texta .= "\n<input class='tbox chatbox' type='text' id='nick' name='nick' value='' maxlength='50' ".($cb_width ? "style='width: ".$cb_width.";'" : '')." /><br />";
+	if (($pref['anon_post'] == "1" && USER === false)) {
+		$texta .= "\n<input class='tbox chatbox' type='text' id='nick' name='nick' value='' maxlength='50' " . ($cb_width
+				? "style='width: " . $cb_width . ";'" : '') . " /><br />";
 	}
 
-	if($pref['cb_layer'] == 2)
-	{
+	if ($pref['cb_layer'] === 2) {
 
-		$oc = "onclick=\"javascript:sendInfo('".SITEURLBASE.e_PLUGIN_ABS."chatbox_menu/chatbox_menu.php', 'chatbox_posts', this.form);\"";
+		$oc =
+			"onclick=\"javascript:sendInfo('" . SITEURLBASE . e_PLUGIN_ABS . "chatbox_menu/chatbox_menu.php', 'chatbox_posts', this.form);\"";
+
+	} else {
+
+		$oc = '';
+
 	}
-	else
-	{
-		$oc = "";
-	}
+
 	$texta .= "
-	<textarea placeholder=\"".LAN_CHATBOX_100."\" required class='tbox chatbox form-control input-xlarge' id='cmessage' name='cmessage' cols='20' rows='5' style='max-width:97%; ".($cb_width ? "width:".$cb_width.";" : '')." overflow: auto' onselect='storeCaret(this);' onclick='storeCaret(this);' onkeyup='storeCaret(this);'></textarea>
+	<textarea placeholder=\"" . LAN_CHATBOX_100 . "\" required class='tbox chatbox form-control input-xlarge' id='cmessage' name='cmessage' cols='20' rows='5' style='max-width:97%; " . ($cb_width
+			? "width:" . $cb_width . ";" : '') . " overflow: auto' onselect='storeCaret(this);' onclick='storeCaret(this);' onkeyup='storeCaret(this);'></textarea>
 	<br />
-	<input class='btn btn-default btn-secondary button' type='submit' id='chat_submit' name='chat_submit' value='".CHATBOX_L4."' {$oc}/>
-	";
-	
+	<input class='btn btn-default btn-secondary button' type='submit' id='chat_submit' name='chat_submit' value='" . CHATBOX_L4 . "' {$oc}/>";
+
+
 	// $texta .= "<input type='reset' name='reset' value='".CHATBOX_L5."' />"; // How often do we see these lately? ;-)
 
-	if($pref['cb_emote'] && $pref['smiley_activate'])
-	{
+
+	if ($pref['cb_emote'] && $pref['smiley_activate']) {
 		$texta .= "
-		<input class='btn btn-default btn-secondary button' type='button' style='cursor:pointer' size='30' value='".CHATBOX_L14."' onclick=\"expandit('emote')\" />
-		<div class='well' style='display:none' id='emote'>".r_emote()."</div>\n";
+		<input class='btn btn-default btn-secondary button' type='button' style='cursor:pointer' size='30' value='" . CHATBOX_L14 . "' onclick=\"expandit('emote')\" />
+		<div class='well' style='display:none' id='emote'>" . r_emote() . "</div>\n";
 	}
 
-	$texta .="</div>\n</form>\n";
+	$texta .= "</div>\n</form>\n";
 }
 
-if($emessage != ""){
-	$texta .= "<div style='text-align:center'><b>".$emessage."</b></div>";
+
+if ($emessage !== '') {
+	$texta .= "<div style='text-align:center'><b>" . $emessage . "</b></div>";
 }
 
-if(!$text = $e107cache->retrieve("nq_chatbox"))
-{
-	global $pref,$tp;
-	$pref['chatbox_posts'] = ($pref['chatbox_posts'] ? $pref['chatbox_posts'] : 10);
+
+if ( ! $text = $e107cache->retrieve("nq_chatbox")) {
+
+	global $pref, $tp;
+
+	$pref['chatbox_posts'] =
+		($pref['chatbox_posts'] ? $pref['chatbox_posts'] : 10);
+
 	$chatbox_posts = $pref['chatbox_posts'];
-	if(!isset($pref['cb_mod']))
-	{
+
+	if ( ! isset($pref['cb_mod'])) {
 		$pref['cb_mod'] = e_UC_ADMIN;
 	}
 
-	if(!defined('CB_MOD'))
-	{
+	if ( ! defined('CB_MOD')) {
 		define("CB_MOD", check_class($pref['cb_mod']));
 	}
 
-	$qry = "
-	SELECT c.*, u.user_name, u.user_image FROM #chatbox AS c
-	LEFT JOIN #user AS u ON SUBSTRING_INDEX(c.cb_nick,'.',1) = u.user_id
-	ORDER BY c.cb_datestamp DESC LIMIT 0, ".intval($chatbox_posts);
+	$qry = "SELECT c.*, u.user_name, u.user_image FROM #chatbox AS c
+	LEFT JOIN #user AS u ON SUBSTRING_INDEX(c.cb_nick, '.', 1) = u.user_id
+	ORDER BY c.cb_datestamp DESC LIMIT 0, " . (int)$chatbox_posts;
 
 	global $CHATBOXSTYLE;
-	
-	if($CHATBOXSTYLE)
+
+	if($CHATBOXSTYLE)  // legacy chatbox style
 	{
-		$legacySrch = array('{USERNAME}','{MESSAGE}','{TIMEDATE}');
-		$legacyRepl = array('{CB_USERNAME}','{CB_MESSAGE}','{CB_TIMEDATE}');	
-		
-		
-		$CHATBOX_TEMPLATE['start'] = "";
-		$CHATBOX_TEMPLATE['item'] = str_replace($legacySrch,$legacyRepl,$CHATBOXSTYLE);
-		$CHATBOX_TEMPLATE['end'] = "";
+		$legacyIconSrc = e_IMAGE_ABS . 'admin_images/chatbox_16.png';
+		$currentIconSrc = e_PLUGIN . 'chatbox_menu/images/chatbox_16.png';
+
+		$legacySrch = array($legacyIconSrc, '{USERNAME}', '{MESSAGE}', '{TIMEDATE}');
+		$legacyRepl = array($currentIconSrc, '{CB_USERNAME}','{CB_MESSAGE}','{CB_TIMEDATE}');
+
+
+		$CHATBOX_TEMPLATE['start'] = '';
+		$CHATBOX_TEMPLATE['item'] = str_replace($legacySrch, $legacyRepl, $CHATBOXSTYLE);
+		$CHATBOX_TEMPLATE['end'] = '';
 	}
 	else 	// default chatbox style
 	{
-		$tp->parseTemplate("{SETIMAGE: w=40}",true); // set thumbnail size. 
-		// FIXME - move to template
-		$CHATBOX_TEMPLATE['start'] 	= "<ul class='media-list unstyled list-unstyled'>";
-		$CHATBOX_TEMPLATE['item'] 	= "<li class='media'>
-										<span class='media-object pull-left'>{CB_AVATAR}</span> 
-										<div class='media-body'><b>{CB_USERNAME}</b>&nbsp;
-										<small class='muted smalltext'>{CB_TIMEDATE}</small><br />
-										<p>{CB_MESSAGE}</p>
-										</div>
-										</li>\n";
-										
-		$CHATBOX_TEMPLATE['end'] 	= "</ul>";
+		$CHATBOX_TEMPLATE = e107::getTemplate('chatbox_menu', null, 'menu');
 	}
-		
+
 	// FIX - don't call getScBatch() if don't need to globally register the methods
 	// $sc = e107::getScBatch('chatbox');
-	
-	// the good way in this case - it works with any object having sc_*, models too
-	$sc = new chatbox_shortcodes();		
 
-	if($sql->gen($qry))
-	{
-		$cbpost = $sql->db_getList();
+	// the good way in this case - it works with any object having sc_*, models too
+	//$sc = new chatbox_shortcodes();
+
+	$sc = e107::getScBatch('chatbox_menu', true);
+
+	if ($sql->gen($qry)) {
+
+		$cbpost = $sql->rows();
+
 		$text .= "<div id='chatbox-posts-block'>\n";
 
 		$text .= $tp->parseTemplate($CHATBOX_TEMPLATE['start'], false, $sc);
 
-		foreach($cbpost as $cb)
-		{
+		foreach ($cbpost as $cb) {
 			$sc->setVars($cb);
 			$text .= $tp->parseTemplate($CHATBOX_TEMPLATE['item'], false, $sc);
 		}
-		
+
 		$text .= $tp->parseTemplate($CHATBOX_TEMPLATE['end'], false, $sc);
 
 		$text .= "</div>";
+
+	} else {
+		$text .= "<span class='mediumtext'>" . CHATBOX_L11 . "</span>";
 	}
-	else
-	{
-		$text .= "<span class='mediumtext'>".CHATBOX_L11."</span>";
-	}
-	
-	
+
 	$total_chats = $sql->count("chatbox");
-	if($total_chats > $chatbox_posts || CB_MOD)
-	{
-		$text .= "<br /><div style='text-align:center'><a href='".e_PLUGIN_ABS."chatbox_menu/chat.php'>".(CB_MOD ? CHATBOX_L13 : CHATBOX_L12)."</a> (".$total_chats.")</div>";
+
+	if ($total_chats > $chatbox_posts || CB_MOD) {
+		$text .= "<br /><div style='text-align:center'><a href='" . e_PLUGIN_ABS . "chatbox_menu/chat.php'>" . (CB_MOD
+				? CHATBOX_L13
+				: CHATBOX_L12) . "</a> (" . $total_chats . ")</div>";
 	}
+
 	$e107cache->set("nq_chatbox", $text);
 }
 
 
+$caption = (file_exists(THEME . "images/chatbox_menu.png")
+	? "<img src='" . THEME_ABS . "images/chatbox_menu.png' alt='' /> " . LAN_PLUGIN_CHATBOX_MENU_NAME
+	: LAN_PLUGIN_CHATBOX_MENU_NAME);
 
 
+if ($pref['cb_layer'] === 1) {
 
-$caption = (file_exists(THEME."images/chatbox_menu.png") ? "<img src='".THEME_ABS."images/chatbox_menu.png' alt='' /> ".LAN_PLUGIN_CHATBOX_MENU_NAME : LAN_PLUGIN_CHATBOX_MENU_NAME);
+	$text =
+		$texta . "<div style='border : 0; padding : 4px; width : auto; height : " . $pref['cb_layer_height'] . "px; overflow : auto; '>" . $text . "</div>";
 
-if($pref['cb_layer'] == 1)
-{
-	$text = $texta."<div style='border : 0; padding : 4px; width : auto; height : ".$pref['cb_layer_height']."px; overflow : auto; '>".$text."</div>";
-	$ns -> tablerender($caption, $text, 'chatbox');
-}
-elseif($pref['cb_layer'] == 2 && e_AJAX_REQUEST)
-{
-	$text = $texta.$text;
+	$ns->tablerender($caption, $text, 'chatbox');
+
+} elseif ($pref['cb_layer'] === 2 && e_AJAX_REQUEST) {
+
+	$text = $texta . $text;
 	$text = str_replace(e_IMAGE, e_IMAGE_ABS, $text);
 	echo $text;
-}
-else
-{
-	$text = $texta.$text;
-	if($pref['cb_layer'] == 2)
-	{
-		$text = "<div id='chatbox_posts'>".$text."</div>";
+
+} else {
+
+	$text = $texta . $text;
+
+	if ($pref['cb_layer'] === 2) {
+		$text = "<div id='chatbox_posts'>" . $text . "</div>";
 	}
-	$ns -> tablerender($caption, $text, 'chatbox');
+
+	$ns->tablerender($caption, $text, 'chatbox');
 }
 
-//$text = ($pref['cb_layer'] ? $texta."<div style='border : 0; padding : 4px; width : auto; height : ".$pref['cb_layer_height']."px; overflow : auto; '>".$text."</div>" : $texta.$text);
-//if(ADMIN && getperms("C")){$text .= "<br /><div style='text-align: center'>[ <a href='".e_PLUGIN."chatbox_menu/admin_chatbox.php'>".CHATBOX_L13."</a> ]</div>";}
-//$ns -> tablerender($caption, $text, 'chatbox');
-
-
-?>

--- a/e107_plugins/chatbox_menu/chatbox_menu_shortcodes.php
+++ b/e107_plugins/chatbox_menu/chatbox_menu_shortcodes.php
@@ -1,0 +1,214 @@
+<?php
+/*
+ * e107 website system
+ *
+ * Copyright (C) 2008-2013 e107 Inc (e107.org)
+ * Released under the terms and conditions of the
+ * GNU General Public License (http://www.gnu.org/licenses/gpl.txt)
+ *
+ * e107 chatbox_menu Plugin
+ *
+*/
+if ( ! defined('e107_INIT')) {
+	exit;
+}
+
+
+class chatbox_menu_shortcodes extends e_shortcode
+{
+	/**
+	 *  Initializer for chatbox_menu_shortcodes class
+	 */
+	public function init()
+	{
+		if ( ! $this->var['user_image'] ) {
+			$this->addVars($this->retrieveUserDataByNick($this->var['cb_nick']));
+		}
+
+	}
+
+
+	/**
+	 * Returns extended user data from user object
+	 *
+	 * @param $nick string
+	 *
+	 * @return array user data
+	 */
+	protected function retrieveUserDataByNick($nick)
+	{
+
+		$tmp = explode('.', $nick);
+		$userId = (int)$tmp[0];
+
+		return e107::user($userId);
+
+	}
+
+
+	/**
+	 * Returns user avatar
+	 *
+	 * @param $parm
+	 *
+	 * @return \
+	 */
+	public function sc_cb_avatar($parm = null)
+	{
+		$this->init();
+
+		$size = $parm['size'] ?: 40;
+		$tp = e107::getParser();
+
+		return $tp->toAvatar($this->var, ['h' => $size, 'w' => $size, 'crop' => 'C']);
+	}
+
+
+	/**
+	 * Returns user profile link
+	 *
+	 * @param null $parm
+	 *
+	 * @return mixed|string
+	 */
+	public function sc_cb_username($parm = null)
+	{
+
+		if (! $this->var['user_id'] && ! $this->var['user_name']) {
+
+			$tmp = explode('.', $this->var['cb_nick']);
+
+			$link = e107::getUrl()->create('user/profile/view', array('id' => $tmp[0], 'name' => $tmp[1]));
+
+			$userName = str_replace('Anonymous', LAN_ANONYMOUS, $tmp[1]);
+
+			return '<a href="' . $link . '">' . $userName . '</a>';
+
+		}
+
+		$this->init();
+
+		$userData = [
+			'id'   => $this->var['user_id'],
+			'name' => $this->var['user_name'],
+		];
+
+		$link = e107::getUrl()->create('user/profile/view', $userData);
+
+		return '<a href="' . $link . '">' . $this->var['user_name'] . '</a>';
+	}
+
+
+	/**
+	 * Returns relative timestamp
+	 *
+	 * @param null $parm
+	 *
+	 * @return string
+	 */
+	public function sc_cb_timedate($parm = null)
+	{
+
+		return e107::getDate()
+			->convert_date($this->var['cb_datestamp'], 'relative');
+	}
+
+
+	/**
+	 * Returns chatbox message
+	 *
+	 * @param null $parm
+	 *
+	 * @return string
+	 */
+	public function sc_cb_message($parm = null)
+	{
+		$this->init();
+
+		if ($this->var['cb_blocked']) {
+			return CHATBOX_L6;
+		}
+
+		$pref = e107::getPref();
+		$emotes_active = $pref['cb_emote'] ? 'USER_BODY, emotes_on'
+			: 'USER_BODY, emotes_off';
+
+		$cb_message = e107::getParser()
+			->toHTML($this->var['cb_message'], false, $emotes_active,
+				$this->var['user_id'], $pref['menu_wordwrap']);
+
+		return $cb_message;
+	}
+
+
+	/**
+	 * Returns bullet image
+	 *
+	 * @param null $parm
+	 *
+	 * @return string
+	 */
+	public function sc_cb_bullet($parm = null)
+	{
+		$bullet = '';
+
+		if (defined('BULLET')) {
+			$bullet =
+				'<img src="' . THEME_ABS . 'images/' . BULLET . '" alt="" class="icon" />';
+		} elseif (file_exists(THEME . 'images/bullet2.gif')) {
+			$bullet =
+				'<img src="' . THEME_ABS . 'images/bullet2.gif" alt="" class="icon" />';
+		}
+
+		return $bullet;
+	}
+
+
+	/**
+	 * Returns moderator options
+	 *
+	 * @param null $parm
+	 *
+	 * @return string
+	 */
+	public function sc_cb_mod($parm = null)
+	{
+		$frm = e107::getForm();
+		$modControls = '';
+
+		if (CB_MOD) {
+			$id = $this->var['cb_id'];
+
+			$modControls .= "<span class='checkbox'>";
+
+			$modControls .= $frm->checkbox('delete[' . $id . ']', 1, false,
+				['inline' => true, 'label' => LAN_DELETE]);
+
+			if ($this->var['cb_blocked']) {
+				$modControls .= $frm->checkbox('unblock[' . $id . ']', 1, false,
+					['inline' => true, 'label' => CHATBOX_L7]);
+			} else {
+				$modControls .= $frm->checkbox('block[' . $id . ']', 1, false,
+					['inline' => true, 'label' => CHATBOX_L9]);
+			}
+
+			$modControls .= '</span>';
+		}
+
+		return $modControls;
+	}
+
+
+	/**
+	 * Returns moderator block message
+	 *
+	 * @param null $parm
+	 *
+	 * @return string
+	 */
+	public function sc_cb_blocked($parm = null)
+	{
+		return $this->var['cb_blocked'] ? '<span class="label label-warning">' . CHATBOX_L25 . '</span>' : '';
+	}
+
+}

--- a/e107_plugins/chatbox_menu/templates/chatbox_menu_template.php
+++ b/e107_plugins/chatbox_menu/templates/chatbox_menu_template.php
@@ -1,0 +1,60 @@
+<?php
+/*
+ * e107 website system
+ *
+ * Copyright (C) 2008-2013 e107 Inc (e107.org)
+ * Released under the terms and conditions of the
+ * GNU General Public License (http://www.gnu.org/licenses/gpl.txt)
+ *
+ * e107 chatbox_menu Plugin
+ *
+*/
+if ( ! defined('e107_INIT')) {
+	exit;
+}
+
+//---------------------------------MENU-----------------------------------------
+
+$CHATBOX_MENU_TEMPLATE['menu']['start'] =
+	'<ul class="media-list unstyled list-unstyled">' . PHP_EOL;
+
+$CHATBOX_MENU_TEMPLATE['menu']['item'] 	= '
+<li class="media">
+<div class="media-left">
+	<span class="media-object">{CB_AVATAR}</span>
+</div> 
+<div class="media-body">
+	<b>{CB_USERNAME}</b>&nbsp;
+	<small class="muted smalltext">{CB_TIMEDATE}</small><br />
+	<p>{CB_MESSAGE}</p>
+</div>
+</li>' . PHP_EOL;
+
+$CHATBOX_MENU_TEMPLATE['menu']['end'] 	= '</ul>'. PHP_EOL;
+
+
+//---------------------------------LIST-----------------------------------------
+
+$CHATBOX_MENU_TEMPLATE['list']['start'] =
+	'<ul class="media-list list-group">' . PHP_EOL;
+
+$CHATBOX_MENU_TEMPLATE['list']['item']  = '
+<li class="media list-group-item" >
+<div class="media-left">
+	<span class="media-object">{CB_AVATAR:size=60}</span>
+</div>
+<div class="media-body">
+	<h4 class="media-heading" style="display: inline !important;">{CB_USERNAME}</h4>
+	<small class="label label-default pull-right">{CB_TIMEDATE}</small><br>
+	<p>{CB_MESSAGE}</p>
+	<div>
+		<div class="pull-left">{CB_BLOCKED}</div>
+		<div class="pull-right">{CB_MOD}</div>
+	</div>
+</div>
+</li>'. PHP_EOL;
+
+$CHATBOX_MENU_TEMPLATE['list']['end']   = '</ul>'. PHP_EOL;
+
+
+


### PR DESCRIPTION
@CaMer0n, 
Please review and merge. If there are changes required please advice. Yet to remove old chat_template.php from plugin folder.

Add chatbox_menu_template.php and chatbox_menu_shortcodes.php, Introduce shortcode/template combination to render avatars in chat.php

Changes:
- Add chatbox_menu_template.php and chatbox_menu_shortcodes.php files.
- Add bootstrap3 styling for some elements in chat.php list view markup.
- Cleanup chat.php and chatbox_menu.php code generally and to replace legacy database calls with current standard.

Succeeded Tests:
- Load chatbox_menu_template.php in {e_PLUGIN}/chatbox_menu/templates/chatbox_menu_template.php
- Load chatbox_menu_template.php in {e_THEME}/templates/chatbox_menu/chatbox_menu_template.php