### PR TITLE
#4245 stay on correct page after editing paginated topic

### DIFF
--- a/e107_plugins/forum/forum_post.php
+++ b/e107_plugins/forum/forum_post.php
@@ -1585,7 +1585,16 @@ class forum_post_handler
 
 	//	$url = e107::getUrl()->create('forum/thread/post', "id={$this->data['post_id']}", 'encode=0&full=1'); // XXX what data is available, find thread name
 
-		$url = e107::url('forum','topic',$this->data); // ."&f=post";
+		$page= (varset($_GET['p']) ? (int)$_GET['p'] : 1);
+		if($page > 1) 
+		{
+				$url = e107::url('forum','topic',$this->data)."?p=".$page; 
+		}
+		else {
+				$url = e107::url('forum','topic',$this->data);
+		}
+        
+		//$url = e107::url('forum','topic',$this->data); // ."&f=post";
 
 		$this->redirect($url);
 

--- a/e107_plugins/forum/shortcodes/batch/view_shortcodes.php
+++ b/e107_plugins/forum/shortcodes/batch/view_shortcodes.php
@@ -672,7 +672,8 @@ class plugin_forum_view_shortcodes extends e_shortcode
 
 		if(USER && !empty($this->postInfo['post_user']) && $this->postInfo['post_user'] == USERID && $this->var['thread_active'])
 		{
-			$qry = array('f' => 'edit', 'id' => $this->postInfo['post_thread'], 'post' => $this->postInfo['post_id']);
+			$page= (varset($_GET['p']) ? (int)$_GET['p'] : 1);
+			$qry = array('f' => 'edit', 'id' => $this->postInfo['post_thread'], 'post' => $this->postInfo['post_id'], 'p' => $page);
 			$editURL = e107::url('forum', 'post', null, array('query' => $qry));
 
 			return "<a class='e-tip' href='" . $editURL . "' title=\"" . LAN_EDIT . "\">" . IMAGE_edit . '</a> ';
@@ -912,6 +913,7 @@ class plugin_forum_view_shortcodes extends e_shortcode
 		$tp = e107::getParser();
 		$threadID = !empty($this->postInfo['post_thread']) ? $this->postInfo['post_thread'] : 0;
 		$postID = !empty($this->postInfo['post_id']) ? $this->postInfo['post_id'] : 0;
+		$page= (varset($_GET['p']) ? (int)$_GET['p'] : 1);
 		// {EMAILITEM} {PRINTITEM} {REPORTIMG}{EDITIMG}{QUOTEIMG}
 
 		$text = '<div class="btn-group pull-right float-right float-end">
@@ -944,7 +946,8 @@ class plugin_forum_view_shortcodes extends e_shortcode
 		{
 
 
-			$url = e107::url('forum', 'post') . "?f=edit&amp;id=" . $threadID . "&amp;post=" . $postID;
+			//$url = e107::url('forum', 'post') . "?f=edit&amp;id=" . $threadID . "&amp;post=" . $postID;
+			$url = e107::url('forum', 'post') . "?f=edit&amp;id=" . $threadID . "&amp;post=" . $postID . "&amp;p=".$page;
 			//$url = e107::getUrl()->create('forum/thread/edit', array('id' => $threadID, 'post'=>$postID));
 			$text .= "<li class='text-right text-end float-right'><a class='dropdown-item' href='" . $url . "'>" . LAN_EDIT . " " . $tp->toGlyph('fa-edit') . "</a></li>";
 
@@ -981,7 +984,8 @@ class plugin_forum_view_shortcodes extends e_shortcode
 			if((USER && isset($this->postInfo['post_user']) && $this->postInfo['post_user'] != USERID && $this->var['thread_active']))
 			{
 
-				$url = e107::url('forum', 'post') . "?f=edit&amp;id=" . $threadID . "&amp;post=" . $postID;
+				//$url = e107::url('forum', 'post') . "?f=edit&amp;id=" . $threadID . "&amp;post=" . $postID;
+				$url = e107::url('forum', 'post') . "?f=edit&amp;id=" . $threadID . "&amp;post=" . $postID . "&amp;p=".$page;
 				// $url = e107::getUrl()->create('forum/thread/edit', array('id' => $threadID, 'post'=>$postID));
 
 				$text .= "<li class='text-right text-end float-right'><a class='dropdown-item' href='" . $url . "'>" . LAN_EDIT . " " . $tp->toGlyph('fa-edit') . "</a></li>";


### PR DESCRIPTION
CLOSES #4245

Tested with PHP 8.1

Description:
When you edit a post on the next page (with the paginated topic), after saving you are redirected to the first page and you don't see that edited message then.

Changes

added p parameter to edit URL in post options and edit image shortcodes
used this parameter when redirecting after reply is updated
it is not needed when updating the thread because you are always on the first page
added check if it is the first page, then the parameter is not used (to have the same behavior as with thread).
Tested

PHP 7.4. + PHP 8
core bootstrap5 theme and custom theme with custom forum templates
Important Note::
Updating/Fixing postoptions are/will be separated issues (more than one). It needs some changes but they are not related to this issue. So now just changed links, nothing more.
 

 