### PR TITLE
`db_verify::getIndex()`: Support `index_col_name` optional parts

### DIFF
--- a/e107_handlers/db_verify_class.php
+++ b/e107_handlers/db_verify_class.php
@@ -1065,9 +1065,8 @@ class db_verify
 	 */
 	function getIndex($data, $print = false)
 	{
-		// $regex = "/(?:(PRIMARY|UNIQUE|FULLTEXT))?[\s]*?KEY (?: ?`?([\w]*)`?)[\s]* ?(?:\([\s]?`?([\w,]*[\s]?)`?\))?,?/i";
-		// $regex = "/(?:(PRIMARY|UNIQUE|FULLTEXT|FOREIGN))?[\s]*?KEY (?: ?`?([\w]*)`?)[\s]* ?(?:\([\s]?([\w\s,`]*[\s]?)`?\))?,?/i";
-		$regex = "/(?:(PRIMARY|UNIQUE|FULLTEXT|FOREIGN))?[\s]*?(INDEX|KEY) (?: ?`?([\w]*)`?)[\s]* ?(?:\([\s]?([\w\s,`]*[\s]?)`?\))?,?/i";
+		$regex = "/(PRIMARY|UNIQUE|FULLTEXT|FOREIGN)?[\s]*?(INDEX|KEY)[\s]*(?:`?([\w]*)`?)?[\s]*?\(`?([\w]+)`?(?:\s*\(\d+\))?(?:\s*(ASC|DESC))?\)[\s]*,?/i";
+
 		preg_match_all($regex,$data,$m);
 
 		if (count($m) > 0)

--- a/e107_tests/tests/unit/db_verifyTest.php
+++ b/e107_tests/tests/unit/db_verifyTest.php
@@ -264,6 +264,53 @@
 		}
 
 		/**
+		 * @see https://github.com/e107inc/e107/issues/5054
+		 */
+		public function testGetIndexOptionalLengthAndSortOrder()
+		{
+			$data = <<<EOF
+`field1` int(10) unsigned NOT NULL AUTO_INCREMENT,
+`field2` varchar(100) NOT NULL DEFAULT '',
+`field3` varchar(100) NOT NULL DEFAULT '',
+`field4` varchar(100) NOT NULL DEFAULT '',
+KEY (`field1`),
+INDEX `field2` (`field2` DESC),
+KEY `field3` (`field3` (100) ASC),
+INDEX `field4` (`field4` (100)),
+EOF;
+
+			$expected = array(
+				'field1' =>
+					array(
+						'type'    => '',
+						'keyname' => 'field1',
+						'field'   => 'field1',
+					),
+				'field2' =>
+					array(
+						'type'    => '',
+						'keyname' => 'field2',
+						'field'   => 'field2',
+					),
+				'field3' =>
+					array(
+						'type'    => '',
+						'keyname' => 'field3',
+						'field'   => 'field3',
+					),
+				'field4' =>
+					array(
+						'type'    => '',
+						'keyname' => 'field4',
+						'field'   => 'field4',
+					),
+			);
+
+			$result = $this->dbv->getIndex($data);
+			$this->assertEquals($expected,$result);
+		}
+
+		/**
 		 * FIXME: This test has no assertions!
 		 */
 		/*


### PR DESCRIPTION
### Motivation and Context
Fixes: https://github.com/e107inc/e107/issues/5054

### Description
Update the regex in `db_verify::getIndex()` to support the optional parts of `index_col_name`

### How Has This Been Tested?
Automated test method: `db_verifyTest::testGetIndexOptionalLengthAndSortOrder()`

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code adheres to the e107 [code style standard](https://github.com/e107inc/e107/wiki/e107-Coding-Standard).
- [x] I have read the [**contributing** document](https://github.com/e107inc/e107/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/e107inc/e107/tree/master/e107_tests) to cover my changes.
- [x] All new and existing tests pass.