### PR TITLE
Disable `USERTHEME` when `e_MENUMANAGER_ACTIVE`

### DIFF
--- a/class2.php
+++ b/class2.php
@@ -782,7 +782,14 @@ if(!isset($_E107['no_module']))
 if(!defined('USERTHEME') && !isset($_E107['no_theme']))
 {
 	$dbg->logTime('Load Theme');
-	define('USERTHEME', (e107::getUser()->getPref('sitetheme') && file_exists(e_THEME.e107::getUser()->getPref('sitetheme'). '/theme.php') ? e107::getUser()->getPref('sitetheme') : false));
+	$userSiteTheme = e107::getUser()->getPref('sitetheme');
+	if (
+		empty($userSiteTheme) ||
+		(defined('e_MENUMANAGER_ACTIVE') && e_MENUMANAGER_ACTIVE === true) ||
+		!file_exists(e_THEME.$userSiteTheme. '/theme.php')
+	)
+		$userSiteTheme = false;
+	define('USERTHEME', $userSiteTheme);
 }
 
 


### PR DESCRIPTION
### Motivation and Context
Fixes: https://github.com/e107inc/e107/issues/4527

As @Jimmi08 said, "the correct solution is to use in Preview mode only site theme, ignore the user theme."

### Description
When `class2.php` defines the `USERTHEME` constant, set it to `false` if the `e_MENUMANAGER_ACTIVE` constant is true.

### How Has This Been Tested?
Can no longer reproduce the issue when following "How to Reproduce" in https://github.com/e107inc/e107/issues/4527

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code adheres to the e107 [code style standard](https://github.com/e107inc/e107/wiki/e107-Coding-Standard).
- [x] I have read the [**contributing** document](https://github.com/e107inc/e107/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/e107inc/e107/tree/master/e107_tests) to cover my changes.
- [x] All new and existing tests pass.