### PR TITLE
#4708 load bbcode buttons only if HTML is allowed for user

### DIFF
--- a/e107_handlers/form_handler.php
+++ b/e107_handlers/form_handler.php
@@ -2490,10 +2490,18 @@ class e_form
 					}
 				}
 			}
-		}
-
-
-		$ret .=	e107::getBB()->renderButtons($template,$help_tagid);
+		
+            if (!check_class(e107::getConfig()->get('post_html', e_UC_MAINADMIN))) 
+            {
+                $ret .=	e107::getBB()->renderButtons($template,$help_tagid);
+            }
+        
+        }
+        else 
+        {
+            $ret .=	e107::getBB()->renderButtons($template,$help_tagid);
+        }
+        
 		$ret .=	$this->textarea($name, $value, $rows, $cols, $options, $counter); // higher thank 70 will break some layouts.
 			
 		$ret .= "</div>\n";


### PR DESCRIPTION
CLOSES #4708

### Motivation and Context
 
https://github.com/e107inc/e107/issues/4708

### Description
see issue

### How Has This Been Tested?
Tested scenarios:
- site wysiwyg on, html access  -  result tinymce
- site wysiwyg on,  no html access  - result bbcodes
- site wysiwyg off,  forum wysiwyg on,  no html access  - result bbcodes
- site wysiwyg off,  forum wysiwyg on,  html access  - result tinymce
It worked like this before too, but bbcodes were always rendered (not visible with tinymce) 

 