### PR TITLE
Resolving an issue with related SEF url's not generating properly

### DIFF
--- a/e107_plugins/news/e_related.php
+++ b/e107_plugins/news/e_related.php
@@ -26,7 +26,11 @@ class news_related // include plugin-folder in the name.
 			
 		$tag_regexp = "'(^|,)(".str_replace(",", "|", $tags).")(,|$)'";
 		
-		$query = "SELECT * FROM #news WHERE news_id != ".$parm['current']." AND news_class REGEXP '".e_CLASS_REGEXP."'  AND news_meta_keywords REGEXP ".$tag_regexp."  ORDER BY news_datestamp DESC LIMIT ".$parm['limit'];
+		$query = "
+		SELECT n.*, nc.category_id, nc.category_name, nc.category_sef 
+		FROM #news AS n
+		LEFT JOIN #news_category AS nc ON n.news_category = nc.category_id
+		WHERE n.news_id != ".$parm['current']." AND n.news_class REGEXP '".e_CLASS_REGEXP."'  AND n.news_meta_keywords REGEXP ".$tag_regexp."  ORDER BY n.news_datestamp DESC LIMIT ".$parm['limit'];
 			
 		if($sql->gen($query))
 		{		


### PR DESCRIPTION
Resolving an issue with related news SEF url's not generating properly when news/news-category/news-title is configured in URL's conected to #4040