### PR TITLE
Delete Account Optional

### DIFF
--- a/e107_admin/users.php
+++ b/e107_admin/users.php
@@ -328,6 +328,7 @@ class users_admin_ui extends e_admin_ui
 		'profile_comments'			=> array('title' => USRLAN_127, 'type' => 'boolean', 'writeParms' => 'label=yesno', 'data' => 'int',),
 		'force_userupdate'			=> array('title' => USRLAN_133, 'type' => 'boolean', 'writeParms' => 'label=yesno', 'help' => USRLAN_134, 'data' => 'int',),
 		'del_unv'					=> array('title' => USRLAN_93,  'type' => 'number',  'writeParms' => array('maxlength' => 5, 'post' => USRLAN_95), 'help' => USRLAN_94, 'data' => 'int',),
+		'del_accu'					=> array('title' => USRLAN_257, 'type' => 'boolean', 'writeParms' => 'label=yesno', 'data' => 'int',),
 		'track_online'				=> array('title' => USRLAN_130, 'type' => 'boolean', 'writeParms' => 'label=yesno', 'help' => USRLAN_131, 'data' => 'int',),
 		'memberlist_access'			=> array('title' => USRLAN_146, 'type' => 'userclass', 'writeParms' => 'classlist=public,member,guest,admin,main,classes,nobody', 'data' => 'int',),
 		'signature_access'			=> array('title' => USRLAN_194, 'type' => 'userclass', 'writeParms' => 'classlist=member,admin,main,classes,nobody', 'data' => 'int',),

--- a/e107_core/shortcodes/batch/usersettings_shortcodes.php
+++ b/e107_core/shortcodes/batch/usersettings_shortcodes.php
@@ -595,19 +595,24 @@ class usersettings_shortcodes extends e_shortcode
 
 	function sc_deleteaccountbutton($parm=array())
 	{
-
 		if((int) $_GET['id'] !== USERID)
 		{
 			return null;
 		}
+		$pref = e107::getPref();
+		if($pref['del_accu'] == 1)
+		{
+			$confirm    = defset("LAN_USET_51", "Are you sure? This procedure cannot be reversed! Once completed all personal data that you have entered on this site will be permanently lost and you will no longer be able to login.");
+			$label      = defset('LAN_USET_50', "Delete All Account Information");
 
-		$confirm    = defset("LAN_USET_51", "Are you sure? This procedure cannot be reversed! Once completed all personal data that you have entered on this site will be permanently lost and you will no longer be able to login.");
-		$label      = defset('LAN_USET_50', "Delete All Account Information");
+			$parm['confirm'] = $confirm;
 
-		$parm['confirm'] = $confirm;
-
-		return e107::getForm()->button('delete_account',1, 'delete', $label, $parm);
-
+			return e107::getForm()->button('delete_account',1, 'delete', $label, $parm);
+		}
+		else
+		{
+			return null;
+		}
 	}
 
 }

--- a/e107_languages/English/admin/lan_users.php
+++ b/e107_languages/English/admin/lan_users.php
@@ -278,6 +278,8 @@ define("USRLAN_254", "Reset all passwords");
 define("USRLAN_255", "Notify User");
 define("USRLAN_256", "Dear");
 
+define("USRLAN_257", "Allow members to delete account?");
+
 // These need review - there are duplicates above - they come from admin/lan_userclass.php and are unconsistent with userclass defines. TODO LANS
 define("UCSLAN_1", "Sending notification email to");
 define("UCSLAN_2", "Updated Privileges");


### PR DESCRIPTION
Added option in admin area to allow users to delete their account or not. In reference to #3945

Basically adds an option in Admin Area > Users > Options > Allow members to delete account? (yesno)
Hides the Delete button on usersettings.php (using shortcode)