### PR TITLE
Fix #5000 user profile UEF change added to event

### DIFF
--- a/usersettings.php
+++ b/usersettings.php
@@ -766,6 +766,10 @@ class usersettings_front // Begin Usersettings rewrite.
 				if (!isset($triggerData['user_name'])) { $triggerData['user_name'] = $udata['user_name']; }
 			}
 
+			if(count($changedEUFData)) {
+				$triggerData['ue'] = $changedEUFData['data'];
+			}
+
 			// Now log changes if required
 			if (count($user_logging_opts))
 			{


### PR DESCRIPTION
### Motivation and Context
Fixes https://github.com/e107inc/e107/issues/5000

### Description
When you edited user profile, trigger _user_profile_edit_ wasn't used if you changed only UEF fields and no user fields

### How Has This Been Tested?
 - with blank plugin and debugging e_event addon 

### Types of Changes
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

 