### PR TITLE
Fix #5025: Type error when sending a PM without the attachment field

### DIFF
--- a/e107_plugins/pm/pm.php
+++ b/e107_plugins/pm/pm.php
@@ -615,14 +615,18 @@
 
 				$maxsize = intval($this->pmPrefs['attach_size']) * 1024;
 
-				foreach(array_keys($_FILES['file_userfile']['size']) as $fid)
+				if(is_array($_FILES['file_userfile']))
 				{
-					if($maxsize > 0 && $_FILES['file_userfile']['size'][$fid] > $maxsize)
+					$file_userfile = $_FILES['file_userfile'];
+					foreach(array_keys($file_userfile['size']) as $fid)
 					{
-						$msg .= str_replace("{FILENAME}", $_FILES['file_userfile']['name'][$fid], LAN_PM_62) . "<br />";
-						$_FILES['file_userfile']['size'][$fid] = 0;
+						if($maxsize > 0 && $file_userfile['size'][$fid] > $maxsize)
+						{
+							$msg .= str_replace("{FILENAME}", $file_userfile['name'][$fid], LAN_PM_62) . "<br />";
+							$file_userfile['size'][$fid] = 0;
+						}
+						$totalsize += $file_userfile['size'][$fid];
 					}
-					$totalsize += $_FILES['file_userfile']['size'][$fid];
 				}
 
 				if(intval($this->pmPrefs['pm_limits']) > 0)


### PR DESCRIPTION
### Motivation and Context
There is a bug where the `pm` plugin would return fatally error in PHP 8.2 if the user doesn't have permission to add an attachment when sending a private message. This error is due to the fact that the code expects `$_FILES['file_userfile']` to be an array, but this array will not be present if the user doesn't have permission to add an attachment.

Fixes #5025

### Description
This change adds a check before trying to iterate through `$_FILES['file_userfile']`, ensuring that it is an array before processing the attachment. If this is not an array, then no actions will be taken on `$_FILES['file_userfile']`, which avoids the `TypeError`.

### How Has This Been Tested?
The fix was manually tested in a local development environment with PHP 8.2 by sending PMs with and without the attachment permission.

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code adheres to the e107 [code style standard](https://github.com/e107inc/e107/wiki/e107-Coding-Standard).
- [x] I have read the [**contributing** document](https://github.com/e107inc/e107/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/e107inc/e107/tree/master/e107_tests) to cover my changes.
- [x] All new and existing tests pass.