### PR TITLE
Don't populate e_user_model as a logged in user if the password is wrong

### DIFF
--- a/e107_handlers/login.php
+++ b/e107_handlers/login.php
@@ -342,8 +342,8 @@ class userlogin
 	 * Note: PASSWORD IS NOT VERIFIED BY THIS ROUTINE
 	 * @param string $username - as entered
 	 * @param boolean $forceLogin - TRUE if login is being forced from clicking signup link; normally FALSE
-	 * @return TRUE if name exists, and $this->userData array set up
-	 *		   otherwise FALSE
+	 * @return boolean TRUE if name exists, and $this->userData array set up
+	 *		           FALSE otherwise
 	 */
 	protected function lookupUser($username, $forceLogin)
 	{
@@ -540,7 +540,7 @@ class userlogin
 		global $pref, $sql;
 
 		$doCheck = FALSE;			// Flag set if need to ban check
-
+		$this->userData = array();
 
 		switch($reason)
 		{

--- a/e107_handlers/login.php
+++ b/e107_handlers/login.php
@@ -625,7 +625,7 @@ class userlogin
 			return $message;
 		}
 
-		define('LOGINMESSAGE', $message);
+		defined('LOGINMESSAGE') or define('LOGINMESSAGE', $message);
 
 	//	$sql->update('online', 'user_active = 0 WHERE user_ip = "'.$this->userIP.'" LIMIT 1');
 

--- a/e107_handlers/user_model.php
+++ b/e107_handlers/user_model.php
@@ -1592,12 +1592,12 @@ class e_user extends e_user_model
 		if($this->isUser()) return false;
 
 		$userlogin = new userlogin();
-		$userlogin->login($uname, $upass_plain, $uauto, $uchallange, $noredirect);
-		
+		$loginSuccess = $userlogin->login($uname, $upass_plain, $uauto, $uchallange, $noredirect);
+
 		$userdata  = $userlogin->getUserData(); 
-		
 		$this->setSessionData(true)->setData($userdata);
-		
+		if ($loginSuccess === false) return false;
+
 		e107::getEvent()->trigger('user_login', $userdata); 	
 
 		return $this->isUser();

--- a/e107_tests/tests/unit/e_user_modelTest.php
+++ b/e107_tests/tests/unit/e_user_modelTest.php
@@ -377,7 +377,15 @@
 
 		}
 */
+		/**
+		 * @see https://github.com/e107inc/e107/issues/4236
+		 */
+		public function testUserLoginWrongCredentialsNotUser()
+		{
+			$user = e107::getUser();
+			$user->login("e107", "DefinitelyTheWrongPassword");
 
-
-
+			$this->assertFalse($user->isUser());
+			$this->assertEmpty($user->getData());
+		}
 	}

--- a/e107_tests/tests/unit/e_user_modelTest.php
+++ b/e107_tests/tests/unit/e_user_modelTest.php
@@ -388,4 +388,24 @@
 			$this->assertFalse($user->isUser());
 			$this->assertEmpty($user->getData());
 		}
+
+		public function testUserLoginFailureDoesNotTriggerUserLoginEvent()
+		{
+			$originalEventHandler = e107::getRegistry('core/e107/singleton/e107_event');
+			$mockEventHandler = $this->createMock(e107_event::class);
+			$mockEventHandler->expects($this->never())->method('trigger');
+			e107::setRegistry('core/e107/singleton/e107_event', $mockEventHandler);
+
+			try
+			{
+				$user = e107::getUser();
+				$user->login("e107", "DefinitelyTheWrongPassword");
+
+				e107::getEvent();
+			}
+			finally
+			{
+				e107::setRegistry('core/e107/singleton/e107_event', $originalEventHandler);
+			}
+		}
 	}


### PR DESCRIPTION
### Motivation and Context
It is not intuitive for `e107::getUser()->isUser()` to be true an `e107::getUser->getData()` to return all the user's information if `e107::getUser()->login()` is called with a valid username but wrong password.

Issue: #4236

### Description
This pull request ensures that `e_user_model`:
- Does not populate `e_user_model` with user data if the `e_user_model::login()` method fails to log in the specified user and
- Does not trigger a "`user_login`" event if authentication fails.

### How Has This Been Tested?
See the tests added to `e_user_modelTest`.

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code adheres to the e107 [code style standard](https://github.com/e107inc/e107/wiki/e107-Coding-Standard).
- [x] I have read the [**contributing** document](https://github.com/e107inc/e107/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/e107inc/e107/tree/master/e107_tests) to cover my changes.
- [x] All new and existing tests pass.