### PR TITLE
#4665 correct user last visit information

### DIFF
--- a/e107_core/shortcodes/batch/user_shortcodes.php
+++ b/e107_core/shortcodes/batch/user_shortcodes.php
@@ -182,13 +182,13 @@ class user_shortcodes extends e_shortcode
 	
 	function sc_user_lastvisit($parm='')
 	{
-		return $this->var['user_currentvisit'] ? e107::getDate()->convert_date($this->var['user_currentvisit'], "long") : "<i>".LAN_USER_33."</i>";
+		return $this->var['user_currentvisit'] ? e107::getDate()->convert_date($this->var['user_currentvisit'], "long") : e107::getDate()->convert_date($this->var['user_lastvisit'], "long");
 	}
 	
 	
 	function sc_user_lastvisit_lapse($parm='')
 	{	
-		return $this->var['user_currentvisit'] ? e107::getDate()->computeLapse($this->var['user_currentvisit']) : '';
+		return $this->var['user_currentvisit'] ? e107::getDate()->computeLapse($this->var['user_currentvisit']) : e107::getDate()->computeLapse($this->var['user_lastvisit']);
 	}
 
 	

--- a/e107_handlers/date_handler.php
+++ b/e107_handlers/date_handler.php
@@ -141,6 +141,7 @@ class e_date
 	function convert_date($datestamp, $mask = '')
 	{
 		$datestamp = (int) $datestamp;
+		if($datestamp == 0) return "";
 
 		if(empty($mask))
 		{
@@ -596,6 +597,7 @@ class e_date
 	function computeLapse($older_date, $newer_date = FALSE, $mode = FALSE, $show_secs = TRUE, $format = 'long') 
 	{
 		$older_date = (int) $older_date;
+		if($older_date == 0) return "";
 
 		if(empty($newer_date))
 		{


### PR DESCRIPTION
CLOSES #4665

Description:
Last visit information fix - either currect visit info (online user) or last visit info
Return empty string for not set value in relative date. 


 