### PR TITLE
Fixing an issue that with contact form sending unnecessary additional…

### DIFF
--- a/contact.php
+++ b/contact.php
@@ -191,7 +191,7 @@ if(isset($_POST['send-contactus']))
 
 		$CONTACT_EMAIL = e107::getCoreTemplate('contact','email');
 
-		unset($_POST['contact_person'], $_POST['author_name'], $_POST['email_send'] , $_POST['subject'], $_POST['body'], $_POST['rand_num'], $_POST['code_verify'], $_POST['send-contactus']);
+		unset($_POST['contact_person'], $_POST['author_name'], $_POST['email_send'] , $_POST['subject'], $_POST['body'], $_POST['rand_num'], $_POST['code_verify'], $_POST['send-contactus'], $_POST['g-recaptcha-response'],  $_POST['gdpr']);
 
 		if(!empty($_POST)) // support for custom fields in contact template.
 		{


### PR DESCRIPTION
… data

There is an option that dev can add additional fields to contact form, that are sent back. But GDPR field is send back too, also if using NoCaptcha ReCaptcha plugin, response token from Google is send back too.