### PR TITLE
#4572: `e_form`: No `htmlspecialchars()` on "other" attributes

### DIFF
--- a/e107_handlers/form_handler.php
+++ b/e107_handlers/form_handler.php
@@ -3907,7 +3907,10 @@ var_dump($select_options);*/
 		//
 		foreach ($options as $option => $optval)
 		{
-			$optval = htmlspecialchars(trim((string) $optval),  ENT_COMPAT | ENT_HTML401, 'UTF-8', false);
+			if ($option !== 'other')
+			{
+				$optval = htmlspecialchars(trim((string) $optval),  ENT_COMPAT | ENT_HTML401, 'UTF-8', false);
+			}
 			switch ($option)
 			{
 

--- a/e107_tests/tests/unit/e_formTest.php
+++ b/e107_tests/tests/unit/e_formTest.php
@@ -867,6 +867,22 @@ class e_formTest extends \Codeception\Test\Unit
 
 				$this->assertSame($expected, $actual);
 			}
+
+			/**
+			 * @link https://github.com/e107inc/e107/issues/4572
+			 */
+			public function testGet_attributesOther()
+			{
+				$options = array(
+					'size'  => '300px',
+					'other' => 'v-bind:class="{ active: isActive }"',
+				);
+
+				$actual = $this->_frm->get_attributes($options);
+				$expected = ' size=\'300px\' v-bind:class="{ active: isActive }"';
+
+				$this->assertSame($expected, $actual);
+			}
 /*
 			public function test_format_id()
 			{
@@ -879,7 +895,7 @@ class e_formTest extends \Codeception\Test\Unit
 				$expected   = 'something-hello-there-and-test';
 
 				$result = $this->_frm->name2id($text);
-				
+
 				$this->assertEquals($expected, $result);
 			}
 /*


### PR DESCRIPTION
Fixes: #4572

### Motivation and Context
https://github.com/e107inc/e107/commit/20882920a0b68937570264949512acc0c4841dbd#diff-a5447d36fe4a988366d3435c36c0cf40e9a00ce4294764cdf186a74a5a79b3a2R3914 inadvertently caused `e_form` attributes in the "other" case to be escaped for use in an attribute value.

### Description
Do not apply `htmlspecialchars()` on "other" attributes in `e_form`.

### How Has This Been Tested?
Added a test for this case: `e_formTest::testGet_attributesOther()`

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code adheres to the e107 [code style standard](https://github.com/e107inc/e107/wiki/e107-Coding-Standard).
- [x] I have read the [**contributing** document](https://github.com/e107inc/e107/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/e107inc/e107/tree/master/e107_tests) to cover my changes.
- [x] All new and existing tests pass.