### PR TITLE
Migrate database charset to utf8mb4 and storage engine to InnoDB

### DIFF
--- a/e107_admin/db.php
+++ b/e107_admin/db.php
@@ -491,7 +491,7 @@ class system_tools
 			if(vartrue($_POST['createdb']))
 			{
 			
-				if($sql->gen("CREATE DATABASE ".$database." CHARACTER SET `utf8`"))
+				if($sql->gen("CREATE DATABASE ".$database." CHARACTER SET `utf8mb4`"))
 				{
 					$mes->addSuccess(DBLAN_75);
 					
@@ -556,7 +556,7 @@ class system_tools
 		preg_match_all("/create(.*?)(?:myisam|innodb);/si", $sql_data, $result );
 
 
-		$sql->gen('SET NAMES `utf8`');
+		$sql->gen('SET NAMES `utf8mb4`');
 
 		foreach ($result[0] as $sql_table)
 		{
@@ -769,11 +769,11 @@ class system_tools
 					<td>".$row['Name']."</td>
 					<td>".$row['Engine']."</td>
 					<td>".$row['Collation']."</td>
-					<td>".(($row['Collation'] == 'utf8_general_ci') ? defset('ADMIN_TRUE_ICON') : defset('ADMIN_FALSE_ICON'))."</td>
+					<td>".(($row['Collation'] == 'utf8mb4_general_ci') ? defset('ADMIN_TRUE_ICON') : defset('ADMIN_FALSE_ICON'))."</td>
 					</tr>";
 			//	 print_a($row);
 				
-				if($row['Collation'] != 'utf8_general_ci')
+				if($row['Collation'] != 'utf8mb4_general_ci')
 				{
 					$invalidCollations = true;	
 				}
@@ -842,12 +842,12 @@ class system_tools
 		
 	
 		$queries = array();
-		$queries[] = $this->getQueries("SELECT CONCAT('ALTER TABLE `', table_name, '` MODIFY ', column_name, ' ', REPLACE(column_type, 'char', 'binary'), ';') FROM information_schema.columns WHERE TABLE_SCHEMA = '".$dbtable."' AND TABLE_NAME LIKE '".$config['mySQLprefix']."%' AND  COLLATION_NAME != 'utf8_general_ci'  and data_type LIKE '%char%';");
-		$queries[] = $this->getQueries("SELECT CONCAT('ALTER TABLE `', table_name, '` MODIFY ', column_name, ' ', REPLACE(column_type, 'text', 'blob'), ';') FROM information_schema.columns WHERE TABLE_SCHEMA = '".$dbtable."' AND TABLE_NAME LIKE '".$config['mySQLprefix']."%' AND  COLLATION_NAME != 'utf8_general_ci' and data_type LIKE '%text%';");
+		$queries[] = $this->getQueries("SELECT CONCAT('ALTER TABLE `', table_name, '` MODIFY ', column_name, ' ', REPLACE(column_type, 'char', 'binary'), ';') FROM information_schema.columns WHERE TABLE_SCHEMA = '".$dbtable."' AND TABLE_NAME LIKE '".$config['mySQLprefix']."%' AND  COLLATION_NAME != 'utf8mb4_general_ci'  and data_type LIKE '%char%';");
+		$queries[] = $this->getQueries("SELECT CONCAT('ALTER TABLE `', table_name, '` MODIFY ', column_name, ' ', REPLACE(column_type, 'text', 'blob'), ';') FROM information_schema.columns WHERE TABLE_SCHEMA = '".$dbtable."' AND TABLE_NAME LIKE '".$config['mySQLprefix']."%' AND  COLLATION_NAME != 'utf8mb4_general_ci' and data_type LIKE '%text%';");
 
 		$queries2 = array();
-		$queries2[] = $this->getQueries("SELECT CONCAT('ALTER TABLE `', table_name, '` MODIFY ', column_name, ' ', column_type, ' CHARACTER SET utf8;') FROM information_schema.columns WHERE TABLE_SCHEMA ='".$dbtable."' AND TABLE_NAME LIKE '".$config['mySQLprefix']."%'  AND COLLATION_NAME != 'utf8_general_ci' and data_type LIKE '%char%';");
-		$queries2[] = $this->getQueries("SELECT CONCAT('ALTER TABLE `', table_name, '` MODIFY ', column_name, ' ', column_type, ' CHARACTER SET utf8;') FROM information_schema.columns WHERE TABLE_SCHEMA = '".$dbtable."' AND TABLE_NAME LIKE '".$config['mySQLprefix']."%' AND  COLLATION_NAME != 'utf8_general_ci' and data_type LIKE '%text%';");
+		$queries2[] = $this->getQueries("SELECT CONCAT('ALTER TABLE `', table_name, '` MODIFY ', column_name, ' ', column_type, ' CHARACTER SET utf8mb4;') FROM information_schema.columns WHERE TABLE_SCHEMA ='".$dbtable."' AND TABLE_NAME LIKE '".$config['mySQLprefix']."%'  AND COLLATION_NAME != 'utf8mb4_general_ci' and data_type LIKE '%char%';");
+		$queries2[] = $this->getQueries("SELECT CONCAT('ALTER TABLE `', table_name, '` MODIFY ', column_name, ' ', column_type, ' CHARACTER SET utf8mb4;') FROM information_schema.columns WHERE TABLE_SCHEMA = '".$dbtable."' AND TABLE_NAME LIKE '".$config['mySQLprefix']."%' AND  COLLATION_NAME != 'utf8mb4_general_ci' and data_type LIKE '%text%';");
 
 
 	//	$sql->gen("USE ".$dbtable);
@@ -881,7 +881,7 @@ class system_tools
 		// Convert Table Fields to utf8
 		$sql2 = e107::getDb('sql2');
 		
-		$sql->gen('SHOW TABLE STATUS WHERE Collation != "utf8_general_ci" ');
+		$sql->gen('SHOW TABLE STATUS WHERE Collation != "utf8mb4_general_ci" ');
 		while ($row = $sql->fetch())
 		{
    			$table = $row['Name'];
@@ -892,7 +892,7 @@ class system_tools
 			}
 			
 			
-			$tab_query = "ALTER TABLE ".$table."  DEFAULT CHARACTER SET utf8 COLLATE utf8_general_ci; ";
+			$tab_query = "ALTER TABLE ".$table."  DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci; ";
 
 			//echo "TABQRT= ".$tab_query;
 
@@ -927,7 +927,7 @@ class system_tools
 
 		//------------
 
-		$lastQry = "ALTER DATABASE `".$dbtable."` DEFAULT CHARACTER SET utf8 COLLATE utf8_general_ci;";
+		$lastQry = "ALTER DATABASE `".$dbtable."` DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;";
 
 		if(!$sql->db_Query($lastQry))
 		{
@@ -936,11 +936,10 @@ class system_tools
 		elseif($ERROR != TRUE)
 		{
 			$message = DBLAN_93;
-			//$message .= "<br />Please now add the following line to your e107_config.php file:<br /><b>\$mySQLcharset   = 'utf8';</b>";
 
 			$mes->add($message, E_MESSAGE_SUCCESS);
 			$mes->addSuccess(DBLAN_94);
-			$mes->addSuccess('$mySQLcharset   = "utf8";');
+			$mes->addSuccess('$mySQLcharset   = "utf8mb4";');
 			
 		}
 

--- a/e107_core/sql/core_sql.php
+++ b/e107_core/sql/core_sql.php
@@ -1,14 +1,13 @@
 <?php
-/*
+/**
  * e107 website system
  *
- * Copyright (C) e107 Inc (e107.org)
+ * Copyright (C) 2008-2021 e107 Inc (e107.org)
  * Released under the terms and conditions of the
  * GNU General Public License (http://www.gnu.org/licenses/gpl.txt)
  *
  * Core SQL
- *
-*/
+ */
 
 header("location:../index.php");
 exit;
@@ -17,7 +16,7 @@ exit;
 # +---------------------------------------------------------------+
 # |        e107 website system
 # |
-# |        Copyright (C) 2008-2015 e107 Inc (e107.org)
+# |        Copyright (C) 2008-2021 e107 Inc (e107.org)
 # |        http://e107.org
 # |
 # |        Released under the terms and conditions of the
@@ -41,7 +40,7 @@ CREATE TABLE admin_log (
   dblog_remarks text NOT NULL,
   PRIMARY KEY  (dblog_id),
   KEY dblog_datestamp (dblog_datestamp)
-) ENGINE=MyISAM;
+) ENGINE=InnoDB;
 # --------------------------------------------------------
 
 #
@@ -59,7 +58,7 @@ CREATE TABLE audit_log (
   dblog_remarks text NOT NULL,
   PRIMARY KEY  (dblog_id),
   KEY dblog_datestamp (dblog_datestamp)
-) ENGINE=MyISAM;
+) ENGINE=InnoDB;
 # --------------------------------------------------------
 
 
@@ -80,7 +79,7 @@ CREATE TABLE banlist (
   KEY banlist_ip (banlist_ip),
   KEY banlist_datestamp (banlist_datestamp),
   KEY banlist_banexpires (banlist_banexpires)
-) ENGINE=MyISAM;
+) ENGINE=InnoDB;
 # --------------------------------------------------------
 
 #
@@ -105,7 +104,7 @@ CREATE TABLE comments (
   PRIMARY KEY  (comment_id),
   KEY comment_blocked (comment_blocked),
   KEY comment_author_id (comment_author_id) 
-) ENGINE=MyISAM;
+) ENGINE=InnoDB;
 # --------------------------------------------------------
 
 #
