### PR TITLE
Added social login provider callback data to event

### DIFF
--- a/e107_handlers/user_handler.php
+++ b/e107_handlers/user_handler.php
@@ -1353,6 +1353,8 @@ class e_user_provider
 			//$user->set('provider', $this->getProvider());
 			$userdata = $user->getData();
 			$userdata['provider'] = $this->getProvider();
+
+            $userdata['callback_data'] = $profile;
 			
 		//	e107::getEvent()->trigger('userveri', $userdata);	 // Trigger New verified user.
 			


### PR DESCRIPTION
Event user_xup_signup was not giving info that may come from the social provider, for example the Birth date or gender, I just added a way to access all provider callback info from within the signup event.