### PR TITLE
Proper generation of Gallery breadcrumb

### DIFF
--- a/e107_plugins/gallery/e_shortcode.php
+++ b/e107_plugins/gallery/e_shortcode.php
@@ -43,7 +43,7 @@ class gallery_shortcodes extends e_shortcode
 		$template = e107::getTemplate('gallery', 'gallery', 'cat');
 
 		$caption = isset($template['caption']) ? e107::getParser()->toText($template['caption']) : LAN_PLUGIN_GALLERY_TITLE;
-		if(!empty($var))
+		if(!empty($this->var))
 		{
 			$breadcrumb[] = array('text' => $caption, 'url' => e107::getUrl()->create('gallery', $this->var));
 		}


### PR DESCRIPTION
Fixing a mistyped condition, causing improper gallery plugin breadcrumb generation