@@ -115,7 +114,7 @@ CREATE TABLE core (
   e107_name varchar(100) NOT NULL default '',
   e107_value text NOT NULL,
   PRIMARY KEY  (e107_name)
-) ENGINE=MyISAM;
+) ENGINE=InnoDB;
 # --------------------------------------------------------
 
 #
@@ -139,7 +138,7 @@ CREATE TABLE core_media (
   media_tags text NOT NULL,
   PRIMARY KEY (media_id),
   UNIQUE KEY media_url (media_url)
-) ENGINE=MyISAM;
+) ENGINE=InnoDB;
 
 CREATE TABLE core_media_cat (
   media_cat_id int(10) unsigned NOT NULL auto_increment,
@@ -153,7 +152,7 @@ CREATE TABLE core_media_cat (
   media_cat_order int(3) unsigned NOT NULL default '0',
   PRIMARY KEY  (media_cat_id),
   UNIQUE KEY media_cat_category (media_cat_category)
-) ENGINE=MyISAM;
+) ENGINE=InnoDB;
 
 
 CREATE TABLE cron (
@@ -187,7 +186,7 @@ CREATE TABLE dblog (
   dblog_remarks text NOT NULL,
   PRIMARY KEY  (dblog_id),
   KEY dblog_datestamp (dblog_datestamp)
-) ENGINE=MyISAM;
+) ENGINE=InnoDB;
 
 # --------------------------------------------------------
 
