### PR TITLE
news: Fix category link in both breadcrumb and menu

### DIFF
--- a/e107_core/url/news/url.php
+++ b/e107_core/url/news/url.php
@@ -129,7 +129,7 @@ class core_news_url extends eUrlConfig
 				break;
 				
 				case 'category':
-					if(!vartrue($params['id']))
+					if(!vartrue($params['category_id']))
 					{
 						 $url .= 'default.0.'.$page;
 					}

--- a/e107_core/url/news/url.php
+++ b/e107_core/url/news/url.php
@@ -135,7 +135,7 @@ class core_news_url extends eUrlConfig
 					}
 					else 
 					{
-						$url .= 'list.'.$params['id'].'.'.$page;	// 'category_id' would break news_categories_menu. 
+						$url .= 'list.'.$params['category_id'].'.'.$page;
 					}
 				break;
 					

--- a/e107_handlers/news_class.php
+++ b/e107_handlers/news_class.php
@@ -999,7 +999,7 @@ class e_news_category_item extends e_front_model
 	public function sc_news_category_url($parm = '')
 	{
 
-		$url = e107::getUrl()->create('news/list/category', array('id' => $this->getId(), 'name' => $this->cat('sef')));
+		$url = e107::getUrl()->create('news/list/category', array($this->getFieldIdName() => $this->getId(), 'name' => $this->cat('sef')));
 		switch($parm)
 		{
 			case 'link':

--- a/e107_plugins/news/news.php
+++ b/e107_plugins/news/news.php
@@ -107,7 +107,7 @@ class news_front
 
 				$itemName = e107::getParser()->toHTML($this->currentRow['news_title'],true, 'TITLE');
 
-				$breadcrumb[] = array('text'=> $categoryName, 'url'=>e107::getUrl()->create('news/list/category', array('id'=>$this->currentRow['news_category'])));
+				$breadcrumb[] = array('text'=> $categoryName, 'url'=>e107::getUrl()->create('news/list/category', $this->currentRow));
 				$breadcrumb[] = array('text'=> $itemName, 'url'=> null);
 				break;
 

--- a/e107_tests/tests/unit/plugins/news/PluginNewsTest.php
+++ b/e107_tests/tests/unit/plugins/news/PluginNewsTest.php
@@ -1,0 +1,124 @@
+<?php
+
+
+class PluginNewsTest extends \Codeception\Test\Unit
+{
+
+	/**
+	 * @see https://github.com/e107inc/e107/issues/4982
+	 */
+	public function testCategoryListDefaultSef()
+	{
+		include_once "e107_core/url/news/url.php";
+		$eUrlConfig = new core_news_url();
+		$output     = $eUrlConfig->create(
+			["list", "category"],
+			["category_id" => 579773, "name" => "regression"],
+			["full" => false, "amp" => "&amp;", "equal" => "=", "encode" => true, "lan" => null]);
+		$this->assertEquals("news.php?list.579773.0", $output);
+	}
+
+	public function testNewsFrontCategoryUrl()
+	{
+		$payload = $this->simulateShowNewsItem();
+		$this->testNewsFrontCategoryUrlSef(
+			$payload,
+			"core",
+			"/news.php?list.{$payload['category_id']}.0"
+		);
+	}
+
+	public function testNewsFrontCategoryUrlCoreSef()
+	{
+		$payload = $this->simulateShowNewsItem();
+		$this->testNewsFrontCategoryUrlSef(
+			$payload,
+			"core/sef",
+			"/news/category/{$payload['category_id']}/{$payload['category_sef']}"
+		);
+	}
+
+	public function testNewsFrontCategoryUrlCoreSefFull()
+	{
+		$payload = $this->simulateShowNewsItem();
+		$this->testNewsFrontCategoryUrlSef(
+			$payload,
+			"core/sef_full",
+			"/news/category/{$payload['category_sef']}"
+		);
+	}
+
+	public function testNewsFrontCategoryUrlCoreSefNoid()
+	{
+		$payload = $this->simulateShowNewsItem();
+		$this->testNewsFrontCategoryUrlSef(
+			$payload,
+			"core/sef_noid",
+			"/news/category/{$payload['category_sef']}.html"
+		);
+	}
+
+	/**
+	 * @param $payload  array
+	 * @param $sefType  string
+	 * @param $expected string
+	 * @return void
+	 */
+	private function testNewsFrontCategoryUrlSef($payload, $sefType, $expected)
+	{
+		$urlConfig         = $oldUrlConfig = e107::getConfig()->get('url_config', array());
+		$urlConfig["news"] = $sefType;
+		e107::getConfig()->set('url_config', $urlConfig);
+		$router = new eRouter();
+		$router->loadConfig(true);
+		$oldRouter = e107::getUrl()->front()->getRouter();
+		try
+		{
+			e107::getUrl()->front()->setRouter($router);
+			$output = e107::getUrl()->create('news/list/category', $payload);
+			$this->assertEquals($expected, $output);
+		}
+		finally
+		{
+			e107::getUrl()->front()->setRouter($oldRouter);
+			e107::getConfig()->set('url_config', $oldUrlConfig);
+		}
+	}
+
+	/**
+	 * @return array
+	 */
+	private function simulateShowNewsItem()
+	{
+		$rowCount = e107::getDb()->select("news", "news_id");
+		$this->assertGreaterThanOrEqual(
+			1,
+			$rowCount,
+			"This integration test requires at least one news item in the database"
+		);
+		$rows = e107::getDb()->rows();
+		include_once e_PLUGIN . "news/news.php";
+		$news = new news_front();
+
+		$reflection = new ReflectionClass($news);
+		$property   = $reflection->getProperty("subAction");
+		$property->setAccessible(true);
+		$property->setValue($news, current($rows)["news_id"]);
+
+		$method = $reflection->getMethod("renderViewTemplate");
+		$method->setAccessible(true);
+		try
+		{
+			$method->invoke($news);
+		}
+		catch(ReflectionException $e)
+		{
+			$this->fail("ReflectionException: " . $e->getMessage());
+		}
+
+		$property = $reflection->getProperty("currentRow");
+		$property->setAccessible(true);
+
+		return $property->getValue($news);
+	}
+}


### PR DESCRIPTION
### Motivation and Context
These changes fixed individual symptoms, but not the root cause:
* https://github.com/e107inc/e107/commit/ba18155c345b66d825804219d1b2e8db0e9860ec broke the `news` plugin category breadcrumb in an effort to fix the category list in the `news_categories` menu.
* https://github.com/e107inc/e107/pull/4982 fixed that category breadcrumb but broke the friendly name for search engine-friendly URLs.

### Description
This change reverts both failed fixes and actually addresses the root cause: When rendering the category list, read out the `category_id`, and `e_news_category_item::sc_news_category_url()` should be passing in `category_id`, not `id`.  `id` cannot mean both the category ID and the news item ID.

### How Has This Been Tested?
Manually, I checked both the `news_categories` menu behavior and the breadcrumb behavior on all `news` SEF variants at `/e107_admin/eurl.php?mode=main&action=config`.

Automated tests for the `news` plugin category SEF URLs are in the new file `e107_tests/tests/unit/plugins/news/PluginNewsTest.php`.

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code adheres to the e107 [code style standard](https://github.com/e107inc/e107/wiki/e107-Coding-Standard).
- [x] I have read the [**contributing** document](https://github.com/e107inc/e107/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/e107inc/e107/tree/master/e107_tests) to cover my changes.
- [x] All new and existing tests pass.