### PR TITLE
fixes #3657: Userclass is reset on all user accounts to the one public userclass "Newsletter"

### DIFF
--- a/e107_handlers/login.php
+++ b/e107_handlers/login.php
@@ -278,7 +278,13 @@ class userlogin
 			{	// 'New user' probationary period expired - we can take them out of the class
 				$this->userData['user_class'] = $this->e107->user_class->ucRemove(e_UC_NEWUSER, $this->userData['user_class']);
 //				$this->e107->admin_log->e_log_event(4,__FILE__."|".__FUNCTION__."@".__LINE__,"DBG","Login new user complete",$this->userData['user_class'],FALSE,FALSE);
-				$sql->update('user',"`user_class` = '".$this->userData['user_class']."'", 'WHERE `user_id`='.$this->userData['user_id']. " LIMIT 1");
+
+				/**
+				 * issue e107inc/e107#3657: Third argument of update() function is for debugging purposes and NOT used for the WHERE clause.
+				 * Therefore the query was run without WHERE, which resulted into applyiing the new classes to all users....
+				 */
+				//$sql->update('user',"`user_class` = '".$this->userData['user_class']."'", 'WHERE `user_id`='.$this->userData['user_id']. " LIMIT 1");
+				$sql->update('user',"`user_class` = '" . $this->userData['user_class'] . "' WHERE `user_id`=" . $this->userData['user_id'] . " LIMIT 1");
 				unset($class_list[e_UC_NEWUSER]);
 				$edata_li = array('user_id' => $user_id, 'user_name' => $username, 'class_list' => implode(',',$class_list), 'user_email'=> $user_email);
 				$e_event->trigger('userNotNew', $edata_li);


### PR DESCRIPTION
In case a user with user_class e_UC_NEWUSER logged in and was ready to be "promoted" to a "normal" user, the e_UC_NEWUSER should be removed. Unfortunately, the db:update() function was used in the
wrong way.
The third argument of update() function is for debugging purposes and NOT used for the WHERE clause.
Therefore the query was run without WHERE, which resulted into applying the new classes to all users....