### PR TITLE
Login flow consistency: Do not use redirect in admin area login box

### DIFF
--- a/e107_admin/auth.php
+++ b/e107_admin/auth.php
@@ -134,12 +134,7 @@ else
 		{
 			e107::coreLan('log_messages', true);
 			e107::getLog()->addEvent(4, __FILE__."|".__FUNCTION__."@".__LINE__, "LOGIN", LAN_ROLL_LOG_11, "U: ".e107::getParser()->toDB($_POST['authname']), FALSE, LOG_TO_ROLLING);
-
-			e107::getRedirect()->redirect('admin.php?failed');
 		}
-
-		exit;
-
 	}
 
 
@@ -274,28 +269,20 @@ class auth
 	// Start Clean 
 	// NOTE: this should NOT be a template of the admin-template, however themes may style it using css. 
 	
-		$class = (e_QUERY === 'failed') ? "class='e-shake'" : "";
-
 		$text = "<form id='admin-login' method='post' action='".e_SELF."' {$incChap} >
 		<div id='logo' ><img src='".e_IMAGE."logo_template_large.png' alt='".LAN_LOGIN."' /></div>
 		<div id='login-admin' class='center'>
 		<div>";
 
-		if(e_QUERY === 'failed')
-		{
-			e107::lan('core', 'login');
-			$text .= e107::getMessage()->render(); // see e107_handlers/login.php L622
-			$text .= "<script>
-				window.setTimeout(function() {
-			    $('.alert').fadeTo(500, 0).slideUp(500, function(){
-			        $(this).remove();
-			    });
-			}, 7000);
-			</script>";
-
-		}
-
-
+		e107::lan('core', 'login');
+		$text .= e107::getMessage()->render(); // see e107_handlers/login.php L622
+		$text .= "<script>
+			window.setTimeout(function() {
+		    $('.alert').fadeTo(500, 0).slideUp(500, function(){
+		        $(this).remove();
+		    });
+		}, 7000);
+		</script>";
 
 		$text .= "
 		<div class='panel well panel-primary'>

--- a/e107_handlers/login.php
+++ b/e107_handlers/login.php
@@ -646,7 +646,7 @@ class userlogin
 				$this->logNote('LAN_ROLL_LOG_10', $username);
 		}
 
-		e107::getMessage()->reset()->addError($message, 'default', true); // prevent duplicates, session=true needed for admin-area login.
+		e107::getMessage()->reset()->addError($message); // prevent duplicates
 
 		if($this->testMode === true)
 		{

--- a/e107_tests/tests/acceptance/0001_AdminLoginCest.php
+++ b/e107_tests/tests/acceptance/0001_AdminLoginCest.php
@@ -11,7 +11,19 @@ class AdminLoginCest
 	{
 	}
 
-	// tests
+	/**
+	 * @see https://github.com/e107inc/e107/issues/4779
+	 */
+	public function testAdminFailedLogin(AcceptanceTester $I)
+	{
+		$I->wantTo("See a login failure message in the admin area if I put in the wrong credentials");
+		$I->amOnPage("/e107_admin/admin.php");
+		$I->fillField('authname', 'e107');
+		$I->fillField('authpass', 'wrong password');
+		$I->click('authsubmit');
+		$I->see("Your login details don't match any registered user");
+	}
+
 	public function testAdminLogin(AcceptanceTester $I)
 	{
 
@@ -26,7 +38,6 @@ class AdminLoginCest
 		$I->see("Status");
 
 	}
-
 
 	private function e107Login(AcceptanceTester $I)
 	{


### PR DESCRIPTION
Fixes: https://github.com/e107inc/e107/issues/4779

### Motivation and Context
The non-admin login flow does not perform a redirect, but the admin login flow did. This led to an inconsistency in how the authentication error message was passed.

### Description
The login failure redirect on the admin area login page (`/e107_admin/admin.php`) has been removed.

### How Has This Been Tested?
`\AdminLoginCest::testAdminFailedLogin()` now checks that the login failure message is displayed in the admin area login page on failed login.

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code adheres to the e107 [code style standard](https://github.com/e107inc/e107/wiki/e107-Coding-Standard).
- [x] I have read the [**contributing** document](https://github.com/e107inc/e107/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/e107inc/e107/tree/master/e107_tests) to cover my changes.
- [x] All new and existing tests pass.