### PR TITLE
Improved portability of db_verify::getPrevious()

### DIFF
--- a/e107_handlers/db_verify_class.php
+++ b/e107_handlers/db_verify_class.php
@@ -726,17 +726,8 @@ class db_verify
 	function getPrevious($array,$cur)
 	{
 		$fkeys = array_keys($array);
-		
-		foreach($fkeys as $fields)
-		{
-			if($fields == $cur)
-			{
-				$current = prev($fkeys); // required. 
-				$previous = prev($fkeys);
-				return $previous;
-			}
-		}
-						
+		$cur_key = array_search($cur, $fkeys);
+		return @$fkeys[$cur_key - 1];
 	}
 	
 	/**


### PR DESCRIPTION
Now works in PHP 7 as it used to work in PHP 5

Fixes: #3768