### PR TITLE
fix(#5131): Accurate resource open check when using log file handle

### DIFF
--- a/e107_handlers/mail.php
+++ b/e107_handlers/mail.php
@@ -130,14 +130,10 @@ if (!defined('e107_INIT')) { exit; }
 //define('MAIL_DEBUG',true);
 //define('LOG_CALLER', true);
 
-//require_once(e_HANDLER.'phpmailer/class.phpmailer.php');
-//require_once(e_HANDLER.'phpmailer/class.smtp.php');
-//require_once(e_HANDLER.'phpmailer/PHPMailerAutoload.php');
-
-use PHPMailer\PHPMailer\PHPMailer;
-// use PHPMailer\PHPMailer\SMTP;
-use PHPMailer\PHPMailer\POP3;
 use PHPMailer\PHPMailer\Exception;
+use PHPMailer\PHPMailer\PHPMailer;
+use PHPMailer\PHPMailer\POP3;
+
 require_once(e_HANDLER.'vendor/autoload.php');
 
 
@@ -438,7 +434,7 @@ class e107Email extends PHPMailer
 	 */
 	protected function openLog($logInfo = true)
 	{
-		if ($this->logEnable && ($this->logHandle === false))
+		if ($this->logEnable && !is_resource($this->logHandle))
 		{
 			$logFileName = MAIL_LOG_PATH.'mailoutlog.log';
 			$this->logHandle = fopen($logFileName, 'a');      // Always append to file
@@ -487,7 +483,7 @@ class e107Email extends PHPMailer
 	 */
 	protected function logLine($text)
 	{
-		if ($this->logEnable && ($this->logHandle > 0))
+		if ($this->logEnable && is_resource($this->logHandle))
 		{
 			fwrite($this->logHandle,date('H:i:s y.m.d').' - '.$text."\r\n");
 		}
@@ -496,11 +492,12 @@ class e107Email extends PHPMailer
 	}
 
 	/**
-	 *	Close log
+	 * Close log
+	 * @return void
 	 */
 	protected function closeLog()
 	{
-		if ($this->logEnable && ($this->logHandle > 0))
+		if ($this->logEnable && is_resource($this->logHandle))
 		{
 			fclose($this->logHandle);
 		}

--- a/e107_tests/tests/unit/e107EmailTest.php
+++ b/e107_tests/tests/unit/e107EmailTest.php
@@ -276,4 +276,50 @@ Admin<br />
 
 		}
 
+		/**
+		 * @see https://github.com/e107inc/e107/issues/5131
+		 * @throws Exception if the {@link e107Email} object cannot be created.
+		 */
+		function testLogFileHandle()
+		{
+			$logFilePath = e_ROOT . MAIL_LOG_PATH . 'mailoutlog.log';
+
+			$randomString1 = uniqid();
+			$randomString2 = uniqid();
+
+			$this->assertFalse($this->fileContainsString($logFilePath, $randomString1));
+			$this->assertFalse($this->fileContainsString($logFilePath, $randomString2));
+
+			$eml = $this->make('e107Email', ['send' => function() { return true; }]);
+			$eml->logEnable(2);
+			$eml->sendEmail(
+				'nobody@example.com',
+				"$randomString1 Example",
+				['body' => 'Message body'],
+			);
+			$this->assertTrue($this->fileContainsString($logFilePath, $randomString1));
+			$eml->sendEmail(
+				'nobody2@example.com',
+				"$randomString2 Example",
+				['body' => 'Message body'],
+			);
+			$this->assertTrue($this->fileContainsString($logFilePath, $randomString2));
+		}
+
+		/**
+		 * @param $filePath
+		 * @param $string
+		 * @return bool
+		 */
+		private function fileContainsString($filePath, $string)
+		{
+			if (!file_exists($filePath)) return false;
+			$handle = fopen($filePath, 'r');
+			while (($buffer = fgets($handle)) !== false) {
+				if (strpos($buffer, $string) !== false) {
+					return true;
+				}
+			}
+			return false;
+		}
 	}


### PR DESCRIPTION
### Motivation and Context
Fixes: https://github.com/e107inc/e107/issues/5131

### Description
Switch the logging file handle check to use `is_resource()` for correctly identifying whether the file handle is open.

### How Has This Been Tested?
New unit test: `e107EmailTest::testLogFileHandle()`

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist
- [x] My code adheres to the e107 [code style standard](https://github.com/e107inc/e107/wiki/e107-Coding-Standard).
- [x] I have read the [**contributing** document](https://github.com/e107inc/e107/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/e107inc/e107/tree/master/e107_tests) to cover my changes.
- [x] All new and existing tests pass.