### PR TITLE
removing google plus key #4305 from {XURL_ICONS}

### DIFF
--- a/e107_plugins/social/e_shortcode.php
+++ b/e107_plugins/social/e_shortcode.php
@@ -70,7 +70,6 @@ class social_shortcodes extends e_shortcode
 			'rss'			=> array('href'=> (e107::isInstalled('rss_menu') ? e107::url('rss_menu', 'index', array('rss_url'=>'news')) : ''), 'title'=>'RSS/Atom Feed'),
 			'facebook'		=> array('href'=> deftrue('XURL_FACEBOOK'), 	'title'=>'Facebook'),
 			'twitter'		=> array('href'=> deftrue('XURL_TWITTER'),		'title'=>'Twitter'),
-			'google-plus'	=> array('href'=> deftrue('XURL_GOOGLE'),		'title'=>'Google Plus'),
 			'linkedin'		=> array('href'=> deftrue('XURL_LINKEDIN'),		'title'=>'LinkedIn'),
 			'github'		=> array('href'=> deftrue('XURL_GITHUB'),		'title'=>'Github'),
 			'pinterest'		=> array('href'=> deftrue('XURL_PINTEREST'),	'title'=>'Pinterest'),


### PR DESCRIPTION
It is displayed after clean installation. 

True is that it is fixed after resaving your social pages, but by default, it is there and related HTML markup too,
 

 