### PR TITLE
fix for always black gallery slidershow background

### DIFF
--- a/e107_plugins/gallery/js/gallery.cycle.js
+++ b/e107_plugins/gallery/js/gallery.cycle.js
@@ -20,6 +20,7 @@ var e107 = e107 || {'settings': {}, 'behaviors': {}};
 					speed: settings.gallery.speed,  // speed of the transition (any valid fx speed value)
 					timeout: settings.gallery.timeout,
 					slideExpr: '.slide',
+                    cleartypeNoBg:    true, 
 					pause: 1, // pause on hover - TODO pref
 					activePagerClass: '.gallery-slide-jumper-selected',
 					before: function (currSlideElement, nextSlideElement, options, forwardFlag)


### PR DESCRIPTION
https://github.com/e107inc/e107/issues/4069
 
### Motivation and Context
to be able to change slideshow background-color

### Description
There is IE6 (no kidding) fix in the actual cycle code:

```
// fix clearType problems in ie6 by setting an explicit bg color
// (otherwise text slides look horrible during a fade transition)
```

That fix is a way how to disable it.

### Source:
https://forum.jquery.com/topic/jquery-background-color-is-being-applied-when-using-cycle-plugin

### Problem:
Problem is that it nowadays doesn't work this way... you can set any background for the parent of slides and slides have always black background.  So I suppose that this is the reason why you hardcoded the black background in gallery.css.  Now it can be changed in theme style.css



 