@@ -204,7 +203,7 @@ CREATE TABLE generic (
   gen_chardata text NOT NULL,
   PRIMARY KEY  (gen_id),
   KEY gen_type (gen_type)
-) ENGINE=MyISAM;
+) ENGINE=InnoDB;
 # --------------------------------------------------------
 
 #
@@ -227,7 +226,7 @@ CREATE TABLE links (
   link_sefurl varchar(255) NOT NULL,
   link_owner varchar(50) NOT NULL default '',
   PRIMARY KEY  (link_id)
-) ENGINE=MyISAM;
+) ENGINE=InnoDB;
 
 # --------------------------------------------------------
 
@@ -248,7 +247,7 @@ CREATE TABLE mail_recipients (
 	PRIMARY KEY (mail_target_id),
 	KEY mail_status (mail_status),
 	KEY mail_detail_id (mail_detail_id)
-) ENGINE=MyISAM;
+) ENGINE=InnoDB;
 
 CREATE TABLE mail_content (
 	mail_source_id int(10) unsigned NOT NULL auto_increment,
@@ -274,7 +273,7 @@ CREATE TABLE mail_content (
 	mail_media text,
 	PRIMARY KEY (mail_source_id),
 	KEY mail_content_status (mail_content_status)
-) ENGINE=MyISAM;
+) ENGINE=InnoDB;
 
 
 #
@@ -292,7 +291,7 @@ CREATE TABLE menus (
   menu_layout varchar(100) NOT NULL default '',
   menu_parms text NOT NULL,
   PRIMARY KEY  (menu_id)
-) ENGINE=MyISAM;
+) ENGINE=InnoDB;
 # --------------------------------------------------------
 
 #
@@ -330,7 +329,7 @@ CREATE TABLE news (
   KEY news_sticky  (news_sticky),
   KEY news_render_type  (news_render_type),
   KEY news_class (news_class)
-) ENGINE=MyISAM;
+) ENGINE=InnoDB;
 
 
 # --------------------------------------------------------
