### PR TITLE
Turn e_date::strptime() into an eShims::strptime()

### DIFF
--- a/e107_handlers/Shims/Internal/ReadfileTrait.php
+++ b/e107_handlers/Shims/Internal/ReadfileTrait.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * e107 website system
+ *
+ * Copyright (C) 2008-2020 e107 Inc (e107.org)
+ * Released under the terms and conditions of the
+ * GNU General Public License (http://www.gnu.org/licenses/gpl.txt)
+ *
+ * Shims for PHP internal functions
+ * readfile()
+ */
+
+namespace e107\Shims\Internal;
+
+trait ReadfileTrait
+{
+	/**
+	 * Outputs a file
+	 *
+	 * Resilient replacement for PHP internal readfile()
+	 *
+	 * @see https://github.com/e107inc/e107/issues/3528 Why this method was implemented
+	 * @param string $filename The filename being read.
+	 * @param bool $use_include_path You can use the optional second parameter and set it to TRUE,
+	 *                               if you want to search for the file in the include_path, too.
+	 * @param resource $context A context stream resource.
+	 * @return int|bool Returns the number of bytes read from the file.
+	 *                   If an error occurs, FALSE is returned.
+	 */
+	public static function readfile($filename, $use_include_path = FALSE, $context = NULL)
+	{
+		$output = @readfile($filename, $use_include_path, $context);
+		if ($output === NULL)
+		{
+			return self::readfile_alt($filename, $use_include_path, $context);
+		}
+		return $output;
+	}
+
+	/**
+	 * Outputs a file
+	 *
+	 * Alternative implementation using file streams
+	 *
+	 * @param $filename
+	 * @param bool $use_include_path
+	 * @param resource $context
+	 * @return bool|int
+	 */
+	public static function readfile_alt($filename, $use_include_path = FALSE, $context = NULL)
+	{
+		// fopen() silently returns false if there is no context
+		if (!is_resource($context)) $context = stream_context_create();
+
+		$handle = @fopen($filename, 'rb', $use_include_path, $context);
+		if ($handle === FALSE) return FALSE;
+		while (!feof($handle))
+		{
+			echo(fread($handle, 8192));
+		}
+		fclose($handle);
+		return filesize($filename);
+	}
+}

--- a/e107_handlers/Shims/Internal/StrptimeTrait.php
+++ b/e107_handlers/Shims/Internal/StrptimeTrait.php
@@ -1,0 +1,163 @@
+<?php
+/**
+ * e107 website system
+ *
+ * Copyright (C) 2008-2020 e107 Inc (e107.org)
+ * Released under the terms and conditions of the
+ * GNU General Public License (http://www.gnu.org/licenses/gpl.txt)
+ *
+ * Shims for PHP internal functions
+ * strptime()
+ */
+
+namespace e107\Shims\Internal;
+
+trait StrptimeTrait
+{
+	/**
+	 * Parse a time/date generated with strftime()
+	 *
+	 * Resilient replacement for PHP internal strptime()
+	 *
+	 * @see https://www.php.net/manual/en/function.strptime.php what this function approximates
+	 * @param string $date The string to parse (e.g. returned from strftime()).
+	 * @param string $format The format used in date (e.g. the same as used in strftime()).
+	 * @return array|bool Returns FALSE on failure.
+	 * 	The following parameters are returned in the array:
+	 *  	"tm_sec"        Seconds after the minute (0-61)
+	 *  	"tm_min"        Minutes after the hour (0-59)
+	 *  	"tm_hour"       Hour since midnight (0-23)
+	 *  	"tm_mday"       Day of the month (1-31)
+	 *  	"tm_mon"        Months since January (0-11)
+	 *  	"tm_year"       Years since 1900
+	 *  	"tm_wday"       Days since Sunday (0-6)
+	 *  	"tm_yday"       Days since January 1 (0-365)
+	 *  	"unparsed"      the date part which was not recognized using the specified format
+	 */
+	public static function strptime($date, $format)
+	{
+		$result = false;
+		if (function_exists('strptime'))
+			$result = strptime($date, $format);
+		if (!is_array($result))
+			$result = self::strptime_alt($date, $format);
+		return $result;
+	}
+
+	/**
+	 * Parse a time/date generated with strftime()
+	 *
+	 * Alternative implementation based on public domain library:
+	 * https://github.com/Polycademy/upgradephp/
+	 *
+	 * @param string $date
+	 * @param string $format
+	 * @return array|bool
+	 */
+	public static function strptime_alt($date, $format)
+	{
+		static $expand = array('%D' => '%m/%d/%y', '%T' => '%H:%M:%S',);
+		static $map_r = array(
+			'%S' => 'tm_sec',
+			'%M' => 'tm_min',
+			'%H' => 'tm_hour',
+			'%I' => 'tm_hour',
+			'%d' => 'tm_mday',
+			'%m' => 'tm_mon',
+			'%Y' => 'tm_year',
+			'%y' => 'tm_year',
+			'%W' => 'tm_wday',
+			'%D' => 'tm_yday',
+			'%u' => 'unparsed',
+		);
+
+		$fullmonth = array();
+		$abrevmonth = array();
+
+		for ($i = 1; $i <= 12; $i++)
+		{
+			$k = strftime('%B', mktime(0, 0, 0, $i));
+			$fullmonth[$k] = $i;
+
+			$j = strftime('%b', mktime(0, 0, 0, $i));
+			$abrevmonth[$j] = $i;
+		}
+
+
+		#-- transform $format into extraction regex
+		$format = str_replace(array_keys($expand), array_values($expand), $format);
+		$preg = preg_replace('/(%\w)/', '(\w+)', preg_quote($format));
+
+		#-- record the positions of all STRFCMD-placeholders
+		preg_match_all('/(%\w)/', $format, $positions);
+		$positions = $positions[1];
+
+		$vals = array();
+
+		#-- get individual values
+		if (preg_match("#$preg#", $date, $extracted))
+		{
+			#-- get values
+			foreach ($positions as $pos => $strfc)
+			{
+				$v = $extracted[$pos + 1];
+				#-- add
+				if (isset($map_r[$strfc]))
+				{
+					$n = $map_r[$strfc];
+					$vals[$n] = ($v > 0) ? (int)$v : $v;
+				}
+				else
+				{
+					if (!isset($vals['unparsed'])) $vals['unparsed'] = '';
+					$vals['unparsed'] .= $v . ' ';
+				}
+			}
+
+			#-- fixup some entries
+			//$vals["tm_wday"] = $names[ substr($vals["tm_wday"], 0, 3) ];
+			if ($vals['tm_year'] >= 1900)
+			{
+				$vals['tm_year'] -= 1900;
+			}
+			elseif ($vals['tm_year'] > 0)
+			{
+				$vals['tm_year'] += 100;
+			}
+
+			if ($vals['tm_mon'])
+			{
+				$vals['tm_mon'] -= 1;
+			}
+
+			if (!isset($vals['tm_sec']))
+			{
+				$vals['tm_sec'] = 0;
+			}
+
+			if (!isset($vals['tm_min']))
+			{
+				$vals['tm_min'] = 0;
+			}
+
+			if (!isset($vals['tm_hour']))
+			{
+				$vals['tm_hour'] = 0;
+			}
+
+
+			if (!isset($vals['unparsed']))
+			{
+				$vals['unparsed'] = '';
+			}
+
+			$unxTimestamp = mktime($vals['tm_hour'], $vals['tm_min'], $vals['tm_sec'], ($vals['tm_mon'] + 1), $vals['tm_mday'], ($vals['tm_year'] + 1900));
+
+			$vals['tm_wday'] = (int)strftime('%w', $unxTimestamp); // Days since Sunday (0-6)
+			$vals['tm_yday'] = (strftime('%j', $unxTimestamp) - 1); // Days since January 1 (0-365)
+		}
+
+		return !empty($vals) ? $vals : false;
+
+	}
+}

--- a/e107_handlers/Shims/InternalShims.php
+++ b/e107_handlers/Shims/InternalShims.php
@@ -2,7 +2,7 @@
 /**
  * e107 website system
  *
- * Copyright (C) 2008-2018 e107 Inc (e107.org)
+ * Copyright (C) 2008-2020 e107 Inc (e107.org)
  * Released under the terms and conditions of the
  * GNU General Public License (http://www.gnu.org/licenses/gpl.txt)
  *

--- a/e107_handlers/Shims/InternalShimsTrait.php
+++ b/e107_handlers/Shims/InternalShimsTrait.php
@@ -14,4 +14,5 @@ namespace e107\Shims;
 trait InternalShimsTrait
 {
 	use Internal\ReadfileTrait;
+	use Internal\StrptimeTrait;
 }

--- a/e107_handlers/Shims/InternalShimsTrait.php
+++ b/e107_handlers/Shims/InternalShimsTrait.php
@@ -2,7 +2,7 @@
 /**
  * e107 website system
  *
- * Copyright (C) 2008-2018 e107 Inc (e107.org)
+ * Copyright (C) 2008-2020 e107 Inc (e107.org)
  * Released under the terms and conditions of the
  * GNU General Public License (http://www.gnu.org/licenses/gpl.txt)
  *
@@ -13,51 +13,5 @@ namespace e107\Shims;
 
 trait InternalShimsTrait
 {
-	/**
-	 * Outputs a file
-	 *
-	 * Resilient replacement for PHP internal readfile()
-	 *
-	 * @see https://github.com/e107inc/e107/issues/3528 Why this method was implemented
-	 * @param string $filename The filename being read.
-	 * @param bool $use_include_path You can use the optional second parameter and set it to TRUE,
-	 *                               if you want to search for the file in the include_path, too.
-	 * @param resource $context A context stream resource.
-	 * @return int|bool Returns the number of bytes read from the file.
-	 *                   If an error occurs, FALSE is returned.
-	 */
-	public static function readfile($filename, $use_include_path = FALSE, $context = NULL)
-	{
-		$output = @readfile($filename, $use_include_path, $context);
-		if ($output === NULL)
-		{
-			return self::readfile_alt($filename, $use_include_path, $context);
-		}
-		return $output;
-	}
-
-	/**
-	 * Outputs a file
-	 *
-	 * Alternative implementation using file streams
-	 *
-	 * @param $filename
-	 * @param bool $use_include_path
-	 * @param resource $context
-	 * @return bool|int
-	 */
-	public static function readfile_alt($filename, $use_include_path = FALSE, $context = NULL)
-	{
-		// fopen() silently returns false if there is no context
-		if (!is_resource($context)) $context = stream_context_create();
-
-		$handle = @fopen($filename, 'rb', $use_include_path, $context);
-		if ($handle === FALSE) return FALSE;
-		while (!feof($handle))
-		{
-			echo(fread($handle, 8192));
-		}
-		fclose($handle);
-		return filesize($filename);
-	}
+	use Internal\ReadfileTrait;
 }

