### PR TITLE
Handle previously unhandled exceptions with `social` plugin and Hybridauth

### DIFF
--- a/e107_core/controllers/system/xup.php
+++ b/e107_core/controllers/system/xup.php
@@ -105,7 +105,7 @@ class core_system_xup_controller extends eController
 	
 	
 		$testUrl = SITEURL."?route=system/xup/test";
-		$providers = $manager->getValidConfiguredProviderConfigs();
+		$providers = $manager->getSupportedConfiguredProviderConfigs();
 
 		foreach($providers as $key=>$var)
 		{

--- a/e107_core/shortcodes/batch/signup_shortcodes.php
+++ b/e107_core/shortcodes/batch/signup_shortcodes.php
@@ -125,7 +125,7 @@ class signup_shortcodes extends e_shortcode
 
 
 		$manager = new social_login_config(e107::getConfig());
-		$providers = $manager->getValidConfiguredProviderConfigs();
+		$providers = $manager->getSupportedConfiguredProviderConfigs();
 
 		foreach ($providers as $p => $v)
 		{

--- a/e107_handlers/user_handler.php
+++ b/e107_handlers/user_handler.php
@@ -1117,24 +1117,43 @@ class e_user_provider
 
 	/**
 	 * Hybridauth adapter
-	 * @var \Hybridauth\Adapter\AdapterInterface
+	 *
+	 * @var \Hybridauth\Adapter\AdapterInterface|null
 	 */
 	public $adapter;
 
 	/**
 	 * Hybridauth object
+	 *
 	 * @var Hybridauth\Hybridauth
 	 */
 	protected $hybridauth;
 	protected $_config = array();
 	/**
-	 * @var social_login_config
+	 * @var social_login_config|null
 	 */
-	protected $social_login_config_manager;
+	protected $social_login_config_manager = null;
 
-	public function __construct($provider = null, $config = array())
+	/**
+	 * Create a new Hybridauth-backed social login provider
+	 *
+	 * This constructor suppresses exceptions due to client usages not handling exceptions and instead sends error
+	 * messages to logged in admins. To check if a Hybridauth configuration is valid, use
+	 * {@link e107::getUserProvider()} with the provider name while logged in as an admin.
+	 *
+	 * @param string|null $provider            The name of the provider to use
+	 * @param array       $config              An override Hybridauth configuration that takes precedence over the
+	 *                                         database Hybridauth configuration for this provider. Leave blank to use
+	 *                                         the database configuration.
+	 * @param bool        $suppress_exceptions Set to false to propagate Hybridauth exceptions
+	 * @throws \Hybridauth\Exception\UnexpectedValueException if the provider is disabled
+	 * @throws \Hybridauth\Exception\InvalidArgumentException if the provider configuration validation failed
+	 */
+	public function __construct($provider = null, $config = array(), $suppress_exceptions = true)
 	{
-		require_once(e_PLUGIN . "social/includes/social_login_config.php");
+		@include_once(e_PLUGIN . "social/includes/social_login_config.php");
+		if (!class_exists('social_login_config')) return;
+
 		$this->social_login_config_manager = new social_login_config(e107::getConfig());
 
 		if (!empty($config))
@@ -1466,6 +1485,8 @@ class e_user_provider
 	 */
 	public function isSocialLoginEnabled()
 	{
+		if ($this->social_login_config_manager === null) return false;
+
 		return $this->social_login_config_manager->isFlagActive(social_login_config::ENABLE_BIT_GLOBAL);
 	}
 

--- a/e107_handlers/user_handler.php
+++ b/e107_handlers/user_handler.php
@@ -1144,8 +1144,8 @@ class e_user_provider
 		else
 		{
 			$this->_config = array(
-				"callback" => $this->generateCallbackUrl($provider),
-				"providers" => $this->social_login_config_manager->getValidConfiguredProviderConfigs(),
+				"callback"   => $this->generateCallbackUrl($provider),
+				"providers"  => $this->social_login_config_manager->getSupportedConfiguredProviderConfigs(),
 				"debug_mode" => 'error',
 				"debug_file" => e_LOG . "hybridAuth.log"
 			);

--- a/e107_plugins/social/admin_config.php
+++ b/e107_plugins/social/admin_config.php
@@ -606,6 +606,19 @@ class social_ui extends e_admin_ui
 
 		foreach ($provider_names as $provider_name)
 		{
+			// Check if the current configuration for the provider is valid
+			try
+			{
+				new e_user_provider($provider_name, [], false);
+			}
+			catch (\Hybridauth\Exception\InvalidArgumentException $e)
+			{
+				e107::getMessage()->addError("[{$e->getCode()}] {$e->getMessage()}");
+			}
+			catch (\Hybridauth\Exception\UnexpectedValueException $ignored)
+			{
+			}
+
 			$text .= $this->generateSocialLoginRow($provider_name, $readonly);
 		}
 

--- a/e107_plugins/social/includes/social_login_config.php
+++ b/e107_plugins/social/includes/social_login_config.php
@@ -162,9 +162,13 @@ class social_login_config
 
 	/**
 	 * Get configs of providers that are supported and configured
+	 *
+	 * These configs are not validated here by the social login implementation.
+	 * This method only filters out providers that are not supported and not configured.
+	 *
 	 * @return array Associative array where the key is the denormalized provider name and the value is its config
 	 */
-	public function getValidConfiguredProviderConfigs()
+	public function getSupportedConfiguredProviderConfigs()
 	{
 		$supported_providers = $this->getSupportedProviders();
 		$configured_providers = $this->getConfiguredProviders();
@@ -233,6 +237,9 @@ class social_login_config
 		return $output;
 	}
 
+	/**
+	 * @return array
+	 */
 	protected function getSocialLoginConfig()
 	{
 		$config = $this->config->get(self::SOCIAL_LOGIN_PREF);

--- a/e107_tests/tests/unit/e_user_providerTest.php
+++ b/e107_tests/tests/unit/e_user_providerTest.php
@@ -115,4 +115,32 @@ class e_user_providerTest extends \Codeception\Test\Unit
 		$result = e_user_provider::getSupplementalFieldsOf("Vkontakte");
 		$this->assertTrue(array_key_exists('photo_size', $result));
 	}
+
+	public function testNewSuppressExceptions()
+	{
+		$this->assertInstanceOf(
+			e_user_provider::class,
+			new e_user_provider("Facebook", ["providers" => ["Facebook", ["enabled" => true]]])
+		);
+	}
+
+	public function testNewNoSuppressConfigurationException()
+	{
+		$this->expectException(\Hybridauth\Exception\InvalidArgumentException::class);
+		new e_user_provider(
+			"Facebook",
+			["providers" => ["Facebook" => ["enabled" => true]]],
+			false
+		);
+	}
+
+	public function testNewNoSuppressDisabledException()
+	{
+		$this->expectException(\Hybridauth\Exception\UnexpectedValueException::class);
+		new e_user_provider(
+			"Facebook",
+			["providers" => ["Facebook" => ["enabled" => false]]],
+			false
+		);
+	}
 }


### PR DESCRIPTION
### Motivation and Context

#### #4192 – social login with FB - avoid fatal error if ID is missing
A frontend error should not happen if any social login provider is not configured correctly.

#### #4199 – handler dependent on social plugin
e107 should not break with a fatal error if the `social` plugin is removed.

### Description
* `e107::getUserProvider()` no longer throws exceptions, as the client usages do not handle them.  Instead, the exceptions are suppressed now.
* Creating an `e_user_provider` manually now has the option to un-suppress exceptions, which lets the admin verify that their configurations are valid at `/e107_plugins/social/admin_config.php?mode=main&action=configure`.
* `e_user_provider` will no longer fatal error if the `social` plugin is removed.

### How Has This Been Tested?
Added tests for bad Hybridauth configurations and resulting exceptions that are either suppressed or rethrown

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code adheres to the e107 [code style standard](https://github.com/e107inc/e107/wiki/e107-Coding-Standard).
- [x] I have read the [**contributing** document](https://github.com/e107inc/e107/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/e107inc/e107/tree/master/e107_tests) to cover my changes.
- [x] All new and existing tests pass.