### PR TITLE
Fix e_form::checkboxes()

### DIFF
--- a/e107_handlers/form_handler.php
+++ b/e107_handlers/form_handler.php
@@ -2550,7 +2550,7 @@ class e_form
 	{
 		$name = (strpos($name, '[') === false) ? $name.'[]' : $name;
 
-		if(!is_array($checked)) $checked = explode(",",$checked);
+		if(!is_array($checked)) $checked = explode(",", $checked);
 		
 		$text = "";
 

--- a/e107_handlers/form_handler.php
+++ b/e107_handlers/form_handler.php
@@ -2576,6 +2576,7 @@ class e_form
 				$c = vartrue($checked[$k]);
 			}
 
+
 			/**
 			 * Label overwrote the other supplied options (if any)
 			 * and also failed in case it contained a = character

--- a/e107_handlers/form_handler.php
+++ b/e107_handlers/form_handler.php
@@ -2576,8 +2576,12 @@ class e_form
 				$c = vartrue($checked[$k]);
 			}
 
-
-			$text .= $this->checkbox($cname, $key, $c, $label);
+			/**
+			 * Label overwrote the other supplied options (if any)
+			 * and also failed in case it contained a = character
+			 */
+			$options['label'] = $label;
+			$text .= $this->checkbox($cname, $key, $c, $options);
 		}
 
 	//	return print_a($checked,true);


### PR DESCRIPTION
fixes an issue with e_form::checkboxes() not displaying labels properly that contain a '=' character. Also overwrote any supplied options.

See line 2585ff. For some reason, github tells me the whole file has changed. In PhpStorm it shows only the really changed lines as changes.