### PR TITLE
install.php: PHP 8.2 exception handler signature compatibility

### DIFF
--- a/install.php
+++ b/install.php
@@ -48,7 +48,11 @@ class installLog
 	const logFile = "e107Install.log";
 
 
-	static function exceptionHandler(Exception $exception)
+	/**
+	 * @param Throwable $exception
+	 * @return void
+	 */
+	static function exceptionHandler($exception)
 	{
 		$message = $exception->getMessage();
 		self::add($message, "error");


### PR DESCRIPTION
### Motivation and Context
Fixes: https://github.com/e107inc/e107/issues/5072

### Description
The exception handler parameter has to be of type `Throwable`, but we are remaining compatible with PHP 5.6, which didn't have `Throwable`, so let's fix this by moving the type to the phpDoc block.

### How Has This Been Tested?
Human static code analysis?

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code adheres to the e107 [code style standard](https://github.com/e107inc/e107/wiki/e107-Coding-Standard).
- [x] I have read the [**contributing** document](https://github.com/e107inc/e107/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/e107inc/e107/tree/master/e107_tests) to cover my changes.
- [x] All new and existing tests pass.