### PR TITLE
#4929: Fix type mismatch in usage of `e107forum::getForumClassMembers()`

### DIFF
--- a/e107_plugins/forum/forum_class.php
+++ b/e107_plugins/forum/forum_class.php
@@ -174,6 +174,22 @@ class e107forum
 
 	}
 
+	/**
+	 * Get an array of the first alphabetical 50 usernames, user IDs, and the users' serialized user classes that match
+	 * the forum's allowed viewers or a user class ID if the allowed viewers is a special user class except if the
+	 * special user class is {@see e_UC_MAINADMIN} or {@see false} if the previous two possibilities are not encountered
+	 *
+	 * @deprecated v2.3.3 Due to the confusing usage, consider writing another method to get the list of members that
+	 *                    can see the forum identified by its forum ID.
+	 * @param $forumId int The ID from `e107_forum`.`forum_id`
+	 * @param $type string Can only be "view"
+	 * @return array|int|false When an array, the first 50 users, sorted alphabetically by username, that can view this
+	 *                         forum, along with their user ID, username, and serialized user classes.
+	 *                         When an int, the special user class ID as defined in {@see e107::set_constants()} except
+	 *                         {@see e_UC_MAINADMIN}.
+	 *                         When boolean false, this is an unhandled case probably due to the
+	 *                         `e107_forum`.`forum_class` column missing from the table.
+	 */
 	function getForumClassMembers($forumId, $type='view')
 	{
 

--- a/e107_plugins/forum/shortcodes/batch/viewforum_shortcodes.php
+++ b/e107_plugins/forum/shortcodes/batch/viewforum_shortcodes.php
@@ -239,29 +239,26 @@
 		{
 			global $forum, $forumId;
 
-			if($users = $forum->getForumClassMembers($forumId))
+			if($usersOrUserClassId = $forum->getForumClassMembers($forumId))
 			{
 				$userList = array();
-				$viewable = e107::getUserClass()->getFixedClassDescription($users);
-				if(is_array($users))
+				if(is_array($usersOrUserClassId))
 				{
-					foreach($users as $user)
+					foreach($usersOrUserClassId as $user)
 					{
 						$userList[] = "<a href='" . e107::getUrl()->create('user/profile/view', $user) . "'>" . $user['user_name'] . "</a>";
 					}
 
 					$viewable = implode(', ', $userList);;
 				}
-				elseif($users == 0)
+				elseif($usersOrUserClassId == 0)
 				{
 					$viewable = '';
 				}
-				/*--
-					else
-					{
-						$viewable =  e107::getUserClass()->getFixedClassDescription($users);
-					}
-				--*/
+				else
+				{
+					$viewable = e107::getUserClass()->getFixedClassDescription($usersOrUserClassId);
+				}
 			}
 
 			/*--


### PR DESCRIPTION
### Motivation and Context
Fixes: https://github.com/e107inc/e107/issues/4929

### Description
`e107forum::getForumClassMembers()` is now documented and deprecated because it has unintuitive return values.

The single usage of this method in `plugin_forum_viewforum_shortcodes::sc_viewable_by()` has been corrected to account for the mixed return type.

### How Has This Been Tested?
Manually verified that there is no uncaught exception when running the steps to reproduce https://github.com/e107inc/e107/issues/4929:

![#4929 manual test](https://user-images.githubusercontent.com/1364268/209465449-3435cb66-0139-4fb4-ac62-4f41b2a6f639.png)

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code adheres to the e107 [code style standard](https://github.com/e107inc/e107/wiki/e107-Coding-Standard).
- [x] I have read the [**contributing** document](https://github.com/e107inc/e107/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/e107inc/e107/tree/master/e107_tests) to cover my changes.
- [x] All new and existing tests pass.