### PR TITLE
#4830: Sensible no delete log in `admin_log_ui::maintenanceProcess()`

### DIFF
--- a/e107_admin/admin_log.php
+++ b/e107_admin/admin_log.php
@@ -403,7 +403,13 @@ class admin_log_ui extends e_admin_ui
 				}
 				else
 				{
-					$mes->addWarning(RL_LAN_054." : ".$sql->mySQLresult);
+					$message = RL_LAN_054;
+					$lastErrorText = $sql->getLastErrorText();
+					if ($lastErrorText)
+					{
+						$message .= "<br />$lastErrorText";
+					}
+					$mes->addWarning($message);
 				}
 
 			}


### PR DESCRIPTION
Fixes: #4830

### Motivation and Context
`$sql->mySQLresult` can't magically be turned into a string, so use the actual interface, `e_db::getLastErrorText()`.

### Description
The SQL last error text will be printed, if any, when there are no system logs to delete in `/e107_admin/admin_log.php?mode=main&action=maintenance`.

### How Has This Been Tested?
![image](https://user-images.githubusercontent.com/1364268/181641542-f03a1c9b-b89b-45b8-ab78-eaa05d0c8d0a.png)

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code adheres to the e107 [code style standard](https://github.com/e107inc/e107/wiki/e107-Coding-Standard).
- [x] I have read the [**contributing** document](https://github.com/e107inc/e107/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/e107inc/e107/tree/master/e107_tests) to cover my changes.
- [x] All new and existing tests pass.