### PR TITLE
fixes e107inc/vstore#99: Difference between MariaDB and MySQL table def

### DIFF
--- a/e107_handlers/db_verify_class.php
+++ b/e107_handlers/db_verify_class.php
@@ -154,6 +154,13 @@ class db_verify
 			$actual['default']   = preg_replace("/DEFAULT '(\d*\.?\d*)'/i", 'DEFAULT $1', $actual['default']  );
 		}
 
+		// Correct difference on CREATE TABLE statement between MariaDB and MySQL
+		if(1 === preg_match('/(DATE|DATETIME|TIMESTAMP|TIME|YEAR)/i', $expected['default']))
+		{
+			$expected['default'] = preg_replace("/CURRENT_TIMESTAMP\(\)/i", 'CURRENT_TIMESTAMP', $expected['default']);
+			$actual['default']   = preg_replace("/CURRENT_TIMESTAMP\(\)/i", 'CURRENT_TIMESTAMP', $actual['default']  );
+		}
+
 		return array_diff_assoc($expected, $actual);
 	}
 	


### PR DESCRIPTION
Difference between MariaDB and MySQL on command TABLE CREATE returns CURRENT_TIMESTAMP w/o brackets
Updated method db_verify::diffStructurePermissive() to correct the given sql table definition.