### PR TITLE
fixes #3632: Lancheck failed on some utf-8 values

### DIFF
--- a/e107_admin/lancheck.php
+++ b/e107_admin/lancheck.php
@@ -1922,7 +1922,7 @@ class lancheck
 			$retloc[$type][$locale[1]]= $locale[2];	
 		}
 				
-		if(preg_match_all('/^\s*?define\s*?\(\s*?(\'|\")([\w]+)(\'|\")\s*?,\s*?(\'|\")([\s\S]*?)\s*?(\'|\")\s*?\)\s*?;/im',$data,$matches))
+		if(preg_match_all('/^\s*?define\s*?\(\s*?(\'|\")([\w]+)(\'|\")\s*?,\s*?(\'|\")([\s\S]*?)\s*?(\'|\")\s*?\)\s*?;/imu',$data,$matches))
 		{
 			$def = $matches[2];
 			$values = $matches[5];	


### PR DESCRIPTION
the regex to extract the language defines and values missed the "u" (unicode) flag. Due to that, some utf-8 values were malformed during processing.