### PR TITLE
Deprecate `e_parse::toJS()`

### DIFF
--- a/contact.php
+++ b/contact.php
@@ -134,24 +134,24 @@ class contact_front
 		// Check Image-Code
 		if(isset($_POST['rand_num']) && ($sec_img->invalidCode($_POST['rand_num'], $_POST['code_verify'])))
 		{
-			$error .= LAN_CONTACT_15 . "\\n";
+			$error .= LAN_CONTACT_15 . "\n";
 		}
 
 		// Check message body.
 		if(strlen(trim($body)) < 15)
 		{
-			$error .= LAN_CONTACT_12 . "\\n";
+			$error .= LAN_CONTACT_12 . "\n";
 		}
 
 		// Check subject line.
 		if(isset($_POST['subject']) && strlen(trim($subject)) < 2)
 		{
-			$error .= LAN_CONTACT_13 . "\\n";
+			$error .= LAN_CONTACT_13 . "\n";
 		}
 
 		if(!strpos(trim($sender), "@"))
 		{
-			$error .= LAN_CONTACT_11 . "\\n";
+			$error .= LAN_CONTACT_11 . "\n";
 		}
 
 		// No errors - so proceed to email the admin and the user (if selected).

--- a/e107_admin/administrator.php
+++ b/e107_admin/administrator.php
@@ -160,7 +160,7 @@ function show_admins()
 		{
     		$text .= "
 							".$frm->submit_image("edit_admin[{$row['user_id']}]", 'edit', 'edit', LAN_EDIT)."
-							".$frm->submit_image("del_admin[{$row['user_id']}]", 'del', 'delete', $tp->toJS(ADMSLAN_59."? [".$row['user_name']."]"))."
+							".$frm->submit_image("del_admin[{$row['user_id']}]", 'del', 'delete', ADMSLAN_59."? [".$row['user_name']."]")."
 
 			";
     	}

--- a/e107_admin/lancheck.php
+++ b/e107_admin/lancheck.php
@@ -1027,7 +1027,7 @@ class lancheck
 	
 		$just_go_diz = (deftrue('LAN_CHECK_20')) ? LAN_CHECK_20 : "Generate Language Pack";
 		$lang_sel_diz = (deftrue('LAN_CHECK_21')) ? LAN_CHECK_21 : "Verify Again";
-		$lan_pleasewait = (deftrue('LAN_PLEASEWAIT')) ?  $tp->toJS(LAN_PLEASEWAIT) : "Please Wait";
+		$lan_pleasewait = (deftrue('LAN_PLEASEWAIT')) ? LAN_PLEASEWAIT : "Please Wait";
 		
 		$message .= "
 		<br /><br />

--- a/e107_admin/language.php
+++ b/e107_admin/language.php
@@ -271,7 +271,7 @@ if(!empty($_GET['iframe']))
 
 			$release_diz = defset("LANG_LAN_30","Release Date");
 			$compat_diz = defset("LANG_LAN_31", "Compatibility");
-			$lan_pleasewait = (deftrue('LAN_PLEASEWAIT')) ?  $tp->toJS(LAN_PLEASEWAIT) : "Please Wait";
+			$lan_pleasewait = (deftrue('LAN_PLEASEWAIT')) ? LAN_PLEASEWAIT : "Please Wait";
 
 
 			$text = "<form id='lancheck' method='post' action='".e_REQUEST_URI."'>

--- a/e107_handlers/e_parse_class.php
+++ b/e107_handlers/e_parse_class.php
@@ -1871,9 +1871,16 @@ class e_parse
 	 *
 	 * @param string|array $stringarray
 	 * @return string
