### PR TITLE
Unify logic of `e_user_model::checkAdminPerms()` and `getperms()`

### DIFF
--- a/e107_tests/tests/unit/class2Test.php
+++ b/e107_tests/tests/unit/class2Test.php
@@ -52,7 +52,11 @@
 			$result = getperms('U1|U2', '0.');
 			$this->assertTrue($result);
 
+			$result = getperms('0', ' ');
+			$this->assertFalse($result);
 
+			$result = getperms(0, '0');
+			$this->assertTrue($result);
 
 			$pid = e107::getDb()->retrieve('plugin', 'plugin_id', "plugin_path = 'gallery'");
 


### PR DESCRIPTION
### Motivation and Context

I had [some concerns](https://github.com/e107inc/e107/issues/5064#issuecomment-1712450153) about https://github.com/e107inc/e107/commit/44526b435c85620d0fb4cff6858f3ef7fc615ca6 and https://github.com/e107inc/e107/commit/001799cb5f95b33d9c227acb41d5d657e21b7d88:

> The modified [method signature of `e_user_model::checkAdminPerms()`](https://github.com/e107inc/e107/commit/44526b435c85620d0fb4cff6858f3ef7fc615ca6#diff-5d42692f7ba27af5aacf29b292c11e2dc15a3ced9ba8d43ad049623644cd7388R654) defeats the [encapsulation](https://en.wikipedia.org/wiki/Encapsulation_(computer_programming)) offered by moving the global `getperms()` to `e_user_model::checkAdminPerms()` per user because `$ap` would override the object's internal state for the purposes of simulating permissions.
> 
> To remedy this, I suggest that we extract `getperms()` into a third **static** method that doesn't depend on state―perhaps called `e_userperms::checkAdminPerms()`―and have both `getperms()` and `e_user_model::checkAdminPerms()` call it to check the admin permissions.  This way, we can have both backwards compatibility and encapsulation for the two different styles we support.
> 
> ----
> 
> I have another concern, which is the extra logic for plugins.  I would move this into a new method called `e_user_model::checkPluginAdminPerms($plugin_name)` which then calls `e_user_model::checkAdminPerms()` once it has figured out the `$perm_str`.

### Description
Along with extensive documentation, `getperms()` is now deprecated and its replacements now have first-class support:
* `e_user_model::checkAdminPerms()` and `getperms()` both use `e_userperms::simulateHasAdminPerms()`.
* `e_user_model::checkPluginAdminPerms()` and `getperms('P', …, …)` both use `e_userperms::simulateHasPluginAdminPerms()`.

----

Partially reverts: https://github.com/e107inc/e107/commit/44526b43

Reverts: https://github.com/e107inc/e107/commit/001799cb

Fixes: https://github.com/e107inc/e107/issues/5064

### How Has This Been Tested?
As this is a refactoring only, all existing tests of `getperms()` pass.

I also added some tests for the misuse cases of whitespace in the second argument or an integer in the first argument of `getperms(0, ' ')`.

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code adheres to the e107 [code style standard](https://github.com/e107inc/e107/wiki/e107-Coding-Standard).
- [x] I have read the [**contributing** document](https://github.com/e107inc/e107/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/e107inc/e107/tree/master/e107_tests) to cover my changes.
- [x] All new and existing tests pass.