@@ -351,7 +350,7 @@ CREATE TABLE news_category (
   category_template varchar(50) default NULL,
   PRIMARY KEY  (category_id),
   KEY category_order (category_order)
-) ENGINE=MyISAM;
+) ENGINE=InnoDB;
 # --------------------------------------------------------
 
 #
@@ -411,7 +410,7 @@ CREATE TABLE page (
   menu_button_text varchar(250) NOT NULL default '',   
   
   PRIMARY KEY  (page_id)
-) ENGINE=MyISAM;
+) ENGINE=InnoDB;
 # --------------------------------------------------------
 
 
@@ -435,7 +434,7 @@ CREATE TABLE page_chapters (
   chapter_fields mediumtext,
   PRIMARY KEY  (chapter_id),
   KEY chapter_order (chapter_order)
-) ENGINE=MyISAM;
+) ENGINE=InnoDB;
 # --------------------------------------------------------
 
 
@@ -454,7 +453,7 @@ CREATE TABLE plugin (
   plugin_category varchar(100) NOT NULL default '',
   PRIMARY KEY  (plugin_id),
   UNIQUE KEY plugin_path (plugin_path)
-) ENGINE=MyISAM;
+) ENGINE=InnoDB;
 
 # --------------------------------------------------------
 #
@@ -471,7 +470,7 @@ CREATE TABLE rate (
   rate_up int(10) unsigned NOT NULL default '0',
   rate_down int(10) unsigned NOT NULL default '0',
   PRIMARY KEY  (rate_id)
-) ENGINE=MyISAM;
+) ENGINE=InnoDB;
 # --------------------------------------------------------
 
 #
@@ -485,7 +484,7 @@ CREATE TABLE session (
   session_data longtext NOT NULL,
   PRIMARY KEY  (session_id),
   INDEX (session_expires)
-) ENGINE=MyISAM;
+) ENGINE=InnoDB;
 # --------------------------------------------------------
 
 
@@ -510,7 +509,7 @@ CREATE TABLE submitnews (
   submitnews_summary text,
   submitnews_media text,
   PRIMARY KEY  (submitnews_id)
-) ENGINE=MyISAM;
+) ENGINE=InnoDB;
 # --------------------------------------------------------
 
 #
@@ -523,7 +522,7 @@ CREATE TABLE tmp (
   tmp_info text NOT NULL,
   KEY tmp_ip (tmp_ip),
   KEY tmp_time (tmp_time)
-) ENGINE=MyISAM;
+) ENGINE=InnoDB;
 # --------------------------------------------------------
 
 #
@@ -548,7 +547,7 @@ CREATE TABLE upload (
   upload_owner varchar(50) NOT NULL default '',
   PRIMARY KEY  (upload_id),
   KEY upload_active (upload_active)
-) ENGINE=MyISAM;
+) ENGINE=InnoDB;
 
 # --------------------------------------------------------
 
@@ -588,7 +587,7 @@ CREATE TABLE user (
   UNIQUE KEY user_name (user_name),
   UNIQUE KEY user_loginname (user_loginname),
   KEY join_ban_index (user_join,user_ban)
-) ENGINE=MyISAM;
+) ENGINE=InnoDB;
 # --------------------------------------------------------
 
 #
@@ -606,7 +605,7 @@ CREATE TABLE userclass_classes (
   userclass_icon varchar(250) NOT NULL default '',
   userclass_perms text NOT NULL,
   PRIMARY KEY  (userclass_id)
-) ENGINE=MyISAM;
+) ENGINE=InnoDB;
 # --------------------------------------------------------
 
 #
@@ -617,7 +616,7 @@ CREATE TABLE user_extended (
   user_extended_id int(10) unsigned NOT NULL default '0',
   user_hidden_fields text,
   PRIMARY KEY  (user_extended_id)
-) ENGINE=MyISAM;
+) ENGINE=InnoDB;
 # --------------------------------------------------------
 
 
@@ -641,6 +640,6 @@ CREATE TABLE user_extended_struct (
   user_extended_struct_order int(10) unsigned NOT NULL default '0',
   user_extended_struct_parent int(10) unsigned NOT NULL default '0',
   PRIMARY KEY  (user_extended_struct_id)
-) ENGINE=MyISAM;
+) ENGINE=InnoDB;
 # --------------------------------------------------------
 

