### PR TITLE
Fix news category breadcrumbs

### DIFF
--- a/e107_plugins/news/news.php
+++ b/e107_plugins/news/news.php
@@ -107,7 +107,7 @@ class news_front
 
 				$itemName = e107::getParser()->toHTML($this->currentRow['news_title'],true, 'TITLE');
 
-				$breadcrumb[] = array('text'=> $categoryName, 'url'=>e107::getUrl()->create('news/list/category', $this->currentRow));
+				$breadcrumb[] = array('text'=> $categoryName, 'url'=>e107::getUrl()->create('news/list/category', array('id'=>$this->currentRow['news_category'])));
 				$breadcrumb[] = array('text'=> $itemName, 'url'=> null);
 				break;
 


### PR DESCRIPTION
The breadcrumbs for news categories were previously pointing to the category page but using the id of the news story instead of the id of the category.

### Motivation and Context
The category breadcrumbs on `/news.php?extend.${NEWS_ID}` were pointing at `/news.php?list.${NEWS_ID}.0` instead of `/news.php?list.${NEWS_CATEGORY_ID}.0`

### Description
Pass an array to the `e107::getUrl()->create` invocation with the category's id instead of the story's id.

### How Has This Been Tested?
- Deployed on our website at https://kyrgaming.com
- See news story at https://kyrgaming.com/news.php?extend.2
- The category breadcrumb was previously pointing to https://kyrgaming.com/news.php?list.2.0 erroneously, which showed "There are no news items for the specified category - please check back soon."
- With this fix, the category breadcrumb now points to https://kyrgaming.com/news.php?list.1.0 instead, which shows the correct news items in that category.
- (Tested on Ubuntu  18.04, php 7.2, mysql 5.7.)

### Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist
- [x] My code adheres to the e107 [code style standard](https://github.com/e107inc/e107/wiki/e107-Coding-Standard).
- [x] I have read the [**contributing** document](https://github.com/e107inc/e107/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/e107inc/e107/tree/master/e107_tests) to cover my changes.
- [ ] All new and existing tests pass.

~~Existing unit tests on `master` are already failing for me, so I'm not touching that.~~

Deltik helped me get the unit tests running, thank you!