### PR TITLE
Add missing comma in 'admin_log' schema.

### DIFF
--- a/e107_core/sql/core_sql.php
+++ b/e107_core/sql/core_sql.php
@@ -39,7 +39,7 @@ CREATE TABLE admin_log (
   dblog_title varchar(255) NOT NULL default '',
   dblog_remarks text NOT NULL,
   PRIMARY KEY  (dblog_id),
-  KEY dblog_datestamp (dblog_datestamp)
+  KEY dblog_datestamp (dblog_datestamp),
   KEY dblog_eventcode (dblog_eventcode),
   KEY dblog_eventcode_title (dblog_eventcode,dblog_title),
   KEY dblog_user_id (dblog_user_id)


### PR DESCRIPTION
### Motivation and Context
Fixes the issue mention in:
https://github.com/e107inc/e107/issues/5495

### Description
Added missing comma in 'admin_log' table schema.

### How Has This Been Tested?
Installer no longer fails

### Types of Changes
- [ X] Bug fix (non-breaking change which fixes an issue)

### Checklist
- [X ] My code adheres to the e107 [code style standard](https://github.com/e107inc/e107/wiki/e107-Coding-Standard).
- [ X] I have read the [**contributing** document](https://github.com/e107inc/e107/blob/master/.github/CONTRIBUTING.md).
