### PR TITLE
#4991: Fix improper array access in sc_signup_extended_user_fields

### DIFF
--- a/e107_core/shortcodes/batch/signup_shortcodes.php
+++ b/e107_core/shortcodes/batch/signup_shortcodes.php
@@ -520,6 +520,7 @@ class signup_shortcodes extends e_shortcode
 			{
 				$opts = $parm;
 				$required = (int) $ext['user_extended_struct_required'];
+				$edit = isset($_POST['ue']['user_' . $ext['user_extended_struct_name']]) ? $_POST['ue']['user_' . $ext['user_extended_struct_name']] : '';
 
 				if($required === 0) // "No - Will not show on Signup page".
 				{
@@ -545,7 +546,7 @@ class signup_shortcodes extends e_shortcode
 				$replace = array(
 					$label,
 					($required === 1 ? $this->sc_signup_is_mandatory('true') : ''),
-					$ue->renderElement($ext, varset($_POST['ue']['user_' . $ext['user_extended_struct_name']]), $opts)
+					$ue->renderElement($ext, $edit, $opts)
 				);
 
 				$text .= str_replace($search, $replace, $this->template['extended-user-fields']);


### PR DESCRIPTION
### Motivation and Context
Fixes: https://github.com/e107inc/e107/issues/4991

### Description
`varset()` is not a language builtin that can handle unset array keys like `isset() ? … : …` can.

This change replaces a `varset()` with the `isset() ? … : …` style.

### How Has This Been Tested?

`/signup.php` shows up now:

![image](https://user-images.githubusercontent.com/1364268/232272875-67494b78-5362-4eec-86ab-26e9e1f93d95.png)

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code adheres to the e107 [code style standard](https://github.com/e107inc/e107/wiki/e107-Coding-Standard).
- [x] I have read the [**contributing** document](https://github.com/e107inc/e107/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/e107inc/e107/tree/master/e107_tests) to cover my changes.
- [x] All new and existing tests pass.