### PR TITLE
#4512: faqs_shortcodes::sc_faq_count(): Return blank string instead of 0

### DIFF
--- a/e107_plugins/faqs/faqs_shortcodes.php
+++ b/e107_plugins/faqs/faqs_shortcodes.php
@@ -283,7 +283,7 @@ class faqs_shortcodes extends e_shortcode
 			return "<span class='faq-total'>(".($this->counter -1).")</span>";
 		}
 
- 		return isset($this->var['f_count']) ? $this->var['f_count'] : 0;
+ 		return isset($this->var['f_count']) ? $this->var['f_count'] : '';
 	}
 	
 	function sc_faq_cat_diz()

--- a/e107_tests/tests/unit/e_parse_shortcodeTest.php
+++ b/e107_tests/tests/unit/e_parse_shortcodeTest.php
@@ -1024,6 +1024,60 @@ class e_parse_shortcodeTest extends \Codeception\Test\Unit
 
     }
 
+	/**
+	 * @see https://github.com/e107inc/e107/issues/4512
+	 * @throws Exception
+	 */
+	public function testFaqShortcodesDisplayFaqTotal()
+	{
+		require_once(e_PLUGIN."faqs/faqs_shortcodes.php");
+
+		/** @var faqs_shortcodes $sc */
+		$sc = $this->make('faqs_shortcodes');
+
+		$faqsConfig = e107::getPlugConfig("faqs");
+		$beforePref = $faqsConfig->getPref("display_total");
+		try
+		{
+			$faqsConfig->setPref("display_total", true);
+			$sc->counter = $counter = 593407;
+
+			$output = e107::getParser()->parseTemplate("<small>{FAQ_COUNT}</small>", true, $sc);
+			$this->assertEquals("<small><span class='faq-total'>(".($counter-1).")</span></small>", $output);
+		}
+		finally
+		{
+			$faqsConfig->setPref("display_total", $beforePref);
+		}
+	}
+
+	/**
+	 * @see https://github.com/e107inc/e107/issues/4512
+	 * @throws Exception
+	 */
+	public function testFaqShortcodesDoNotDisplayFaqTotal()
+	{
+		require_once(e_PLUGIN . "faqs/faqs_shortcodes.php");
+
+		/** @var faqs_shortcodes $sc */
+		$sc = $this->make('faqs_shortcodes');
+
+		$faqsConfig = e107::getPlugConfig("faqs");
+		$beforePref = $faqsConfig->getPref("display_total");
+		try
+		{
+			$faqsConfig->setPref("display_total", false);
+			$sc->counter = 1017703;
+
+			$output = e107::getParser()->parseTemplate("<small>{FAQ_COUNT}</small>", true, $sc);
+			$this->assertEquals("<small></small>", $output);
+		}
+		finally
+		{
+			$faqsConfig->setPref("display_total", $beforePref);
+		}
+	}
+
 	public function testFpwShortcodes()
 	{
 		require_once(e_CORE."shortcodes/batch/fpw_shortcodes.php");


### PR DESCRIPTION
### Motivation and Context
Previously incorrect null coalesce returns `0` instead of a blank string when `display_total` is turned off in the `faqs` plugin preferences

### Description
Fixes: #4512

Replaced the `0` with `''` in `faqs_shortcodes::sc_faq_count()`

### How Has This Been Tested?
Shortcode `{FAQ_COUNT}` now has unit tests for both possible settings of the `display_total` pref

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code adheres to the e107 [code style standard](https://github.com/e107inc/e107/wiki/e107-Coding-Standard).
- [x] I have read the [**contributing** document](https://github.com/e107inc/e107/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/e107inc/e107/tree/master/e107_tests) to cover my changes.
- [x] All new and existing tests pass.