### PR TITLE
Enable PHP session file garbage collection

### DIFF
--- a/e107_handlers/session_handler.php
+++ b/e107_handlers/session_handler.php
@@ -194,59 +194,58 @@ class e_session
 	 */
 	public function setDefaultSystemConfig()
 	{
-		if(!$this->getSessionId())
-		{
-			$config = array(
-				'ValidateRemoteAddr' 		=> (e_SECURITY_LEVEL >= self::SECURITY_LEVEL_BALANCED),
-				'ValidateHttpVia' 			=> (e_SECURITY_LEVEL >= self::SECURITY_LEVEL_HIGH),
-				'ValidateHttpXForwardedFor' => (e_SECURITY_LEVEL >= self::SECURITY_LEVEL_BALANCED),
-				'ValidateHttpUserAgent' 	=> (e_SECURITY_LEVEL >= self::SECURITY_LEVEL_HIGH),
-			);
-			
-			$options = array(
-		//		'httponly' => (e_SECURITY_LEVEL >= self::SECURITY_LEVEL_PARANOID),
-				'httponly' => true,
-			);
-			
-			if(!defined('E107_INSTALL'))
-			{
-				$systemSaveMethod = ini_get('session.save_handler');
+        if ($this->getSessionId()) return $this;
 
-			//	e107::getDebug()->log("Save Method:".$systemSaveMethod);
+        $config = array(
+            'ValidateRemoteAddr' => (e_SECURITY_LEVEL >= self::SECURITY_LEVEL_BALANCED),
+            'ValidateHttpVia' => (e_SECURITY_LEVEL >= self::SECURITY_LEVEL_HIGH),
+            'ValidateHttpXForwardedFor' => (e_SECURITY_LEVEL >= self::SECURITY_LEVEL_BALANCED),
+            'ValidateHttpUserAgent' => (e_SECURITY_LEVEL >= self::SECURITY_LEVEL_HIGH),
+        );
 
-				$saveMethod = (!empty($systemSaveMethod)) ? $systemSaveMethod : 'files';
+        $options = array(
+            //		'httponly' => (e_SECURITY_LEVEL >= self::SECURITY_LEVEL_PARANOID),
+            'httponly' => true,
+        );
 
-				$config['SavePath'] = e107::getPref('session_save_path', false); // FIXME - new pref
-				$config['SaveMethod'] = e107::getPref('session_save_method', $saveMethod); // FIXME - new pref
-				$options['lifetime'] = (integer) e107::getPref('session_lifetime', 86400); //
-				$options['path'] = e107::getPref('session_cookie_path', ''); // FIXME - new pref
-				$options['secure'] = e107::getPref('ssl_enabled', false); //
+        if (!defined('E107_INSTALL'))
+        {
+            $systemSaveMethod = ini_get('session.save_handler');
 
-				if(!empty($options['secure']))
-				{
-					ini_set('session.cookie_secure', 1);
-				}
-			}
+            //	e107::getDebug()->log("Save Method:".$systemSaveMethod);
 
-			if(defined('SESSION_SAVE_PATH')) // safer than a pref.
-			{
-				$config['SavePath'] = e_BASE. SESSION_SAVE_PATH;
-			}
+            $saveMethod = (!empty($systemSaveMethod)) ? $systemSaveMethod : 'files';
 
-			$hashes = hash_algos();
+            $config['SavePath'] = e107::getPref('session_save_path', false); // FIXME - new pref
+            $config['SaveMethod'] = e107::getPref('session_save_method', $saveMethod); // FIXME - new pref
+            $options['lifetime'] = (integer)e107::getPref('session_lifetime', 86400); //
+            $options['path'] = e107::getPref('session_cookie_path', ''); // FIXME - new pref
+            $options['secure'] = e107::getPref('ssl_enabled', false); //
 
-			if((e_SECURITY_LEVEL >= self::SECURITY_LEVEL_BALANCED) && in_array('sha512',$hashes))
-			{
-				ini_set('session.hash_function', 'sha512');
-				ini_set('session.hash_bits_per_character', 5);
-			}
+            if (!empty($options['secure']))
+            {
+                ini_set('session.cookie_secure', 1);
+            }
+        }
 
-			
-			$this->setConfig($config)
-				->setOptions($options);
-		}
+        if (defined('SESSION_SAVE_PATH')) // safer than a pref.
+        {
+            $config['SavePath'] = e_BASE . SESSION_SAVE_PATH;
+        }
 
-		return $this;
+        $hashes = hash_algos();
+
+        if ((e_SECURITY_LEVEL >= self::SECURITY_LEVEL_BALANCED) && in_array('sha512', $hashes))
+        {
+            ini_set('session.hash_function', 'sha512');
+            ini_set('session.hash_bits_per_character', 5);
+        }
+
+
+        $this->setConfig($config)
+            ->setOptions($options);
+
+        return $this;
 	}
 	
 	/**

--- a/e107_handlers/session_handler.php
+++ b/e107_handlers/session_handler.php
@@ -241,12 +241,30 @@ class e_session
             ini_set('session.hash_bits_per_character', 5);
         }
 
+        $this->fixSessionFileGarbageCollection();
 
         $this->setConfig($config)
             ->setOptions($options);
 
         return $this;
 	}
+
+    /**
+     * Modify PHP ini at runtime to enable session file garbage collection
+     *
+     * Takes no action if the garbage collector is already enabled.
+     *
+     * @see https://github.com/e107inc/e107/issues/4113
+     * @return void
+     */
+	private function fixSessionFileGarbageCollection()
+    {
+        $gc_probability = ini_get('session.gc_probability');
+        if ($gc_probability > 0) return;
+
+        ini_set('session.gc_probability', 1);
+        ini_set('session.gc_divisor', 100);
+    }
 	
 	/**
 	 * Retrieve value from current session namespace


### PR DESCRIPTION
### Motivation and Context
An e107 administrator's hosting account could run out of inodes if their `php.ini` does not enable PHP session file garbage collection.

### Description
This pull request modifies the session behavior of e107 to enable session file garbage collection at runtime only if it is not already enabled.

### How Has This Been Tested?
The change has not been tested.

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code adheres to the e107 [code style standard](https://github.com/e107inc/e107/wiki/e107-Coding-Standard).
- [x] I have read the [**contributing** document](https://github.com/e107inc/e107/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/e107inc/e107/tree/master/e107_tests) to cover my changes.
- [x] All new and existing tests pass.