### PR TITLE
`strftime()` shim with intl locale support

### DIFF
--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -69,7 +69,7 @@ jobs:
         )
         USE_GIT_BPO="$(. /etc/os-release && test $VERSION_ID -lt 10 && echo "-t ${DEBIAN_RELEASE}-backports" || echo)"
         apt-get $USE_GIT_BPO install -y git
-        apt-get -t "${DEBIAN_RELEASE}-backports" install -y zip libzip-dev libbz2-dev libpng-dev libjpeg-dev libwebp-dev libvpx-dev
+        apt-get -t "${DEBIAN_RELEASE}-backports" install -y zip libzip-dev libbz2-dev libpng-dev libjpeg-dev libwebp-dev libvpx-dev libicu-dev
 
     - name: Configure PHP gd extension with default bundle
       run: |
@@ -86,7 +86,7 @@ jobs:
     - name: Install necessary PHP extensions
       run: |
         docker-php-ext-install -j "$(nproc)" \
-        zip bz2 gd pdo_mysql mysqli
+        zip bz2 gd pdo_mysql mysqli intl
 
     - name: PECL install xdebug
       run: |

--- a/e107_handlers/Shims/Internal/StrftimeTrait.php
+++ b/e107_handlers/Shims/Internal/StrftimeTrait.php
@@ -1,0 +1,271 @@
+<?php
+/**
+ * e107 website system
+ *
+ * Copyright (C) 2008-2021 e107 Inc (e107.org)
+ * Released under the terms and conditions of the
+ * GNU General Public License (http://www.gnu.org/licenses/gpl.txt)
+ *
+ */
+
+namespace e107\Shims\Internal;
+
+use DateTimeInterface;
+use DateTimeZone;
+
+trait StrftimeTrait
+{
+	/**
+	 * Polyfill for {@see strftime()}, which was deprecated in PHP 8.1
+	 *
+	 * The implementation is an approximation that may be wrong for some obscure formatting characters.
+	 *
+	 * This function will attempt to use the locale features provided by
+	 * {@link https://www.php.net/manual/en/book.intl.php ext-intl} and fall back to the PHP-builtin {@see DateTime}.
+	 * Note that without ext-intl, formatted times will be in English.
+	 *
+	 * @param string   $format    The old {@see strftime()} format string
+	 * @param int|null $timestamp A Unix epoch timestamp. If null, defaults to the value of {@see time()}.
+	 * @return string Datetime formatted according to the provided arguments
+	 */
+	public static function strftime($format, $timestamp = null)
+	{
+		if ($timestamp === null) $timestamp = time();
+		$datetime = date_create("@$timestamp");
+		$datetime->setTimezone(new DateTimeZone(date_default_timezone_get()));
+
+		foreach (self::getFormatMap() as $strftime_key => $date_format_key)
+		{
+			if (is_callable($date_format_key))
+			{
+				$replacement = self::escapeDateTimePattern($date_format_key($datetime));
+			}
+			else
+			{
+				$replacement = $date_format_key;
+			}
+			$format = str_replace($strftime_key, $replacement, $format);
+		}
+
+		return self::date_format($datetime, $format);
+	}
+
+	/**
+	 * @param DateTimeInterface $datetime
+	 * @param string            $format
+	 * @return string
+	 */
+	protected static function date_format($datetime, $format)
+	{
+		if (!extension_loaded('intl'))
+		{
+			return date_format($datetime, $format);
+		}
+
+		$formatter = new \IntlDateFormatter(
+			self::getSensibleLocale(),
+			\IntlDateFormatter::NONE,
+			\IntlDateFormatter::NONE,
+			null,
+			null,
+			$format
+		);
+
+		return $formatter->format($datetime);
+	}
+
+	/**
+	 * Try to figure out the e107 locale, falling back to the {@see setlocale()} value, and falling back again to "C"
+	 *
+	 * @return string An {@link http://www.faqs.org/rfcs/rfc1766 RFC 1766} language tag such as "en_US"
+	 */
+	protected static function getSensibleLocale()
+	{
+		if (defined('CORE_LC') && defined('CORE_LC2'))
+		{
+			return strtolower(CORE_LC) . "_" . strtoupper(CORE_LC2);
+		}
+
+		$setlocale = setlocale(LC_ALL, "0");
+		return $setlocale ?: 'C';
+	}
+
+	/**
+	 * Escape a literal string for use inside a datetime pattern
+	 *
+	 * Implementation differs depending on whether {@link https://www.php.net/manual/en/book.intl.php ext-intl} is
+	 * enabled
+	 *
+	 * @param string $input
+	 * @return string
+	 */
+	protected static function escapeDateTimePattern($input)
+	{
+		if (extension_loaded('intl'))
+		{
+			return "'" . str_replace("'", "''", $input) . "'";
+		}
+
+		return chunk_split($input, 1, "\\");
+	}
+
+	/**
+	 * Get the {@see strftime()} format to date format pattern mapping depending on if
+	 * {@link https://www.php.net/manual/en/book.intl.php ext-intl} is enabled
+	 *
+	 * @return array<string, string|callable>
+	 */
+	protected static function getFormatMap()
+	{
+		if (extension_loaded('intl'))
+		{
+			return self::getFormatMapForIntlDateFormatter();
+		}
+
+		return self::getFormatMapForDateTime();
+	}
+
+	protected static function getFormatMapForIntlDateFormatter()
+	{
+		return [
+			'%a' => 'eee',
+			'%A' => 'eeee',
+			'%d' => 'dd',
+			'%e' => function($datetime)
+			{
+				return str_pad(self::date_format($datetime, 'd'), 2, " ", STR_PAD_LEFT);
+			},
+			'%j' => function($datetime)
+			{
+				return str_pad(self::date_format($datetime, 'D'), 3, "0", STR_PAD_LEFT);
+			},
+			'%u' => 'e',
+			'%w' => function($datetime)
+			{
+				return date_format($datetime, 'w');
+			},
+			'%U' => 'w',
+			'%V' => 'ww',
+			'%W' => function($datetime)
+			{
+				return date_format($datetime, 'W');
+			},
+			'%b' => 'MMM',
+			'%B' => 'MMMM',
+			'%h' => 'MMM',
+			'%m' => 'MM',
+			'%C' => function($datetime)
+			{
+				return (string) ((int) self::date_format($datetime, 'y') / 100);
+			},
+			'%g' => 'yy',
+			'%G' => 'y',
+			'%y' => 'yy',
+			'%Y' => 'y',
+			'%H' => 'HH',
+			'%k' => function($datetime)
+			{
+				return str_pad(self::date_format($datetime, 'H'), 2, " ", STR_PAD_LEFT);
+			},
+			'%I' => 'hh',
+			'%l' => function($datetime)
+			{
+				return str_pad(self::date_format($datetime, 'h'), 2, " ", STR_PAD_LEFT);
+			},
+			'%M' => 'mm',
+			'%p' => function($datetime)
+			{
+				return strtoupper(self::date_format($datetime, 'a'));
+			},
+			'%P' => 'a',
+			'%r' => 'hh:mm:ss a',
+			'%R' => 'HH:mm',
+			'%S' => 'ss',
+			'%T' => 'HH:mm:ss',
+			'%X' => 'HH:mm:ss',
+			'%z' => 'Z',
+			'%Z' => 'z',
+			'%c' => function($datetime)
+			{
+				/** @noinspection PhpComposerExtensionStubsInspection */
+				return \IntlDateFormatter::formatObject($datetime);
+			},
+			'%D' => 'MM/dd/yy',
+			'%F' => 'y-MM-dd',
+			'%s' => function($datetime)
+			{
+				return date_timestamp_get($datetime);
+			},
+			'%x' => function($datetime)
+			{
+				/** @noinspection PhpComposerExtensionStubsInspection */
+				return \IntlDateFormatter::formatObject($datetime, \IntlDateFormatter::SHORT);
+			},
+			'%n' => "\n",
+			'%t' => "\t",
+			'%%' => "'%'",
+		];
+	}
+
+	protected static function getFormatMapForDateTime()
+	{
+		return [
+			'%a' => 'D',
+			'%A' => 'l',
+			'%d' => 'd',
+			'%e' => function($datetime)
+			{
+				return str_pad(self::date_format($datetime, 'n'), 2, " ", STR_PAD_LEFT);
+			},
+			'%j' => function($datetime)
+			{
+				return str_pad(self::date_format($datetime, 'z'), 3, "0", STR_PAD_LEFT);
+			},
+			'%u' => 'N',
+			'%w' => 'w',
+			'%U' => 'W',
+			'%V' => 'W',
+			'%W' => 'W',
+			'%b' => 'M',
+			'%B' => 'F',
+			'%h' => 'M',
+			'%m' => 'm',
+			'%C' => function($datetime)
+			{
+				return (string) ((int) self::date_format($datetime, 'Y') / 100);
+			},
+			'%g' => 'y',
+			'%G' => 'Y',
+			'%y' => 'y',
+			'%Y' => 'Y',
+			'%H' => 'H',
+			'%k' => function($datetime)
+			{
+				return str_pad(self::date_format($datetime, 'G'), 2, " ", STR_PAD_LEFT);
+			},
+			'%I' => 'h',
+			'%l' => function($datetime)
+			{
+				return str_pad(self::date_format($datetime, 'g'), 2, " ", STR_PAD_LEFT);
+			},
+			'%M' => 'i',
+			'%p' => 'A',
+			'%P' => 'a',
+			'%r' => 'h:i:s A',
+			'%R' => 'H:i',
+			'%S' => 's',
+			'%T' => 'H:i:s',
+			'%X' => 'H:i:s',
+			'%z' => 'O',
+			'%Z' => 'T',
+			'%c' => 'r',
+			'%D' => 'm/d/y',
+			'%F' => 'Y-m-d',
+			'%s' => 'U',
+			'%x' => 'Y-m-d',
+			'%n' => "\n",
+			'%t' => "\t",
+			'%%' => '\%',
+		];
+	}
+}

