### PR TITLE
#4938: Workaround for PHP 8.2.0 segmentation fault / assertion error

### DIFF
--- a/e107_handlers/xml_class.php
+++ b/e107_handlers/xml_class.php
@@ -549,7 +549,7 @@ class xmlClass
 		
 		$ret = array();
 	
-		$tags = get_object_vars($xml);
+		$tags = (array) $xml;
 	
 		
 		//remove comments


### PR DESCRIPTION
Fixes: https://github.com/e107inc/e107/issues/4938

### Motivation and Context
e107 won't run on PHP 8.2.0 due to this bug: https://github.com/e107inc/e107/issues/4938 » https://github.com/php/php-src/issues/10200

### Description
Casting a `SimpleXMLElement` to an array should be equivalent to `get_object_vars(…)` as far as I can tell.  At least all existing tests pass and I don't see any visual regressions upon making this change.

By replacing `get_object_vars(…)` with a cast to array, we sidestep this PHP 8.2.0 bug: https://github.com/php/php-src/issues/10200

### How Has This Been Tested?
Existing tests pass, and I don't see anything amiss when clicking around e107 with this patch.

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code adheres to the e107 [code style standard](https://github.com/e107inc/e107/wiki/e107-Coding-Standard).
- [x] I have read the [**contributing** document](https://github.com/e107inc/e107/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/e107inc/e107/tree/master/e107_tests) to cover my changes.
- [x] All new and existing tests pass.