### PR TITLE
fixes e_form::checkboxes() not displaying labels properly

### DIFF
--- a/e107_handlers/form_handler.php
+++ b/e107_handlers/form_handler.php
@@ -2576,8 +2576,12 @@ class e_form
 				$c = vartrue($checked[$k]);
 			}
 
-
-			$text .= $this->checkbox($cname, $key, $c, $label);
+			/**
+			 * Label overwrote the other supplied options (if any)
+			 * and also failed in case it contained a "=" character
+			 */
+			$options['label'] = $label;
+			$text .= $this->checkbox($cname, $key, $c, $options);
 		}
 
 	//	return print_a($checked,true);


### PR DESCRIPTION
fixes e_form::checkboxes() not displaying labels properly that contain a '=' character. Also overwrote any supplied options.
The line endings seem to be screwed up, no matter what i do... 
This is a screenshot of my changes to that file...
![grafik](https://user-images.githubusercontent.com/7572616/54642274-80524000-4a94-11e9-89f6-1fd748f9c682.png)
