### PR TITLE
fix #5031 for false error when deleting plugin DB field 

### DIFF
--- a/e107_handlers/plugin_class.php
+++ b/e107_handlers/plugin_class.php
@@ -2214,7 +2214,7 @@ class e107plugin
 		{
 			//var_dump($field_attrib, $field_name, $type);
 			$status = $this->module['ue']->user_extended_remove($field_name, $field_name);
-			if($status && $type == EUF_DB_FIELD)
+			if($status && $type == EUF_DB_FIELD && strpos($field_name, 'plugin_') != 0) 
 			{
 				$status = $this->manage_extended_field_sql('remove', $field_attrib['name']);
 			}


### PR DESCRIPTION
### Motivation and Context
 Fixes https://github.com/e107inc/e107/issues/5031
 

### How Has This Been Tested?
with real example
```
		<field name="uid" type='EUF_DB_FIELD' text="UID" default='0' active="true" system="0" parms="plugin_efiction^,^^,^^,^0^,^^,^" 
			values="fanfiction_authors,uid,penname,penname" read="250" write="250" applicable="253" required="0" />
```

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code adheres to the e107 [code style standard](https://github.com/e107inc/e107/wiki/e107-Coding-Standard).
- [ ] I have read the [**contributing** document](https://github.com/e107inc/e107/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/e107inc/e107/tree/master/e107_tests) to cover my changes.
- [ ] All new and existing tests pass.