### PR TITLE
Hotfix #4547: Strip BBCode from `download_shortcodes` JavaScript alerts

### DIFF
--- a/e107_plugins/download/download_shortcodes.php
+++ b/e107_plugins/download/download_shortcodes.php
@@ -373,7 +373,7 @@ class download_shortcodes extends e_shortcode
 	  
       if ($parm == "request")
       {
-      	$agreetext = $tp->toAttribute($tp->toJSON($tp->filter($tp->toHTML($this->pref['agree_text'],FALSE,'DESCRIPTION'), 'str')));
+      	$agreetext = $tp->toAttribute($tp->toJSON($tp->toText($this->pref['agree_text'],FALSE,'DESCRIPTION'), 'str'));
 		
       	if ($this->var['download_mirror_type'])
       	{
@@ -473,7 +473,7 @@ class download_shortcodes extends e_shortcode
 		$tp = e107::getParser();
 		$img = '';
 
-      	$agreetext = !empty($this->pref['agree_text']) ? $tp->toAttribute($tp->toJSON($tp->filter($tp->toHTML($this->pref['agree_text'],FALSE,'DESCRIPTION'), 'str'))) : '';
+      	$agreetext = !empty($this->pref['agree_text']) ? $tp->toAttribute($tp->toJSON($tp->toText($this->pref['agree_text'],FALSE,'DESCRIPTION'), 'str')) : '';
 
 		if(defined('IMAGE_DOWNLOAD'))
 		{


### PR DESCRIPTION

### Motivation and Context
Discussion: https://github.com/e107inc/e107/pull/4547#issuecomment-917229877

### Description
Use `e_parse::toText()` to strip BBCode from JavaScript alerts in `download_shortcodes`

### How Has This Been Tested?
Manually with a `download` plugin agreement confirmation

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code adheres to the e107 [code style standard](https://github.com/e107inc/e107/wiki/e107-Coding-Standard).
- [x] I have read the [**contributing** document](https://github.com/e107inc/e107/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/e107inc/e107/tree/master/e107_tests) to cover my changes.
- [x] All new and existing tests pass.