### PR TITLE
CoreImage: Support path exclusions

### DIFF
--- a/.github/workflows/build-release/CoreImage.php
+++ b/.github/workflows/build-release/CoreImage.php
@@ -9,6 +9,11 @@
 
 abstract class CoreImage
 {
+    const EXCLUDED_PATHS = [
+        'install.php',
+        'robots.txt'
+    ];
+
     protected function create_image($exportFolder, $tempFolder, $currentVersion)
     {
         echo("[Core-Image] Scanning Dir: " . $exportFolder . "\n");
@@ -34,6 +39,7 @@ abstract class CoreImage
             $relativePath = preg_replace("/^" . preg_quote($absoluteBase . "/", "/") . "/", "", $absolutePath);
 
             if (empty($relativePath) || $relativePath == $absolutePath) continue;
+            if ($this->isExcluded($relativePath)) continue;
 
             $checksum = $this->checksumPath($absolutePath);
             $this->insertChecksumIntoDatabase($relativePath, $checksum, $currentVersion);
@@ -126,6 +132,8 @@ abstract class CoreImage
             );
             foreach ($removedFiles as $removedFilePath)
             {
+                if ($this->isExcluded($removedFilePath)) continue;
+
                 $checksum = $this->checksumPath($timeMachineFolder . '/' . $removedFilePath);
                 $this->insertChecksumIntoDatabase($removedFilePath, $checksum, $version);
             }
@@ -156,5 +164,15 @@ abstract class CoreImage
         $data .= "if (!defined('e107_INIT')) { exit; }\n\n";
 
         return $data;
+    }
+
+    /**
+     * Determines whether the provided relative path should make it into the generated integrity database
+     * @param $relativePath string Relative path candidate
+     * @return bool TRUE if the relative path should not be added to the integrity database; FALSE otherwise
+     */
+    protected function isExcluded($relativePath)
+    {
+        return in_array($relativePath, self::EXCLUDED_PATHS);
     }
 }


### PR DESCRIPTION
### Motivation and Context
`install.php` and `robots.txt` should not be in the integrity database.

### Description
Adds an exclusion list to class `CoreImage`

### How Has This Been Tested?
Didn't test, but the build's `./e107_admin/core_image.php` should no longer have the excluded paths.

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code adheres to the e107 [code style standard](https://github.com/e107inc/e107/wiki/e107-Coding-Standard).
- [x] I have read the [**contributing** document](https://github.com/e107inc/e107/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/e107inc/e107/tree/master/e107_tests) to cover my changes.
- [x] All new and existing tests pass.