### PR TITLE
Issue #3656: Tinymce shows Mediamanager icons on quick-reply

### DIFF
--- a/e107_plugins/forum/forum_post.php
+++ b/e107_plugins/forum/forum_post.php
@@ -16,14 +16,15 @@ if(!defined('e107_INIT'))
 	require_once('../../class2.php');
 }
 
-if(USER)
-{
-	define('e_TINYMCE_TEMPLATE', 'member'); // allow images / videos.
-}
-else
-{
-	define('e_TINYMCE_TEMPLATE', 'public');
-}
+// Now defined in shortcodes that handle the editors
+// if(USER)
+// {
+// 	define('e_TINYMCE_TEMPLATE', 'member'); // allow images / videos.
+// }
+// else
+// {
+// 	define('e_TINYMCE_TEMPLATE', 'public');
+// }
 
 define('NAVIGATION_ACTIVE','forum'); // ??
 

--- a/e107_plugins/forum/shortcodes/batch/post_shortcodes.php
+++ b/e107_plugins/forum/shortcodes/batch/post_shortcodes.php
@@ -153,7 +153,13 @@ class plugin_forum_post_shortcodes extends e_shortcode
 	{
 		$tp = e107::getParser();
 
-
+		// Define which tinymce4 template should be used, depending if the current user is registered or a guest
+		if (!deftrue('e_TINYMCE_TEMPLATE'))
+		{
+			define('e_TINYMCE_TEMPLATE', (USER ? 'member' : 'public')); // allow images / videos.
+		}
+		
+		
 		if(!empty($_POST['post']))
 		{
 			$text = $tp->post_toForm($_POST['post']);
@@ -182,7 +188,8 @@ class plugin_forum_post_shortcodes extends e_shortcode
 		//$wysiwyg = ($editor === 'bbcode') ? false : null;
 		$wysiwyg = is_null($editor) ? 'default' : $editor;
 
-		return e107::getForm()->bbarea('post',$text,'forum','_common','large', array('wysiwyg' => $wysiwyg));
+		//return e107::getForm()->bbarea('post',$text,'forum','_common','large', array('wysiwyg' => $wysiwyg));
+		return e107::getForm()->bbarea('post',$text,'forum','forum','large', array('wysiwyg' => $wysiwyg));
 
 	}
 

--- a/e107_plugins/forum/shortcodes/batch/view_shortcodes.php
+++ b/e107_plugins/forum/shortcodes/batch/view_shortcodes.php
@@ -1188,6 +1188,12 @@
 		{
 			global $forum, $forum_quickreply;
 
+			// Define which tinymce4 template should be used, depending if the current user is registered or a guest
+			if (!deftrue('e_TINYMCE_TEMPLATE'))
+			{
+				define('e_TINYMCE_TEMPLATE', (USER ? 'member' : 'public')); // allow images / videos.
+			}
+			
 			if($forum->checkPerm($this->var['thread_forum_id'], 'post') && $this->var['thread_active'])
 			{
 				//XXX Show only on the last page??
@@ -1224,7 +1230,8 @@
 						$text = "
 						<form action='" . $url . "' method='post'>
 						<div class='form-group'>" .
-						e107::getForm()->bbarea('post','','forum', '_common', 'small', array('id' => 'forum-quickreply-text', 'wysiwyg' => $editor)) .
+//						e107::getForm()->bbarea('post','','forum', '_common', 'small', array('id' => 'forum-quickreply-text', 'wysiwyg' => $editor)) .
+						e107::getForm()->bbarea('post','','forum', 'forum', 'medium', array('id' => 'forum-quickreply-text', 'wysiwyg' => $editor)) .
 						"</div>
 						<div class='center text-center form-group'>
 							<input type='submit' data-token='" . e_TOKEN . "' data-forum-insert='" . $ajaxInsert . "' data-forum-post='" . $this->var['thread_forum_id'] . "' data-forum-thread='" . $this->var['thread_id'] . "' data-forum-action='quickreply' name='reply' value='" . LAN_FORUM_2006 . "' class='btn btn-success button' />

--- a/e107_plugins/tinymce4/templates/member.xml
+++ b/e107_plugins/tinymce4/templates/member.xml
@@ -3,7 +3,7 @@
 	<plugins>advlist autosave lists link image charmap print preview hr anchor pagebreak searchreplace wordcount visualchars fullscreen
         insertdatetime media nonbreaking table contextmenu directionality emoticons template paste textcolor </plugins>
 	<menubar>edit view insert format table tools</menubar>
-	<toolbar1>undo redo | bold italic underline forecolor | alignleft aligncenter alignright alignjustify | bullist numlist | outdent indent | link image  media table   | smileys | fullscreen</toolbar1>
+	<toolbar1>undo redo | bold italic underline forecolor | alignleft aligncenter alignright alignjustify | bullist numlist | outdent indent | link image  media table  | e107-image e107-video e107-glyph smileys | fullscreen</toolbar1>
 	<external_plugins>e107</external_plugins>
 	<image_advtab>false</image_advtab>
 	<media_alt_source>false</media_alt_source>

--- a/e107_plugins/tinymce4/templates/member.xml
+++ b/e107_plugins/tinymce4/templates/member.xml
@@ -3,7 +3,7 @@
 	<plugins>advlist autosave lists link image charmap print preview hr anchor pagebreak searchreplace wordcount visualchars fullscreen
         insertdatetime media nonbreaking table contextmenu directionality emoticons template paste textcolor </plugins>
 	<menubar>edit view insert format table tools</menubar>
-	<toolbar1>undo redo | bold italic underline forecolor | alignleft aligncenter alignright alignjustify | bullist numlist | outdent indent | link image  media table  | e107-image e107-video e107-glyph smileys | fullscreen</toolbar1>
+	<toolbar1>undo redo | bold italic underline forecolor | alignleft aligncenter alignright alignjustify | bullist numlist | outdent indent | link image  media table  | smileys | fullscreen</toolbar1>
 	<external_plugins>e107</external_plugins>
 	<image_advtab>false</image_advtab>
 	<media_alt_source>false</media_alt_source>


### PR DESCRIPTION
Tinymce was showing Mediamanager icons on forum quick-reply
Made sure, that the correct tinymce template is used for quick-reply an new post page