### PR TITLE
#2898 fix comments offsets for bootstrap4

### DIFF
--- a/e107_handlers/comment_class.php
+++ b/e107_handlers/comment_class.php
@@ -263,7 +263,7 @@ class comment
 			
 			// -------------------------------------------------------------
 			
-			$indent = ($action == 'reply') ? " class='media col-md-offset-1 offset1' " : " class='media' ";
+			$indent = ($action == 'reply') ? " class='media offset-md-1 col-md-offset-1 offset1' " : " class='media' ";
 			$formid = ($action == 'reply') ? "e-comment-form-reply" : "e-comment-form";
 			
 			$text = "\n<div{$indent}>\n".e107::getMessage()->render('postcomment', true, false, false);//temporary here
@@ -482,7 +482,7 @@ class comment
 			{
 
 				$renderstyle = $COMMENT_TEMPLATE['item_start'];
-				$renderstyle .= "<div class='row media offset".$width." col-md-".(12 - (int) $width)." col-md-offset-".$width."' >".$COMMENT_TEMPLATE['item']."</div>";
+				$renderstyle .= "<div class='row media offset".$width." col-md-".(12 - (int) $width)." offset-md-".$width." col-md-offset-".$width."' >".$COMMENT_TEMPLATE['item']."</div>";
 				$renderstyle .= $COMMENT_TEMPLATE['item_end'];					
 			}
 			else


### PR DESCRIPTION
 #2898 fix comments offsets for bootstrap4

it should be tested, I did it only for metis theme. 