### PR TITLE
[PHP 8.3] Fix `get_class()` deprecations

### DIFF
--- a/e107_tests/lib/preparers/E107Preparer.php
+++ b/e107_tests/lib/preparers/E107Preparer.php
@@ -24,14 +24,14 @@ class E107Preparer implements Preparer
 
 		if(is_dir($system))
 		{
-			throw new Exception(get_class() . " couldn't delete ".$system);
+			throw new Exception(__CLASS__ . " couldn't delete ".$system);
 		}
 
 	}
 
 	private function deleteDir($dirPath)
 	{
-		codecept_debug(get_class() . ' is deleting '.escapeshellarg($dirPath).'…');
+		codecept_debug(__CLASS__ . ' is deleting '.escapeshellarg($dirPath).'…');
 
 		if(!is_dir($dirPath))
 		{

--- a/e107_tests/lib/preparers/GitPreparer.php
+++ b/e107_tests/lib/preparers/GitPreparer.php
@@ -134,6 +134,6 @@ class GitPreparer implements Preparer
 
 	protected function debug($message)
 	{
-		codecept_debug(get_class() . ': ' . $message);
+		codecept_debug(__CLASS__ . ': ' . $message);
 	}
 }


### PR DESCRIPTION
### Motivation and Context
In PHP 8.3, [calling `get_class()` and `get_parent_class()` functions without arguments is deprecated](https://php.watch/versions/8.3/get_class-get_parent_class-parameterless-deprecated).

This fixes tests using `get_class()` pattern with identical alternatives that do not cause the deprecation notice.

References:
 - [PHP RFC: Deprecate functions with overloaded signatures](https://wiki.php.net/rfc/deprecate_functions_with_overloaded_signatures)
 - [PHP 8.3: get_class() and get_parent_class() function calls without arguments deprecated](https://php.watch/versions/8.3/get_class-get_parent_class-parameterless-deprecated)

### How Has This Been Tested?


### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code adheres to the e107 [code style standard](https://github.com/e107inc/e107/wiki/e107-Coding-Standard).
- [x] I have read the [**contributing** document](https://github.com/e107inc/e107/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/e107inc/e107/tree/master/e107_tests) to cover my changes.
- [ ] All new and existing tests pass.