--- a/e107_handlers/Shims/InternalShimsTrait.php
+++ b/e107_handlers/Shims/InternalShimsTrait.php
@@ -15,5 +15,6 @@ trait InternalShimsTrait
 {
 	use Internal\GetParentClassTrait;
 	use Internal\ReadfileTrait;
+	use Internal\StrftimeTrait;
 	use Internal\StrptimeTrait;
 }

--- a/e107_handlers/date_handler.php
+++ b/e107_handlers/date_handler.php
@@ -207,9 +207,9 @@ class e_date
 	}
 
 	/**
-	 * Polyfill for {@see strftime()}, which was deprecated in PHP 8.1
+	 * Alias of {@see eShims::strftime()}
 	 *
-	 * The implementation is an approximation that may be wrong for some obscure formatting characters.
+	 * See {@see eShims::strftime()} for more information.
 	 *
 	 * @param string   $format    The old {@see strftime()} format string
 	 * @param int|null $timestamp A Unix epoch timestamp. If null, defaults to the value of {@see time()}.
@@ -217,83 +217,7 @@ class e_date
 	 */
 	public static function strftime($format, $timestamp = null)
 	{
-		if ($timestamp === null) $timestamp = time();
-		$datetime = date_create("@$timestamp");
-		$datetime->setTimezone(new DateTimeZone(date_default_timezone_get()));
-
-		$formatMap = [
-			'%a' => 'D',
-			'%A' => 'l',
-			'%d' => 'd',
-			'%e' => function($datetime)
-			{
-				return str_pad(date_format($datetime, 'n'), 2, " ", STR_PAD_LEFT);
-			},
-			'%j' => function($datetime)
-			{
-				return str_pad(date_format($datetime, 'z'), 3, "0", STR_PAD_LEFT);
-			},
-			'%u' => 'N',
-			'%w' => 'w',
-			'%U' => 'W',
-			'%V' => 'W',
-			'%W' => 'W',
-			'%b' => 'M',
-			'%B' => 'F',
-			'%h' => 'M',
-			'%m' => 'm',
-			'%C' => function($datetime)
-			{
-				return (string) ((int) date_format($datetime, 'Y') / 100);
-			},
-			'%g' => 'y',
-			'%G' => 'Y',
-			'%y' => 'y',
-			'%Y' => 'Y',
-			'%H' => 'H',
-			'%k' => function($datetime)
-			{
-				return str_pad(date_format($datetime, 'G'), 2, " ", STR_PAD_LEFT);
-			},
-			'%I' => 'h',
-			'%l' => function($datetime)
-			{
-				return str_pad(date_format($datetime, 'g'), 2, " ", STR_PAD_LEFT);
-			},
-			'%M' => 'i',
-			'%p' => 'A',
-			'%P' => 'a',
-			'%r' => 'h:i:s A',
-			'%R' => 'H:i',
-			'%S' => 's',
-			'%T' => 'H:i:s',
-			'%X' => 'H:i:s',
-			'%z' => 'O',
-			'%Z' => 'T',
-			'%c' => 'r',
-			'%D' => 'm/d/y',
-			'%F' => 'Y-m-d',
-			'%s' => 'U',
-			'%x' => 'Y-m-d',
-			'%n' => "\n",
-			'%t' => "\t",
-			'%%' => '\%',
-		];
-
-		foreach ($formatMap as $strftime_key => $date_format_key)
-		{
-			if (is_callable($date_format_key))
-			{
-				$replacement = chunk_split($date_format_key($datetime), 1, "\\");
-			}
-			else
-			{
-				$replacement = $date_format_key;
-			}
-			$format = str_replace($strftime_key, $replacement, $format);
-		}
-
-		return date_format($datetime, $format);
+		return eShims::strftime($format, $timestamp);
 	}
 
 	/**

--- a/e107_handlers/sitelinks_class.php
+++ b/e107_handlers/sitelinks_class.php
@@ -1338,7 +1338,7 @@ i.e-cat_users-32{ background-position: -555px 0; width: 32px; height: 32px; }
             || e_REQUEST_HTTP === varset($e107_vars[$act]['link'])
 			)
 			{
-				$temp = varset($tmpl['button_active'.$kpost]);
+				$temp = isset($tmpl['button_active' . $kpost]) ? $tmpl['button_active' . $kpost] : '';
 			}
 			else
 			{

--- a/e107_tests/tests/unit/e107/Shims/Internal/e_dateAlternateTest.php
+++ b/e107_tests/tests/unit/e107/Shims/Internal/e_dateAlternateTest.php
@@ -1,0 +1,93 @@
+<?php
+/**
+ * e107 website system
+ *
+ * Copyright (C) 2008-2021 e107 Inc (e107.org)
+ * Released under the terms and conditions of the
+ * GNU General Public License (http://www.gnu.org/licenses/gpl.txt)
+ *
+ */
+
+namespace e107\Shims\Internal;
+
+/**
+ * @param string $extension
+ * @return bool
+ */
+function extension_loaded($extension)
+{
+	if (e_dateAlternateTest::$alternate_formatter) return false;
+
+	return \extension_loaded($extension);
+}
+
+/**
+ * @param string $constant_name
+ * @return bool
+ */
+function defined($constant_name)
+{
+	if (e_dateAlternateTest::$alternate_locale) return false;
+
+	return \defined($constant_name);
+}
+
+/**
+ * @param int              $category
+ * @param array|string|int $locales
+ * @param string           ...$rest
+ * @return false|string
+ */
+function setlocale($category, $locales, ...$rest)
+{
+	if (e_dateAlternateTest::$alternate_locale) return 'nl_NL';
+
+	return \setlocale($category, $locales, ...$rest);
+}
+
+
+class e_dateAlternateTest extends \e_dateTest
+{
+	/**
+	 * @var bool
+	 */
+	public static $alternate_formatter;
+	/**
+	 * @var bool
+	 */
+	public static $alternate_locale;
+
+	public function _before()
+	{
+		self::$alternate_formatter = true;
+		parent::_before();
+	}
+
+	public function _after()
+	{
+		parent::_after();
+		self::$alternate_formatter = false;
+	}
+
+	public function testConvert_dateDutch()
+	{
+		self::$alternate_formatter = false;
+		self::$alternate_locale = true;
+
+		try
+		{
+
+			$actual = $this->dateObj->convert_date(mktime(12, 45, 03, 2, 5, 2018), 'long');
+			$expected = 'maandag 05 februari 2018 - 12:45:03';
+			$this->assertEquals($expected, $actual);
+
+			$actual = $this->dateObj->convert_date(mktime(12, 45, 03, 2, 5, 2018), 'inputtime');
+			$expected = '12:45 P.M.';
+			$this->assertEquals($expected, $actual);
+		}
+		finally
+		{
+			self::$alternate_locale = false;
+		}
+	}
+}


### PR DESCRIPTION
### Motivation and Context
@tgtje and @Jimmi08 reported that [the reimplementation of `strftime()`](https://github.com/e107inc/e107/pull/4554/commits/20882920a0b68937570264949512acc0c4841dbd#diff-3414784d80a8145da073c2a7a4cb2bb4e8e6a16bea65cbdcf7c2bbf5b0b362aaR209-R297) does not support locales.  This pull request adds locale support and moves `e_date::strftime()` to `eShims::strftime()`.

### Description
* Move `e_date::strftime()` to `eShims::strftime()`.
* Detect if the `intl` PHP extension is installed, and if so, use the new code path that formats datetimes with [`IntlDateFormatter`](https://www.php.net/manual/en/class.intldateformatter.php).

### How Has This Been Tested?
Both implementations are tested with two test classes:
* `\e107\Shims\Internal\e_dateAlternateTest()`
* `\e_dateTest()`

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code adheres to the e107 [code style standard](https://github.com/e107inc/e107/wiki/e107-Coding-Standard).
- [x] I have read the [**contributing** document](https://github.com/e107inc/e107/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/e107inc/e107/tree/master/e107_tests) to cover my changes.
- [x] All new and existing tests pass.