### PR TITLE
Automated Acceptance Tests

### DIFF
--- a/.github/workflows/test-acceptance.yml
+++ b/.github/workflows/test-acceptance.yml
@@ -1,0 +1,53 @@
+name: Acceptance Tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test-acceptance:
+    runs-on: ubuntu-latest
+    container:
+      image: php:latest
+    services:
+      target:
+        image: ghcr.io/e107inc/e107/e107-dev:latest
+        ports:
+          - 22
+          - 80
+          - 3306
+        options: >-
+          --tmpfs /tmp
+          --tmpfs /run
+          --tmpfs /run/lock
+          --volume /sys/fs/cgroup:/sys/fs/cgroup:ro
+
+    steps:
+      - name: Install system dependencies
+        run: |
+          apt-get update
+          apt-get install -y git zip libzip-dev sshpass rsync
+
+      - name: Install necessary PHP extensions
+        run: docker-php-ext-install -j "$(nproc)" zip pdo_mysql mysqli
+
+      - uses: actions/checkout@v2
+
+      - name: Install Composer
+        run: curl -sSL https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin/ --filename=composer
+
+      - name: Install test dependencies
+        run: composer update --prefer-dist --no-progress
+        working-directory: ./e107_tests/
+
+      - name: Download Git submodule dependencies
+        run: git submodule update --init --recursive --remote
+
+      - name: Install the CI test configuration file
+        run: |
+          cp ./e107_tests/lib/ci/config.ci.yml ./e107_tests/config.yml
+          sed -i "s/host: 'db'/host: 'target'/" ./e107_tests/config.yml
+
+      - name: Run acceptance tests
+        run: php ./vendor/bin/codecept run acceptance --steps --debug
+        working-directory: ./e107_tests/

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -11,7 +11,7 @@ env:
   CC_TEST_REPORTER_ID: 8948074581c1ffe7f4e47995c65d7d303882310256edd73536723d7c92adb1e3
 
 jobs:
-  test:
+  test-unit:
     strategy:
       fail-fast: false
       matrix:
@@ -105,7 +105,7 @@ jobs:
     - name: Install Composer
       run: curl -sSL https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin/ --filename=composer
 
-    - name: Install dependencies
+    - name: Install test dependencies
       run: composer update --prefer-dist --no-progress
       working-directory: ./e107_tests/
 

--- a/e107_tests/lib/ci/Dockerfile
+++ b/e107_tests/lib/ci/Dockerfile
@@ -1,0 +1,27 @@
+FROM ubuntu:20.04
+
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN apt-get update
+RUN apt-get install -y wget gnupg
+RUN wget -O - https://repo.saltstack.com/py3/ubuntu/20.04/amd64/latest/SALTSTACK-GPG-KEY.pub | apt-key add -
+RUN mkdir -pv /etc/apt/sources.list.d/
+RUN echo 'deb http://repo.saltstack.com/py3/ubuntu/20.04/amd64/latest focal main' |\
+    tee /etc/apt/sources.list.d/saltstack.list
+RUN apt-get update
+RUN apt-get install -y systemd-sysv salt-minion openssh-server rsync
+RUN systemctl disable salt-minion.service
+RUN mkdir -pv /etc/salt/
+
+COPY salt /var/tmp/salt
+COPY config.ci.yml /var/tmp/salt/pillars/config-local.sls
+RUN rm -fv /var/tmp/salt/pillars/config.sls && touch /var/tmp/salt/pillars/config.sls
+RUN rm -fv /var/tmp/salt/pillars/config-sample.sls && touch /var/tmp/salt/pillars/config-sample.sls
+RUN cp -fv /var/tmp/salt/master /etc/salt/minion
+
+WORKDIR /var/tmp/salt
+RUN salt-call -l debug --id=e107-dev --local state.apply e107-dev
+WORKDIR /
+
+VOLUME ["/sys/fs/cgroup"]
+ENTRYPOINT ["/usr/sbin/init"]

--- a/e107_tests/lib/ci/config.ci.yml
+++ b/e107_tests/lib/ci/config.ci.yml
@@ -1,9 +1,15 @@
 ---
-deployer: 'local'
-url: 'http://set-this-to-your-acceptance-test-url.local/'
+deployer: 'sftp'
+url: 'http://target/e107/'
 db:
   host: 'db'
   dbname: 'app'
   user: 'root'
   password: 'Database Password for Continuous Integration'
   populate: true
+fs:
+  host: 'target'
+  user: 'www-data'
+  port: '22'
+  password: 'UNIX Password for Continuous Integration'
+  path: '/var/www/html/e107/'

--- a/e107_tests/lib/deployers/SFTPDeployer.php
+++ b/e107_tests/lib/deployers/SFTPDeployer.php
@@ -34,7 +34,8 @@ class SFTPDeployer extends Deployer
 
 	private function generateRsyncRemoteShell()
 	{
-		$prefix = 'ssh -p '.escapeshellarg($this->getFsParam('port'));
+		$prefix = 'ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -p '.
+			escapeshellarg($this->getFsParam('port'));
 		if (!empty($this->getFsParam('privkey_path')))
 			return $prefix.' -i ' . escapeshellarg($this->getFsParam('privkey_path'));
 		else


### PR DESCRIPTION
### Motivation and Context
e107 has had automated unit tests running in the main repository since [28 December 2019](https://github.com/e107inc/e107/pull/4038).  Acceptance tests existed at the time, but there was no build pipeline that verified them… 𝓾𝓷𝓽𝓲𝓵 𝓷𝓸𝔀!

To run acceptance tests, a full e107 system (web server, database server, and e107 itself) must be deployed and then orchestrated by [the Codeception acceptance test system](https://codeception.com/docs/03-AcceptanceTests), and a web browser must start up to browse the e107 site.  The unit tests already running only have the database server and various PHP interpreters, so acceptance tests need quite a lot more setup.

### Description
This pull request introduces automated acceptance tests running the acceptance tests that have already been written.

To start, automated acceptance tests run on the new [`ghcr.io/e107inc/e107/e107-dev` container image](https://github.com/orgs/e107inc/packages/container/package/e107%2Fe107-dev), which is a [systemd](https://www.freedesktop.org/wiki/Software/systemd/)-based full [Ubuntu](https://ubuntu.com/) 20.04 operating system.  A [Dockerfile](https://docs.docker.com/engine/reference/builder/), with the help of [SaltStack](https://www.saltstack.com/), builds that image with Apache, PHP, MariaDB, and OpenSSH Server.  The GitHub Actions workflow spawns a client container that deploys e107 to the acceptance test container and runs the acceptance tests in an automated fashion.

### How Has This Been Tested?
The introduction of automated acceptance tests was tested in the head repository's GitHub Actions: https://github.com/Deltik/e107/runs/1619192554?check_suite_focus=true

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code adheres to the e107 [code style standard](https://github.com/e107inc/e107/wiki/e107-Coding-Standard).
- [x] I have read the [**contributing** document](https://github.com/e107inc/e107/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/e107inc/e107/tree/master/e107_tests) to cover my changes.
- [x] All new and existing tests pass.