--- a/e107_handlers/e_db_pdo_class.php
+++ b/e107_handlers/e_db_pdo_class.php
@@ -2610,11 +2610,11 @@ class e_db_pdo implements e_db
 
 
 	/**
-	 * Set Database charset to utf8
+	 * Set Database charset to utf8mb4
 	 *
 	 * @access private
 	 */
-	public function setCharset($charset = 'utf8')
+	public function setCharset($charset = 'utf8mb4')
 	{
 		$this->db_Query("SET NAMES `$charset`");
 
@@ -2627,7 +2627,8 @@ class e_db_pdo implements e_db
 	 */
 	public function getCharset()
 	{
-		return $this->mySQLcharset;
+		require_once(e_HANDLER."db_verify_class.php");
+		return (new db_verify())->getIntendedCharset($this->mySQLcharset);
 	}
 
 

--- a/e107_handlers/mysql_class.php
+++ b/e107_handlers/mysql_class.php
@@ -2450,7 +2450,7 @@ class e_db_mysql implements e_db
 
 
 	/**
-	 * Check if MySQL version is utf8 compatible and may be used as it accordingly to the user choice
+	 * Check if MySQL version is utf8mb4 compatible and may be used as it accordingly to the user choice
 	 *
 	 * @TODO Simplify when the conversion script will be available
 	 * @access public
@@ -2463,15 +2463,16 @@ class e_db_mysql implements e_db
 	{
 		// Get the default user choice
 		global $mySQLcharset;
-		if (isset($mySQLcharset) && $mySQLcharset != 'utf8')
+		if (isset($mySQLcharset) && $mySQLcharset != 'utf8mb4')
 		{
-			// Only utf8 is accepted
+			// Only utf8mb4 is accepted
 			$mySQLcharset = '';
 		}
 		$charset = ($charset ? $charset : $mySQLcharset);
 		$message = (( ! $charset && $debug) ? 'Empty charset!' : '');
 		if($charset)
 		{
+			$this->mySQLaccess->set_charset($charset);
 			if ( ! $debug)
 			{
 			   @mysqli_query($this->mySQLaccess, "SET NAMES `$charset`");

--- a/e107_handlers/plugin_class.php
+++ b/e107_handlers/plugin_class.php
@@ -3412,9 +3412,8 @@ class e107plugin
 			return null;
 		}
 
+		/** @var db_verify $dbv */
 		$dbv = e107::getSingleton('db_verify', e_HANDLER."db_verify_class.php");
-	//	require_once(e_HANDLER."db_verify_class.php");
-	//	$dbv = new db_verify;
 		$sql = e107::getDb();
 
 		// Add or Remove Table --------------
@@ -3436,12 +3435,15 @@ class e107plugin
 
 			foreach($tableData['tables'] as $k=>$v)
 			{
+				$engine = $dbv->getIntendedStorageEngine($tableData['engine'][$k]);
+				$charset = $dbv->getIntendedCharset($tableData['charset'][$k]);
+
 				switch($function)
 				{
 					case "install":
 						$query = "CREATE TABLE  `".MPREFIX.$v."` (\n";
 						$query .= $tableData['data'][$k];
-						$query .= "\n) ENGINE=". vartrue($tableData['engine'][$k],"InnoDB")." DEFAULT CHARSET=utf8 ";
+						$query .= "\n) ENGINE=$engine DEFAULT CHARSET=$charset ";
 
 						$txt = EPL_ADLAN_239." <b>{$v}</b> ";
 						$status = $sql->db_Query($query) ? E_MESSAGE_SUCCESS : E_MESSAGE_ERROR;
@@ -4633,7 +4635,7 @@ class e107plugin
 	/**
 	 * Installs a plugin by ID or folder name
 	 *
-	 * @param int $id
+	 * @param int|string $id
 	 * @param array $options (currently only 'nolinks' - set to true to prevent sitelink creation during install)
 	 */
 	function install($id, $options = array())

--- a/e107_languages/English/admin/lan_db_verify.php
+++ b/e107_languages/English/admin/lan_db_verify.php
@@ -22,6 +22,8 @@ define("DBVLAN_13", "Table missing!");
 define("DBVLAN_14", "Choose table(s) to validate");
 define("DBVLAN_15", "Start Verify");
 define("DBVLAN_16", "SQL Verification");
+define("DBVLAN_17", "Storage engine should be [x] but is [y]");
+define("DBVLAN_18", "Character set should be [x] but is [y]");
 
 define("DBVLAN_19", "Attempt to Fix");
 
@@ -32,5 +34,8 @@ define("DBVLAN_24", "Please select action.");
 define("DBVLAN_25", "Index missing!");
 define("DBVLAN_26", "[x] table(s) have problems.");
 
-// IMPORTANT NOTE: DBLAN has been replaced by DBBLAN in this file since 0.7 due to conflicts with db.php
+define("DBVLAN_27", "Table inconsistency");
+define("DBVLAN_28", "Not applicable");
+
+// IMPORTANT NOTE: DBLAN has been replaced by DBVLAN in this file since 0.7 due to conflicts with db.php
 

--- a/e107_plugins/alt_auth/e107db_auth.php
+++ b/e107_plugins/alt_auth/e107db_auth.php
@@ -98,7 +98,7 @@ class auth_login extends alt_auth_base
 	  */
 
 	//	$dsn = 'mysql:dbname=' . $this->conf['e107db_database'] . ';host=' . $this->conf['e107db_server'];
-		$dsn = "mysql:host=".$this->conf['e107db_server'].";port=".varset($this->conf['e107db_port'],3306).";dbname=".$this->conf['e107db_database'];
+		$dsn = "mysql:host=".$this->conf['e107db_server'].";port=".varset($this->conf['e107db_port'],3306).";dbname=".$this->conf['e107db_database'].";charset=".(new db_verify())->getIntendedCharset();
 
 		try
 		{

--- a/e107_plugins/alt_auth/otherdb_auth.php
+++ b/e107_plugins/alt_auth/otherdb_auth.php
@@ -81,7 +81,7 @@ class auth_login extends alt_auth_base
 	{
 		/* Begin - Deltik's PDO Workaround (part 1/2) */
 	//	$dsn = 'mysql:dbname=' . $this->conf['otherdb_database'] . ';host=' . $this->conf['otherdb_server'];
-		$dsn = "mysql:host=".$this->conf['otherdb_server'].";port=".varset($this->conf['otherdb_port'],3306).";dbname=".$this->conf['otherdb_database'];
+		$dsn = "mysql:host=".$this->conf['otherdb_server'].";port=".varset($this->conf['otherdb_port'],3306).";dbname=".$this->conf['otherdb_database'].";charset=".(new db_verify())->getIntendedCharset();
 
 
 		try

--- a/e107_tests/tests/unit/db_verifyTest.php
+++ b/e107_tests/tests/unit/db_verifyTest.php
@@ -49,6 +49,8 @@
   table_summary text,
   table_media text,
   table_email2 tinyint(3) unsigned NOT NULL default '0',
+  table_email90 tinyint(3) unsigned NOT NULL default '0',
+  e107_name varchar(100) NOT NULL default '',
   PRIMARY KEY  (table_id)";
 
 	$expected = array (
@@ -188,6 +190,22 @@
 		    'null' => 'NOT NULL',
 		    'default' => 'DEFAULT \'0\'',
 		  ),
+		  'table_email90' =>
+			  array (
+				  'type' => 'TINYINT',
+				  'value' => '3',
+				  'attributes' => 'UNSIGNED',
+				  'null' => 'NOT NULL',
+				  'default' => 'DEFAULT \'0\'',
+			  ),
+  		  'e107_name' =>
+  		  array (
+  		  	'type' => 'VARCHAR',
+		    'value' => '100',
+		    'attributes' => '',
+		    'null' => 'NOT NULL',
+		    'default' => 'DEFAULT \'\'',
+	      ),
 		);
 
            $actual =  $this->dbv->getFields($data);
@@ -402,7 +420,7 @@ EOF;
 				  PRIMARY KEY  (table_id)
 				  UNIQUE KEY `table_email` (`table_email`),
 				  KEY `table_user` (`table_user`)
-				  ) ENGINE=InnoDB;';
+				  ) ENGINE=InnoDB DEFAULT CHARACTER SET=utf8mb4;';
 
 			$expected = str_replace("\t", "",$expected);
 			$actual = str_replace("\t", "",$actual);
@@ -809,6 +827,11 @@ EOF;
 			$fileData['index']	= $this->dbv->getIndex($file);
 			$sqlData['index']	= $this->dbv->getIndex($sql);
 
+			$fileData['engine'] = $this->dbv->getIntendedStorageEngine("InnoDB");
+			$sqlData['engine'] = $this->dbv->getCanonicalStorageEngine("InnoDB");
+
+			$fileData['charset'] = $this->dbv->getIntendedCharset("utf8mb4");
+			$sqlData['charset'] = $this->dbv->getCanonicalCharset("utf8mb4");
 
 			$this->dbv->prepareResults('schedule', 'myplugin', $sqlData, $fileData);
 
@@ -946,4 +969,75 @@ EOF;
 		{
 
 		}*/
+
+		public function testGetCanonicalStorageEngine()
+		{
+			$input = "InnoDB";
+
+			$output = $this->dbv->getCanonicalStorageEngine($input);
+
+			$this->assertEquals($input, $output);
+		}
+
+		public function testGetCanonicalStorageEngineUnknownStorageEngine()
+		{
+			$this->expectException(UnexpectedValueException::class);
+
+			$this->dbv->getCanonicalStorageEngine("FakeEngine");
+		}
+
+		public function testGetCanonicalCharsetUtf8Alias()
+		{
+			$input = "utf8";
+			$expected = "utf8mb4";
+
+			$output = $this->dbv->getCanonicalCharset($input);
+
+			$this->assertEquals($expected, $output);
+		}
+
+		public function testGetCanonicalCharsetOther()
+		{
+			$inputs = ["latin1", "utf8mb3", "utf8mb4"];
+
+			foreach ($inputs as $input)
+			{
+				$output = $this->dbv->getCanonicalCharset($input);
+
+				$this->assertEquals($input, $output);
+			}
+		}
+
+		public function testGetIntendedStorageEngine()
+		{
+			$output = $this->dbv->getIntendedStorageEngine("MyISAM");
+			$this->assertEquals("InnoDB", $output);
+
+			$output = $this->dbv->getIntendedStorageEngine("InnoDB");
+			$this->assertEquals("InnoDB", $output);
+
+			$output = $this->dbv->getIntendedStorageEngine("Aria");
+			$this->assertContains($output, ["Aria", "Maria", "MyISAM"]);
+
+			$output = $this->dbv->getIntendedStorageEngine("MEMORY");
+			$this->assertEquals("MEMORY", $output);
+		}
+
+		public function testGetIntendedCharset()
+		{
+			$output = $this->dbv->getIntendedCharset("");
+			$this->assertEquals("utf8mb4", $output);
+
+			$output = $this->dbv->getIntendedCharset();
+			$this->assertEquals("utf8mb4", $output);
+
+			$output = $this->dbv->getIntendedCharset("utf8");
+			$this->assertEquals("utf8mb4", $output);
+
+			$output = $this->dbv->getIntendedCharset("utf8mb3");
+			$this->assertEquals("utf8mb3", $output);
+
+			$output = $this->dbv->getIntendedCharset("latin1");
+			$this->assertEquals("latin1", $output);
+		}
 	}

--- a/e107_tests/tests/unit/e_db_pdoTest.php
+++ b/e107_tests/tests/unit/e_db_pdoTest.php
@@ -40,7 +40,7 @@ class e_db_pdoTest extends e_db_abstractTest
 		$this->db->setCharset();
 		$result = $this->db->getCharset();
 
-		$this->assertEquals('utf8', $result);
+		$this->assertEquals('utf8mb4', $result);
 	}
 
 	public function testBackup()

