### PR TITLE
 deprecated static::method() calls for PHP 8.2

### DIFF
--- a/e107_handlers/e107_class.php
+++ b/e107_handlers/e107_class.php
@@ -4642,23 +4642,23 @@ class e107
 	{
 
 		// Block common bad agents / queries / php issues.
-		array_walk($_SERVER,  array('self', 'filter_request'), '_SERVER');
+		array_walk($_SERVER,  [self::class, "filter_request"] , '_SERVER');
 		if (isset($_GET))
 		{
-			array_walk($_GET, array('self', 'filter_request'), '_GET');
+			array_walk($_GET, [self::class, "filter_request"], '_GET');
 		}
 		if (isset($_POST))
 		{
-			array_walk($_POST,    array('self', 'filter_request'), '_POST');
+			array_walk($_POST,   [self::class, "filter_request"], '_POST');
 			reset($_POST);		// Change of behaviour in PHP 5.3.17?
 		}
 		if (isset($_COOKIE))
 		{
-			array_walk($_COOKIE, array('self', 'filter_request'), '_COOKIE');
+			array_walk($_COOKIE, [self::class, "filter_request"], '_COOKIE');
 		}
 		if (isset($_REQUEST))
 		{
-			array_walk($_REQUEST, array('self', 'filter_request'), '_REQUEST');
+			array_walk($_REQUEST, [self::class, "filter_request"], '_REQUEST');
 		}
 
 		// A better way to detect an AJAX request. No need for "ajax_used=1";


### PR DESCRIPTION
discussed in #4987
 
### Motivation and Context
PHP 8.2 fix

### Description
see #4987

### How Has This Been Tested?
It wasn't tested. PR created by editing file directly.

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code adheres to the e107 [code style standard](https://github.com/e107inc/e107/wiki/e107-Coding-Standard).
- [ ] I have read the [**contributing** document](https://github.com/e107inc/e107/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/e107inc/e107/tree/master/e107_tests) to cover my changes.
- [ ] All new and existing tests pass.