### PR TITLE
Add support for wrapper in custom menus

### DIFF
--- a/e107_handlers/menu_class.php
+++ b/e107_handlers/menu_class.php
@@ -650,7 +650,7 @@ class e_menu
 			{
 				$template = e107::getCoreTemplate('menu',$page['menu_template'],true,true);	// override and merge required. ie. when menu template is not in the theme, but only in the core. 
 				$page_shortcodes = e107::getScBatch('page',null,'cpage');  
-				$page_shortcodes->setVars($page);
+				$page_shortcodes->setVars($page)->wrapper('menu/'.$page['menu_template'] );
 				  
 				$head = $tp->parseTemplate($template['start'], true, $page_shortcodes);
 				$foot = $tp->parseTemplate($template['end'], true, $page_shortcodes);


### PR DESCRIPTION
Solves #4872

Minimalize number of needed template keys for custom menus

I am not able to test if it is not breaking something in global, but it works in theme I am working on. 


 