--- a/install.php
+++ b/install.php
@@ -833,13 +833,13 @@ class e_install
 				if($this->previous_steps['mysql']['createdb'] == 1)
 				{
 					$notification = "<br /><span class='glyphicon glyphicon-ok'></span> ".LANINS_044;
-				    $query = 'CREATE DATABASE `'.$this->previous_steps['mysql']['db'].'` CHARACTER SET `utf8` ';
+				    $query = 'CREATE DATABASE `'.$this->previous_steps['mysql']['db'].'` CHARACTER SET `utf8mb4` ';
 					
 				}
 				else
 				{
 					$notification = "<br /><span class='glyphicon glyphicon-ok'></span>  ".LANINS_137;
-				    $query = 'ALTER DATABASE `'.$this->previous_steps['mysql']['db'].'` CHARACTER SET `utf8` ';
+				    $query = 'ALTER DATABASE `'.$this->previous_steps['mysql']['db'].'` CHARACTER SET `utf8mb4` ';
 				}
 
 				if (!$this->dbqry($query))
@@ -854,7 +854,7 @@ class e_install
 				}
 				else
 				{
-                    $this->dbqry('SET NAMES `utf8`');
+                    $this->dbqry('SET NAMES `utf8mb4`');
 
 					$page_content .= $notification; // "
 				}
