### PR TITLE
Update lan_news.php

### DIFF
--- a/e107_languages/English/lan_news.php
+++ b/e107_languages/English/lan_news.php
@@ -12,7 +12,7 @@
 
 
 
-
+define("LAN_PLUGIN_NEWS_NAME", "News");
 define("LAN_NEWS_1", "News for specific members only");
 define("LAN_NEWS_2", "You are not allowed to see this news");
 //define("LAN_NEWS_5", "Error! Was unable to update news item into database!");


### PR DESCRIPTION
added new define

<!--- Please fill out the following template, which will help other contributors review your GitHub pull request. -->

<!--- Provide a general summary of your changes in the title section above. -->

### Motivation and Context
Recent change of constant from PAGE_NAME  to LAN_PLUGIN_NEWS_NAME


### Description
Recent change of constant from PAGE_NAME (deleted) replaced by LAN_PLUGIN_NEWS_NAME
a new constant was not added to the language folder (eg languages/English/lan_news.php). This change adds the new LAN and define.

### How Has This Been Tested?
Adding the new LAN to lan_news php in 2 different installments 
Php 7 and php 8 

### Types of Changes
Since define now can be seen by the system it displays the correct name on top of the news LIST
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code adheres to the e107 [code style standard](https://github.com/e107inc/e107/wiki/e107-Coding-Standard).
- [x] I have read the [**contributing** document](https://github.com/e107inc/e107/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/e107inc/e107/tree/master/e107_tests) to cover my changes.
- [x] All new and existing tests pass.