### PR TITLE
Tests: MDEV-29446 workaround: Ignore COLLATE clause in SHOW CREATE TABLE

### DIFF
--- a/e107_tests/tests/unit/db_table_adminTest.php
+++ b/e107_tests/tests/unit/db_table_adminTest.php
@@ -346,10 +346,14 @@
 
 			$result = $this->dta->get_current_table('core');
 
-			// MySQL 8.0+: Alias CHARSET=utf8mb3 to CHARSET=utf8
 			array_walk_recursive($result, function(&$element)
 			{
+				// MySQL 8.0+
+				//   Alias CHARSET=utf8mb3 to CHARSET=utf8
 				$element = str_replace("CHARSET=utf8mb3", "CHARSET=utf8", $element);
+				// MariaDB 10.3.37, 10.4.27, 10.5.18, 10.6.11, 10.7.7, 10.8.6, 10.9.4, 10.10.2, 10.11.0
+				//   Ignore COLLATE clause (https://jira.mariadb.org/browse/MDEV-29446)
+				$element = preg_replace("/ COLLATE=[^\s;]+/", "", $element);
 			});
 
 			$this->assertSame($expected, $result);


### PR DESCRIPTION
### Motivation and Context
Failing test:

```
---------
1) db_table_adminTest: Get_current_table
 Test  tests/unit/db_table_adminTest.php:testGet_current_table
Failed asserting that two arrays are identical.
- Expected | + Actual
@@ @@
e107_name varchar(100) NOT NULL DEFAULT '',\n
e107_value text NOT NULL,\n
PRIMARY KEY (e107_name)\n
-) ENGINE=MyISAM DEFAULT CHARSET=utf8;'
+) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci;'
1 => 'e107_core'
2 => 'e107_name varchar(100) NOT NULL DEFAULT '',\n
e107_value text NOT NULL,\n
PRIMARY KEY (e107_name)'
-        3 => 'MyISAM DEFAULT CHARSET=utf8'
+        3 => 'MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci'
)
)
#1  /__w/e107/e107/e107_tests/tests/unit/db_table_adminTest.php:355
#2  /__w/e107/e107/e107_tests/vendor/bin/codecept:120
```

### Description
https://jira.mariadb.org/browse/MDEV-29446 changes the output of `SHOW CREATE TABLE`, which MySQL and MariaDB 10.2 and older do not do.

To tolerate the new behavior, this change strips the `COLLATE` clause from the `SHOW CREATE TABLE` output to ignore it.

Fixes: https://github.com/e107inc/e107/issues/4912

### How Has This Been Tested?
Test modified

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code adheres to the e107 [code style standard](https://github.com/e107inc/e107/wiki/e107-Coding-Standard).
- [x] I have read the [**contributing** document](https://github.com/e107inc/e107/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/e107inc/e107/tree/master/e107_tests) to cover my changes.
- [x] All new and existing tests pass.