+	 * @deprecated v2.3.1 This method will not escape a string properly for use as a JavaScript or JSON string. Use
+	 *             {@see e_parse::toJSON()} instead. When using {@see e_parse::toJSON()}, do not surround its output
+	 *             with quotation marks, and do not attempt to escape sequences like "\n" as "\\n". If HTML tags need to
+	 *             be removed, consider {@see e_parse::toText()} separately. If the text needs to be used in an HTML
+	 *             tag attribute (e.g. &lt;a onclick="ATTRIBUTE"&gt;&lt;/a&gt;), surround the string with
+	 *             {@see e_parse::toAttribute()} and either single-quote or double-quote the attribute value.
 	 */
 	public function toJS($stringarray)
 	{
+		trigger_error('<b>' . __METHOD__ . ' is deprecated. See method DocBlock for alternatives.</b>', E_USER_WARNING); // NO LAN
 
 		$search = array("\r\n", "\r", '<br />', "'");
 		$replace = array("\\n", '', "\\n", "\'");

--- a/e107_handlers/form_handler.php
+++ b/e107_handlers/form_handler.php
@@ -3910,8 +3910,7 @@ var_dump($select_options);*/
 		//
 		foreach ($options as $option => $optval)
 		{
-			$optval = trim((string) $optval);
-			$optval = htmlspecialchars($optval,  ENT_COMPAT | ENT_HTML401, 'UTF-8', false);
+			$optval = htmlspecialchars(trim((string) $optval),  ENT_COMPAT | ENT_HTML401, 'UTF-8', false);
 			switch ($option)
 			{
 

--- a/e107_handlers/menumanager_class.php
+++ b/e107_handlers/menumanager_class.php
@@ -1329,7 +1329,7 @@ class e_menuManager
 		{
 			if(isset($pref['sitetheme_layouts'][$layout]['menuPresets']))
 			{
-		    	$text .= "<input type='submit' class='menu-btn' name='menuUsePreset' value=\"".MENLAN_40."\" onclick=\"return jsconfirm('".$tp->toJS(MENLAN_41)."')\" /><br /><br />\n";  // Use Menu Presets
+		    	$text .= "<input type='submit' class='menu-btn' name='menuUsePreset' value=\"".MENLAN_40."\" onclick=\"return jsconfirm(".$tp->toAttribute($tp->toJSON(MENLAN_41)).")\" /><br /><br />\n";  // Use Menu Presets
 				$text .= "<input type='hidden' name='menuPreset' value='".$layout."' />";
 			}
 			$text .= "<input type='hidden'  name='curLayout' value='".$layout."' />";

--- a/e107_handlers/message_handler.php
+++ b/e107_handlers/message_handler.php
@@ -1152,11 +1152,11 @@ $SYSTEM_DIRECTORY    = "e107_system/";</pre>
 
 		case "ALERT":
 			$message = isset($emessage[$message]) ? $emessage[$message] : $message;
-			echo "<noscript>$message</noscript><script type='text/javascript'>alert(".json_encode($message)."); window.history.go(-1); </script>\n"; exit;
+			echo "<noscript>$message</noscript><script type='text/javascript'>alert(".$tp->toJSON($message)."); window.history.go(-1); </script>\n"; exit;
 			break;
 
 		case "P_ALERT":
-			echo "<script type='text/javascript'>alert(".json_encode($message)."); </script>\n";
+			echo "<script type='text/javascript'>alert(".$tp->toJSON($message)."); </script>\n";
 			break;
 
 		case 'POPUP':

--- a/e107_plugins/download/download_shortcodes.php
+++ b/e107_plugins/download/download_shortcodes.php
@@ -373,15 +373,15 @@ class download_shortcodes extends e_shortcode
 	  
       if ($parm == "request")
       {
-      	$agreetext = $tp->toJS($tp->toHTML($this->pref['agree_text'],FALSE,'DESCRIPTION'));
+      	$agreetext = $tp->toAttribute($tp->toJSON($tp->filter($tp->toHTML($this->pref['agree_text'],FALSE,'DESCRIPTION'), 'str')));
 		
       	if ($this->var['download_mirror_type'])
       	{
-      		$text = ($this->pref['agree_flag'] ? "<a href='".e_PLUGIN_ABS."download/download.php?mirror.".$this->var['download_id']."' onclick= \"return confirm('{$agreetext}');\">" : "<a href='".e_PLUGIN_ABS."download/download.php?mirror.".$this->var['download_id']."' title='".LAN_DOWNLOAD."'>");
+      		$text = ($this->pref['agree_flag'] ? "<a href='".e_PLUGIN_ABS."download/download.php?mirror.".$this->var['download_id']."' onclick= \"return confirm({$agreetext});\">" : "<a href='".e_PLUGIN_ABS."download/download.php?mirror.".$this->var['download_id']."' title='".LAN_DOWNLOAD."'>");
       	}
       	else
       	{
-      		$text = ($this->pref['agree_flag'] ? "<a href='".e_PLUGIN_ABS."download/request.php?".$this->var['download_id']."' onclick= \"return confirm('{$agreetext}');\">" : "<a href='".e_PLUGIN_ABS."download/request.php?".$this->var['download_id']."' title='".LAN_DOWNLOAD."'>");
+      		$text = ($this->pref['agree_flag'] ? "<a href='".e_PLUGIN_ABS."download/request.php?".$this->var['download_id']."' onclick= \"return confirm({$agreetext});\">" : "<a href='".e_PLUGIN_ABS."download/request.php?".$this->var['download_id']."' title='".LAN_DOWNLOAD."'>");
       	}
 		
       	$text .= $tp->toHTML($this->var['download_name'], FALSE, 'TITLE')."</a>";
@@ -473,7 +473,7 @@ class download_shortcodes extends e_shortcode
 		$tp = e107::getParser();
 		$img = '';
 
-      	$agreetext = !empty($this->pref['agree_text']) ? $tp->toJS($tp->toHTML($this->pref['agree_text'],FALSE,'DESCRIPTION')) : '';
+      	$agreetext = !empty($this->pref['agree_text']) ? $tp->toAttribute($tp->toJSON($tp->filter($tp->toHTML($this->pref['agree_text'],FALSE,'DESCRIPTION'), 'str'))) : '';
 
 		if(defined('IMAGE_DOWNLOAD'))
 		{
@@ -493,7 +493,7 @@ class download_shortcodes extends e_shortcode
      	else
      	{
      		$url = $tp->parseTemplate("{DOWNLOAD_REQUEST_URL}",true, $this); // $this->sc_download_request_url();
-     	  	return (!empty($this->pref['agree_flag']) ? "<a class='e-tip' title='".LAN_DOWNLOAD."' href='".$url."' onclick= \"return confirm('{$agreetext}');\">{$img}</a>" : "<a class='e-tip' title='".LAN_DOWNLOAD."' href='".$url."' >{$img}</a>");
+     	  	return (!empty($this->pref['agree_flag']) ? "<a class='e-tip' title='".LAN_DOWNLOAD."' href='".$url."' onclick= \"return confirm({$agreetext});\">{$img}</a>" : "<a class='e-tip' title='".LAN_DOWNLOAD."' href='".$url."' >{$img}</a>");
    
 		//	return ($this->pref['agree_flag'] ? "<a class='e-tip' title='".LAN_DOWNLOAD."' href='".e_PLUGIN_ABS."download/request.php?".$this->var['download_id']."' onclick= \"return confirm('{$agreetext}');\">{$img}</a>" : "<a class='e-tip' title='".LAN_DOWNLOAD."' href='".e_PLUGIN_ABS."download/request.php?".$this->var['download_id']."' >{$img}</a>");
      	}
@@ -653,7 +653,7 @@ class download_shortcodes extends e_shortcode
 	  
       if (!empty($this->pref['agree_flag']))
       {
-       	return "<a href='".$url."' onclick= \"return confirm('".$tp->toJS($tp->toHTML($this->pref['agree_text'],FALSE,'DESCRIPTION'))."');\" title='".LAN_dl_46."'>".$this->var['download_name']."</a>";
+       	return "<a href='".$url."' onclick= \"return confirm(".$tp->toAttribute($tp->toJSON($tp->toHTML($this->pref['agree_text'],FALSE,'DESCRIPTION'))).");\" title='".LAN_dl_46."'>".$this->var['download_name']."</a>";
     //  	return "<a href='".e_PLUGIN_ABS."download/request.php?".$dl['download_id']."' onclick= \"return confirm('".$tp->toJS($tp->toHTML($this->pref['agree_text'],FALSE,'DESCRIPTION'))."');\" title='".LAN_dl_46."'>".$dl['download_name']."</a>";
       } 
       else 
@@ -799,7 +799,7 @@ class download_shortcodes extends e_shortcode
 		
 		if(!empty($this->pref['agree_flag']))
 		{
-      		$click = " onclick='return confirm(\"".$tp->toJS($tp->toHTML($this->pref['agree_text'],true,'emotes, no_tags'))."\")'";
+      		$click = " onclick='return confirm(".$tp->toAttribute($tp->toJSON($tp->toHTML($this->pref['agree_text'],true,'emotes, no_tags'))).")'";
 		}
 		
 		$url = 	$url = $tp->parseTemplate("{DOWNLOAD_REQUEST_URL}",true,$this); //$this->sc_download_request_url();
@@ -955,7 +955,7 @@ class download_shortcodes extends e_shortcode
 		$tp = e107::getParser();
 		$img = '';
 
- 		$click = !empty($this->pref['agree_text']) ? " onclick='return confirm(\"".$tp->toJS($tp->toHTML($this->pref['agree_text'],FALSE,'DESCRIPTION'))."\")'" : '';
+ 		$click = !empty($this->pref['agree_text']) ? " onclick='return confirm(".$tp->toAttribute($tp->toJSON($tp->toHTML($this->pref['agree_text'],FALSE,'DESCRIPTION'))).")'" : '';
 
 		if(defined('IMAGE_DOWNLOAD'))
 		{

--- a/e107_plugins/download/includes/admin.php
+++ b/e107_plugins/download/includes/admin.php
@@ -410,6 +410,20 @@ $columnInfo = array(
 			'pref_name' 				=> array('title'=> 'name', 'type' => 'text', 'data' => 'string', 'validate' => 'regex', 'rule' => '#^[\w]+$#i', 'help' => 'allowed characters are a-zA-Z and underscore')
 		);
 
+	/**
+	 * @var e_parse
+	 */
+	private $tp;
+
+	/**
+	 * @inheritDoc
+	 */
+	public function __construct($request, $response, $params = array())
+	{
+		parent::__construct($request, $response, $params);
+		$this->tp = e107::getParser();
+	}
+
 		
 		public function observe()
 		{
@@ -796,7 +810,7 @@ $columnInfo = array(
 		                     $text .= '<td>'.$tp->toHTML($row['download_category_name']).'</td>';
 		                     $text .= '<td>
 		                                 <a href="'.e_SELF.'?create.edit.'.$row["download_id"].'.maint.duplicates">'.ADMIN_EDIT_ICON.'</a>
-		   				                  <input type="image" title="'.LAN_DELETE.'" name="delete[main_'.$row["download_id"].']" src="'.ADMIN_DELETE_ICON_PATH.'" onclick=\'return jsconfirm("'.$tp->toJS(DOWLAN_33.' [ID: '.$row["download_id"].' ]').'") \'/>
+		   				                  <input type="image" title="'.LAN_DELETE.'" name="delete[main_'.$row["download_id"].']" src="'.ADMIN_DELETE_ICON_PATH.'" onclick=\'return jsconfirm('. $this->getJsConfirm($row["download_id"]) .') \'/>
 		   				               </td>';
 		                     $text .= '</tr>';
 		                  }
@@ -888,7 +902,7 @@ $columnInfo = array(
 		                     $text .= '<td>'.$tp->toHTML($row['download_url']).'</td>';
 		                     $text .= '<td>
 		                                 <a href="'.e_SELF.'?create.edit.'.$row["download_id"].'.maint.missing">'.ADMIN_EDIT_ICON.'</a>
-		   					               <input type="image" title="'.LAN_DELETE.'" name="delete[main_'.$row["download_id"].']" src="'.ADMIN_DELETE_ICON_PATH.'" onclick=\'return jsconfirm("'.$tp->toJS(DOWLAN_33.' [ID: '.$row["download_id"].' ]').'") \'/>
+		   					               <input type="image" title="'.LAN_DELETE.'" name="delete[main_'.$row["download_id"].']" src="'.ADMIN_DELETE_ICON_PATH.'" onclick=\'return jsconfirm('. $this->getJsConfirm($row["download_id"]) .') \'/>
 		   					            </td>';
 		                     $text .= '</tr>';
 		                  }
@@ -944,7 +958,7 @@ $columnInfo = array(
 		                  }
 		                  $text .= '<td>
 		                              <a href="'.e_SELF.'?create.edit.'.$row["download_id"].'.maint.inactive">'.ADMIN_EDIT_ICON.'</a>
-		   				               <input type="image" title="'.LAN_DELETE.'" name="delete[main_'.$row["download_id"].']" src="'.ADMIN_DELETE_ICON_PATH.'" onclick=\'return jsconfirm("'.$tp->toJS(DOWLAN_33.' [ID: '.$row["download_id"].' ]').'") \'/>
+		   				               <input type="image" title="'.LAN_DELETE.'" name="delete[main_'.$row["download_id"].']" src="'.ADMIN_DELETE_ICON_PATH.'" onclick=\'return jsconfirm('. $this->getJsConfirm($row["download_id"]) .') \'/>
 		   				            </td>';
 		                  $text .= '</tr>';
 		               }
@@ -996,7 +1010,7 @@ $columnInfo = array(
 		                  }
 		                  $text .= '<td>
 		                              <a href="'.e_SELF.'?create.edit.'.$row["download_id"].'.maint.nocategory">'.ADMIN_EDIT_ICON.'</a>
-		   				               <input type="image" title="'.LAN_DELETE.'" name="delete[main_'.$row["download_id"].']" src="'.ADMIN_DELETE_ICON_PATH.'" onclick=\'return jsconfirm("'.$tp->toJS(DOWLAN_33.' [ID: '.$row["download_id"].' ]').'") \'/>
+		   				               <input type="image" title="'.LAN_DELETE.'" name="delete[main_'.$row["download_id"].']" src="'.ADMIN_DELETE_ICON_PATH.'" onclick=\'return jsconfirm('. $this->getJsConfirm($row["download_id"]) .') \'/>
 		   				            </td>';
 		                  $text .= '</tr>';
 		               }
@@ -1047,7 +1061,7 @@ $columnInfo = array(
 		                        $text .= '</td>';
 		                        $text .= '<td>
 		                                    <a href="'.e_SELF.'?create.edit.'.$row["download_id"].'.maint.filesize">'.ADMIN_EDIT_ICON.'</a>
-		   					                  <input type="image" title="'.LAN_DELETE.'" name="delete[main_'.$row["download_id"].']" src="'.ADMIN_DELETE_ICON_PATH.'" onclick=\'return jsconfirm("'.$tp->toJS(DOWLAN_33.' [ID: '.$row["download_id"].' ]').'") \'/>
+		   					                  <input type="image" title="'.LAN_DELETE.'" name="delete[main_'.$row["download_id"].']" src="'.ADMIN_DELETE_ICON_PATH.'" onclick=\'return jsconfirm('. $this->getJsConfirm($row["download_id"]) .') \'/>
 		   					               </td>';
 		                        $text .= '</tr>';
 		                     }
@@ -2444,9 +2458,18 @@ $columnInfo = array(
 	      }
 	      return $ret;
 	   }
-	   
-	   
-	   
+
+	/**
+	 * @param string|int $download_id
+	 * @return string
+	 */
+	private function getJsConfirm($download_id)
+	{
+		$tp = $this->tp;
+		return $tp->toAttribute($tp->toJSON(DOWLAN_33 . ' [ID: ' . $download_id . ' ]'));
+	}
+
+
 }
 
 class download_main_admin_form_ui extends e_admin_form_ui

--- a/e107_plugins/forum/forum_viewforum.php
+++ b/e107_plugins/forum/forum_viewforum.php
@@ -450,7 +450,7 @@ function init()
 	echo "<script type=\"text/javascript\">
 	function confirm_(thread_id)
 	{
-		return confirm(\"" . $tp->toJS(LAN_JSCONFIRM) . "\");
+		return confirm(" . $tp->toJSON(LAN_JSCONFIRM) . ");
 	}
 	</script>";
 

--- a/e107_plugins/forum/forum_viewtopic.php
+++ b/e107_plugins/forum/forum_viewtopic.php
@@ -396,9 +396,9 @@ else
 echo "<script type=\"text/javascript\">
 	function confirm_(mode, forum_id, thread_id, thread) {
 	if (mode == 'Thread') {
-	return confirm(\"" . $tp->toJS(LAN_FORUM_2009) . "\");
+	return confirm(" . $tp->toJSON(LAN_FORUM_2009) . ");
 	} else {
-	return confirm(\"" . $tp->toJS(LAN_FORUM_2010) . " [ " . $tp->toJS(LAN_FORUM_0074) . " \" + thread + \" ]\");
+	return confirm(" . $tp->toJSON(LAN_FORUM_2010 . " [ " . LAN_FORUM_0074) . " + thread + \" ]\");
 	}
 	}
 	</script>";

--- a/e107_plugins/gsitemap/admin_config.php
+++ b/e107_plugins/gsitemap/admin_config.php
@@ -813,7 +813,7 @@ class gsitemap
 				<td class='center' style='white-space:nowrap'>
 				<div>
 				<button class='btn btn-default' type='submit' name='edit[{$row2['gsitemap_id']}]' value='edit' alt='".LAN_EDIT."' title='".LAN_EDIT."' style='border:0px' >".ADMIN_EDIT_ICON."</button>
-				<button class='btn btn-default btn-secondary action delete' type='submit' name='delete[{$row2['gsitemap_id']}]' value='del' data-confirm='".$tp->toJS(LAN_CONFIRMDEL." [".$row2['gsitemap_name']."]")."' title='".LAN_DELETE."' >".ADMIN_DELETE_ICON."</button>
+				<button class='btn btn-default btn-secondary action delete' type='submit' name='delete[{$row2['gsitemap_id']}]' value='del' data-confirm='".$tp->toAttribute(LAN_CONFIRMDEL." [".$row2['gsitemap_name']."]")."' title='".LAN_DELETE."' >".ADMIN_DELETE_ICON."</button>
 				</div>
 				</td>
 				</tr>

--- a/e107_plugins/login_menu/login_menu_shortcodes.php
+++ b/e107_plugins/login_menu/login_menu_shortcodes.php
@@ -529,7 +529,7 @@ e107::getLanguage()->bcDefs($bcDefs);
 					$srch = array("<br />","'");
 					$rep = array("\\n","\'");
 					return "<script type='text/javascript'>
-						alert('".$tp->toJS(LOGINMESSAGE)."');
+						alert(".$tp->toJSON(LOGINMESSAGE).");
 						</script>";
 				}
 				else

--- a/e107_plugins/newsletter/admin_config.php
+++ b/e107_plugins/newsletter/admin_config.php
@@ -157,7 +157,7 @@ class newsletter
 					<td>".((substr_count($data['newsletter_subscribers'], chr(1))!= 0)?"<a href='".e_SELF."?vs.".$data['newsletter_id']."'>".substr_count($data['newsletter_subscribers'], chr(1))."</a>":substr_count($data['newsletter_subscribers'], chr(1)))."</td>
 					<td>
 						<a class='btn btn-default btn-secondary btn-large' href='".e_SELF."?edit.".$data['newsletter_id']."'>".ADMIN_EDIT_ICON."</a>
-						<input class='btn btn-default btn-secondary btn-large' type='image' title='".LAN_DELETE."' name='delete[newsletter_".$data['newsletter_id']."]' src='".ADMIN_DELETE_ICON_PATH."' onclick=\"return jsconfirm('".$tp->toJS(LAN_CONFIRMDEL." [ID: ".$data['newsletter_id']." ]")."') \"/>
+						<input class='btn btn-default btn-secondary btn-large' type='image' title='".LAN_DELETE."' name='delete[newsletter_".$data['newsletter_id']."]' src='".ADMIN_DELETE_ICON_PATH."' onclick=\"return jsconfirm(".$tp->toAttribute($tp->toJSON(LAN_CONFIRMDEL." [ID: ".$data['newsletter_id']." ]")).") \"/>
 
 					</td>
 				</tr>
@@ -206,8 +206,8 @@ class newsletter
 					<td>".$data['newsletter_id']."</td>
 					<td>".$data['newsletter_issue']."</td>
 					<td>[ ".$data['newsletter_parent']." ] ".$data['newsletter_title']."</td>
-					<td>".($data['newsletter_flag'] ? LAN_YES : "<input class='btn btn-default btn-secondary button' type='submit' name='nlmailnow_".$data['newsletter_id']."' value='".NLLAN_17."' onclick=\"return jsconfirm('".$tp->toJS(NLLAN_18)."') \" />")."</td>
-					<td><a class='btn btn-large' href='".e_SELF."?edit.".$data['newsletter_id']."'>".ADMIN_EDIT_ICON."</a><input type='image' title='".LAN_DELETE."' name='delete[issue_".$data['newsletter_id']."]' src='".ADMIN_DELETE_ICON_PATH."' onclick=\"return jsconfirm('".$tp->toJS(NLLAN_19." [ID: ".$data['newsletter_id']." ]")."') \"/>
+					<td>".($data['newsletter_flag'] ? LAN_YES : "<input class='btn btn-default btn-secondary button' type='submit' name='nlmailnow_".$data['newsletter_id']."' value='".NLLAN_17."' onclick=\"return jsconfirm(".$tp->toAttribute($tp->toJSON(NLLAN_18)).") \" />")."</td>
+					<td><a class='btn btn-large' href='".e_SELF."?edit.".$data['newsletter_id']."'>".ADMIN_EDIT_ICON."</a><input type='image' title='".LAN_DELETE."' name='delete[issue_".$data['newsletter_id']."]' src='".ADMIN_DELETE_ICON_PATH."' onclick=\"return jsconfirm(".$tp->toAttribute($tp->toJSON(NLLAN_19." [ID: ".$data['newsletter_id']." ]")).") \"/>
 				
 				</td>
 				</tr>

--- a/e107_plugins/newsletter/newsletter_legacy_menu.php
+++ b/e107_plugins/newsletter/newsletter_legacy_menu.php
@@ -84,13 +84,13 @@ foreach($newsletterArray as $nl)
 	if(preg_match("#".chr(1).USERID."(".chr(1)."|$)#si", $nl['newsletter_subscribers']))
 	{
 		$text .= NLLAN_48."<br /><br />
-		<input class='btn btn-sm btn-primary button' type='submit' name='nlUnsubscribe_".$nl['newsletter_id']."' value='".NLLAN_51."' onclick=\"return jsconfirm('".$tp->toJS(NLLAN_49)."') \" />
+		<input class='btn btn-sm btn-primary button' type='submit' name='nlUnsubscribe_".$nl['newsletter_id']."' value='".NLLAN_51."' onclick=\"return jsconfirm(".$tp->toAttribute($tp->toJSON(NLLAN_49)).") \" />
 		";
 	}
 	else
 	{
 		$text .= NLLAN_50." <b>".USEREMAIL."</b>)<br /><br />
-		<input class='btn btn-sm btn-primary button' type='submit' name='nlSubscribe_".$nl['newsletter_id']."' value='".NLLAN_52."' onclick=\"return jsconfirm('".$tp->toJS(NLLAN_53)."') \" />
+		<input class='btn btn-sm btn-primary button' type='submit' name='nlSubscribe_".$nl['newsletter_id']."' value='".NLLAN_52."' onclick=\"return jsconfirm(".$tp->toAttribute($tp->toJSON(NLLAN_53))."') \" />
 		";
 	}
 	$nl_count = $sql->count('newsletter', "(*)", "WHERE newsletter_parent='".$nl['newsletter_id']."' AND newsletter_flag='1'");

--- a/e107_plugins/poll/admin_config.php
+++ b/e107_plugins/poll/admin_config.php
@@ -211,7 +211,7 @@ function poll_list()
 				$text .= "
 				<td class='center' style='white-space:nowrap'>
 					<button class='btn btn-default btn-secondary btn-large' type='submit' name='edit[{$poll_id}]' value='edit' alt='".LAN_EDIT."' title='".LAN_EDIT."' >".ADMIN_EDIT_ICON."</button>
-					<button class='btn btn-default btn-secondary btn-large action delete' type='submit' name='delete[$poll_id]' value='del' onclick=\"return jsconfirm('".$tp->toJS(LAN_CONFIRMDEL." [".$poll_id."]")."') \" title='".LAN_DELETE."' >".ADMIN_DELETE_ICON."</button>
+					<button class='btn btn-default btn-secondary btn-large action delete' type='submit' name='delete[$poll_id]' value='del' onclick=\"return jsconfirm(".$tp->toAttribute($tp->toJSON(LAN_CONFIRMDEL." [".$poll_id."]")).") \" title='".LAN_DELETE."' >".ADMIN_DELETE_ICON."</button>
 				</td>
 			</tr>";
 		}


### PR DESCRIPTION
Fixes: #4546

### Motivation and Context
`e_parse::toJS()`, documented with the description

> Convert text blocks which are to be embedded within JS

, does not protect strings from injections, which appears to be its
primary use.  Additionally, it performs multiple unrelated string
modifications:

* Replace Windows line breaks with a literal `\\n` (which would later be
  parsed as `\n` in JavaScript/JSON)
* Does not modify Unix line breaks (`\n`), which is inconsistent with
  the Windows line break behavior
* Removes HTML tags
* Replaces HTML entities as `htmlentities()` does

This method cannot be fixed because its usages are inconsistent.  Most 
notably, some usages surround the method's output in single quotes while
others surround it with double quotes.  Strings cannot be JSON-encoded
without confounding quotation mark styles.

### Description
`e_parse::toJS()` has been marked as deprecated.

All core usages of `e_parse::toJS()` have been replaced with
alternatives, which are also documented in the method's DocBlock.

### How Has This Been Tested?
Not tested

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (a change to man pages or other documentation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code adheres to the e107 [code style standard](https://github.com/e107inc/e107/wiki/e107-Coding-Standard).
- [x] I have read the [**contributing** document](https://github.com/e107inc/e107/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/e107inc/e107/tree/master/e107_tests) to cover my changes.
- [x] All new and existing tests pass.