### PR TITLE
adding custom class to be able style just PM link

### DIFF
--- a/e107_plugins/pm/e_shortcode.php
+++ b/e107_plugins/pm/e_shortcode.php
@@ -61,7 +61,7 @@ class pm_shortcodes extends e_shortcode
 		$urlOutbox = e107::url('pm','index','', array('query'=>array('mode'=>'outbox')));
 		$urlCompose = e107::url('pm','index','', array('query'=>array('mode'=>'send')));
 
-		return '<a class="nav-link dropdown-toggle" data-toggle="dropdown" data-bs-toggle="dropdown" href="#">'.$icon.$count.'</a>
+		return '<a class="pm_nav nav-link dropdown-toggle" data-toggle="dropdown" data-bs-toggle="dropdown" href="#">'.$icon.$count.'</a>
 		<ul class="dropdown-menu dropdown-menu-end">
 		<li>
 			<a class="dropdown-item" href="'.$urlInbox.'">'.LAN_PLUGIN_PM_INBOX.'</a>


### PR DESCRIPTION
Now it has clean bootstrap markup. If you have a higher menu, the position of PM icon is wrong (it is correct, the height of the icon is different than the avatar or text itself), but you need a class to be able to fix this position without changing other stuff.

 