### PR TITLE
Exclude current user from user options when sending PM

### DIFF
--- a/e107_handlers/form_handler.php
+++ b/e107_handlers/form_handler.php
@@ -1921,6 +1921,7 @@ class e_form
 			foreach($users as $u)
 			{
 				$id = $u['user_id'];
+				if(!empty($options['excludeSelf']) && ($id == USERID)){continue;}
 				$opt[$id] = $u['user_name'];
 			}
 


### PR DESCRIPTION
### Motivation and Context
The current code for the form userlist DON'T excludes current user even if the trigger `'excludeSelf'` is true.
Ie: this line `userlist('pm_to',null,array('excludeSelf'=>true, 'default'=>'blank', 'classes'=>varset($this->pmPrefs['send_to_class'], e_UC_MEMBER)))` would ALWAYS give the list INCLUNDING current user...
Issue is visible when trying to send a PM to another user

### Description
Added code line to exclude current user if trigger is set

### How Has This Been Tested?
Tested on latest e107 from github

### Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist
- [x] My code adheres to the e107 [code style standard](https://github.com/e107inc/e107/wiki/e107-Coding-Standard).
- [ x I have read the [**contributing** document](https://github.com/e107inc/e107/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/e107inc/e107/tree/master/e107_tests) to cover my changes.
- [ ] All new and existing tests pass.