--- a/e107_handlers/php_compatibility_handler.php
+++ b/e107_handlers/php_compatibility_handler.php
@@ -26,17 +26,12 @@ if (!defined('e107_INIT'))
  */
 
 
-
-
 if (!function_exists('strptime'))
 {
-
-	define('STRPTIME_COMPAT', true);
-	function strptime($str, $format)
+	function strptime($date, $format)
 	{
-		return e107::getDate()->strptime($str,$format);	
-	} 
-	
+		return eShims::strptime($date, $format);
+	}
 }
 
 //PHP < 5.2 compatibility

--- a/e107_tests/tests/unit/e107/Shims/StrptimeTest.php
+++ b/e107_tests/tests/unit/e107/Shims/StrptimeTest.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * e107 website system
+ *
+ * Copyright (C) 2008-2020 e107 Inc (e107.org)
+ * Released under the terms and conditions of the
+ * GNU General Public License (http://www.gnu.org/licenses/gpl.txt)
+ *
+ */
+
+namespace e107\Shims;
+
+class StrptimeTest extends \Codeception\Test\Unit
+{
+	public function testStrptimeDefault()
+	{
+		$this->testStrptimeImplementation([\e107\Shims\InternalShims::class, 'strptime']);
+	}
+
+	public function testStrptimeDefaultLegacy()
+	{
+		$this->testStrptimeImplementation([\eShims::class, 'strptime']);
+	}
+
+	public function testStrptimeAlt()
+	{
+		$this->testStrptimeImplementation([\e107\Shims\InternalShims::class, 'strptime_alt']);
+	}
+
+	protected function testStrptimeImplementation($implementation)
+	{
+		$this->testStrptimeDateOnly($implementation);
+		$this->testStrptimeDateTime($implementation);
+		$this->testStrptimeUnparsed($implementation);
+		$this->testStrptimeInvalid($implementation);
+	}
+
+	protected function testStrptimeDateOnly($implementation)
+	{
+		$actual = call_user_func($implementation, '2018/05/13', '%Y/%m/%d');
+		$expected = array(
+			'tm_year' => 118,
+			'tm_mon' => 4,
+			'tm_mday' => 13,
+			'tm_sec' => 0,
+			'tm_min' => 0,
+			'tm_hour' => 0,
+			'unparsed' => '',
+			'tm_wday' => 0,
+			'tm_yday' => 132,
+		);
+		$this->assertEquals($expected, $actual);
+	}
+
+	protected function testStrptimeDateTime($implementation)
+	{
+		$actual = call_user_func($implementation, '2018/05/13 20:10', '%Y/%m/%d %H:%M');
+		$expected = array(
+			'tm_year' => 118,
+			'tm_mon' => 4,
+			'tm_mday' => 13,
+			'tm_hour' => 20,
+			'tm_min' => 10,
+			'tm_sec' => 0,
+			'unparsed' => '',
+			'tm_wday' => 0,
+			'tm_yday' => 132,
+		);
+		$this->assertEquals($expected, $actual);
+	}
+
+	protected function testStrptimeUnparsed($implementation)
+	{
+		$actual = call_user_func($implementation, '1607-09-04 08:10 PM', '%Y-%m-%d %l:%M %P');
+		$expected = array(
+			'tm_year' => 1707,
+			'tm_mon' => 8,
+			'tm_mday' => 4,
+			'tm_hour' => 0,
+			'tm_min' => 10,
+			'tm_sec' => 0,
+			'unparsed' => '08 PM ',
+			'tm_wday' => 2,
+			'tm_yday' => 246,
+		);
+		$this->assertEquals($expected, $actual);
+	}
+
+	protected function testStrptimeInvalid($implementation)
+	{
+		$actual = call_user_func($implementation, 'garbage', '%Y-%m-%d');
+		$this->assertFalse($actual);
+	}
+}


### PR DESCRIPTION
### Motivation and Context
e107 currently handles a potentially unimplemented built-in function `strptime()` by setting a global constant, `STRPTIME_COMPAT` and then later checking for the constant when `e_date::strptime()` is called to decide whether to use the built-in function or to use a pure PHP replacement implementation.

The [first attempted fix](https://github.com/e107inc/e107/commit/ce510159a9913b104e0c0a07d5018e774f47898b) was just to remove the constant, which broke the method `e_date::strptime()` for Windows due to a stack overflow.  [The change had to be reverted.](https://github.com/e107inc/e107/commit/0b26a972178d624ed6d7535ca5819b9fd132794d)

In reevaluating how to refactor this better, I found that `e_date::strptime()` has non-standard features.  Specifically, the output contains:

- a localized full month name (key `tm_fmon`)
- a localized abbreviated month name (key `tm_amon`)

And the input of _only_ the `STRPTIME_COMPAT` implementation of `e_date::strptime()` accepts:

- a localized full month name
- a localized abbreviated month name
- AM or PM
- am or pm

These are not supported by the built-in `strptime()`, so those features wouldn't work on Linux/Unix/macOS unless `STRPTIME_COMPAT` was forced on.  I could find no documentation or other usage of `STRPTIME_COMPAT`, so it may be best to remove it to avoid confusion between Unix and Windows implementations.

### Description

- Added `\e107\Shims\Internal\StrptimeTrait` as `eShims::strptime()` or `\e107\Shims\InternalShims::strptime()`, which implements PHP internal function `strptime()`. On not-Windows, the built-in function is called. If that function fails or if the operating system is Windows, the alternative pure PHP implementation is attempted. The first successful call is returned, or false if none are successful.
- Deprecated `e_date::strptime()` in favor of `eShims::strptime()`.  `e_date::strptime()` continues to return the non-standard keys `tm_amon` and `tm_fmon`.
- Fixed a misattributed license for `e_date::strptime()` (now `eShims::strptime()`). The library used was public domain, not CC BY-NC-SA 2.0 FR by Lionel Sauron.
- Removed `STRPTIME_COMPAT` constant now that `eShims::strptime()` exists
- Removed support for calling `e_date::strptime()` with:

  - a localized full month name
  - a localized abbreviated month name
  - AM or PM
  - am or pm

  because these features were only implemented in Windows mode (`STRPTIME_COMPAT`).
- `php_compatibility_handler.php` now defines global `strptime()` using the `eShims::strptime()` implementation.
- Tests for all(?) the possibilities of `eShims::strptime()`

Fixes: #4076

### How Has This Been Tested?
`\e107\Shims\Internal\StrptimeTrait` should have 100% test coverage on Unix.  On Windows, the alternative implementation is tested twice due to the built-in `strptime()` not existing.

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code adheres to the e107 [code style standard](https://github.com/e107inc/e107/wiki/e107-Coding-Standard).
- [x] I have read the [**contributing** document](https://github.com/e107inc/e107/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/e107inc/e107/tree/master/e107_tests) to cover my changes.
- [x] All new and existing tests pass.