### PR TITLE
core social icons are not FA anymore  #4305

### DIFF
--- a/e107_plugins/social/e_shortcode.php
+++ b/e107_plugins/social/e_shortcode.php
@@ -86,6 +86,7 @@ class social_shortcodes extends e_shortcode
 		// print_a($social);
 	
 		$class      = (vartrue($parm['size'])) ?  'fa-'.$parm['size'] : '';
+		$class      = (vartrue($parm['class'])) ?  $parm['class'] : $class;
 
 		// @deprecated - use template.
 		/*


### PR DESCRIPTION
If you want to use core social links, size parm is useless.  This way you can style your links without a theme template.

 