@@ -1496,7 +1496,7 @@ class e_install
 \$mySQLpassword  = '{$this->previous_steps['mysql']['password']}';
 \$mySQLdefaultdb = '{$this->previous_steps['mysql']['db']}';
 \$mySQLprefix    = '{$this->previous_steps['mysql']['prefix']}';
-\$mySQLcharset   = 'utf8';
+\$mySQLcharset   = 'utf8mb4';
 
 \$ADMIN_DIRECTORY     = '{$this->e107->e107_dirs['ADMIN_DIRECTORY']}';
 \$FILES_DIRECTORY     = '{$this->e107->e107_dirs['FILES_DIRECTORY']}';
@@ -1903,9 +1903,10 @@ if($this->pdo == true)
 	 */
 	public function install_plugin($plugpath)
 	{
-		e107::getPlugin()->install_plugin($plugpath);
-	//	e107::getPlugin()->install_plugin($row['plugin_id']);
-		
+		$plugin_handler = e107::getPlugin();
+		$plugin_handler->XmlTables('uninstall', ['plugin_path' => $plugpath], ['delete_tables' => true]);
+		$plugin_handler->install($plugpath);
+
 		e107::getMessage()->reset(false, false, true);
 		
 		return null;
@@ -2165,7 +2166,7 @@ if($this->pdo == true)
 		preg_match_all("/create(.*?)(?:myisam|innodb);/si", $sql_data, $result );
 
 		// Force UTF-8 again
-		$this->dbqry('SET NAMES `utf8`');
+		$this->dbqry('SET NAMES `utf8mb4`');
 
 		$srch = array("CREATE TABLE","(");
 		$repl = array("DROP TABLE IF EXISTS","");


### PR DESCRIPTION
Fixes: #4501

### Motivation and Context
Add emoji support and stop using the obsolete MyISAM storage engine

### Description
Convert and run e107 using the MySQL/MariaDB utf8mb4 character set and InnoDB storage engine

Components affected:
* `db_verify` now checks and corrects the table storage engine
* `db_verify` now checks and corrects the table default character set
  * Note: Field character sets can still be overridden
  * Note: When correcting, the entire table is converted to the target
    charset.
* The alt_auth plugin now connects via PDO using the e107 default
  charset, utf8mb4
* `e_db_pdo` now sets the charset to utf8mb4. This is currently not
  customizable because it was previously not customizable.
* `install.php` now generates an `e107_config.php` file with
  `$mySQLcharset = 'utf8mb4';`, though this option is not actually used.
* `install.php` now removes plugin tables before installing plugins.
* `e_db_mysql` now only accepts the `utf8mb4` charset. Previously, it
  only accepted the `utf8` charset.
* `e_db_mysql` now configures `mysqli_real_escape_string` to match the
  new default charset, `utf8mb4`.
* Plugin installations now use the preferred MySQL table storage engines
  and charsets.

The preferred MySQL table storage engines are now mapped like so:
* If `ENGINE=MyISAM` is specified, the actual storage engine set will be
  the first available of: InnoDB, Aria, Maria, MyISAM
* If `ENGINE=Aria` is specified, the actual storage engine set will be
  the first available of: Aria, Maria, MyISAM
* If `ENGINE=InnoDB` is specified, the actual storage engine set will be
  the first available of: InnoDB, XtraDB
* If `ENGINE=XtraDB` is specified, the actual storage engine set will be
  the first available of: XtraDB, InnoDB

The preferred MySQL character set is now aliased like so:
* `utf8`    => `utf8mb4`
* `utf8mb3` => `utf8mb3`
* `utf8mb4` => `utf8mb4`

### How Has This Been Tested?
Unit tests included in pull request

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code adheres to the e107 [code style standard](https://github.com/e107inc/e107/wiki/e107-Coding-Standard).
- [x] I have read the [**contributing** document](https://github.com/e107inc/e107/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/e107inc/e107/tree/master/e107_tests) to cover my changes.
- [x] All new and existing tests pass.