### PR TITLE
Correct text for membersonly site and disabled login

### DIFF
--- a/e107_core/shortcodes/batch/membersonly_shortcodes.php
+++ b/e107_core/shortcodes/batch/membersonly_shortcodes.php
@@ -55,11 +55,26 @@ class membersonly_shortcodes extends e_shortcode
 	 */
 	function sc_membersonly_login()
 	{
-
-		$srch = array("[", "]");
-		$repl = array("<a class='alert-link' href='" . e_LOGIN . "'>", "</a>");
-
-		return str_replace($srch, $repl, LAN_MEMBERS_2);
+		$pref = e107::pref('core');
+		switch(intval($pref['user_reg'])) {
+			case 0:
+				$text = "";
+				break;
+			case 1:
+				$srch = array("[", "]");
+				$repl = array("<a class='alert-link' href='" . e_LOGIN . "'>", "</a>");
+				$text = str_replace($srch, $repl, LAN_MEMBERS_2);
+				break;
+			case 2:
+				$srch = array("[", "]");
+				$repl = array("<a class='alert-link' href='" . e_LOGIN . "'>", "</a>");
+				$text = str_replace($srch, $repl, LAN_MEMBERS_2) . ".";
+				break;
+			default:
+				$text = "";
+				break;
+		}
+		return $text; 
 	}
 
 }


### PR DESCRIPTION
### Motivation and Context
 https://github.com/e107inc/e107/issues/4349
 
### Description
This change respects selected user registration system and correct message for membersonly site.
- if login is disabled (0), there is no login link
_This is a restricted area._
- if only login is allowed, there is login link but with dot (finished sentence) -
 _This is a restricted area. For access please [log in]._
- if login and signup allowed, there is original solution  
_This is a restricted area. For access please [log in] or [register] as a member._
### How Has This Been Tested?
 

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

 