### PR TITLE
Don't overwrite e_db_pdo::$mySQLlastQuery with _getMySQLaccess()

### DIFF
--- a/e107_handlers/e_db_pdo_class.php
+++ b/e107_handlers/e_db_pdo_class.php
@@ -314,6 +314,7 @@ class e_db_pdo implements e_db
 		global $db_time, $queryinfo;
 		$this->queryCount++;
 
+		$this->_getMySQLaccess();
 		$this->mySQLlastQuery = $query;
 
 		if ($debug == 'now')
@@ -330,10 +331,7 @@ class e_db_pdo implements e_db
 			$this->log($log_type, $log_remark, $query);
 		}
 
-		$this->_getMySQLaccess();
-
 		$b = microtime();
-
 
 		if(is_array($query) && !empty($query['PREPARE']) && !empty($query['BIND']))
 		{


### PR DESCRIPTION
`e_db_pdo::_getMySQLaccess()` overwrites the `e_db_pdo::$mySQLlastQuery`, so the fix for this is to run the method before `e_db_pdo::$mySQLlastQuery` gets set.

Fixes: #3673