### PR TITLE
Add index to database session handler for session expiry

### DIFF
--- a/e107_core/sql/core_sql.php
+++ b/e107_core/sql/core_sql.php
@@ -478,8 +478,9 @@ CREATE TABLE session (
   session_id varchar(250) NOT NULL default '',
   session_expires int(10) unsigned NOT NULL default 0,
   session_user int(10) unsigned default NULL,
-  session_data mediumtext NOT NULL,
-  PRIMARY KEY  (session_id)
+  session_data longtext NOT NULL,
+  PRIMARY KEY  (session_id),
+  INDEX (session_expires)
 ) ENGINE=MyISAM;
 # --------------------------------------------------------
 


### PR DESCRIPTION
Fixes: #4574

### Motivation and Context
Adding an index on the session expiry field in the session table greatly improves garbage collection performance

### Description
Add an index for `e107_session.session_expiry`

### How Has This Been Tested?
Manual acceptance test: Observed that site loads faster after adding the new index on a site with a million rows in the `e107_session` table

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code adheres to the e107 [code style standard](https://github.com/e107inc/e107/wiki/e107-Coding-Standard).
- [x] I have read the [**contributing** document](https://github.com/e107inc/e107/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/e107inc/e107/tree/master/e107_tests) to cover my changes.
- [x] All new and existing tests pass.