### PR TITLE
Implicit FULLTEXT indexes from `e_search`

### DIFF
--- a/e107_handlers/e_search_fulltext_indexer_class.php
+++ b/e107_handlers/e_search_fulltext_indexer_class.php
@@ -1,0 +1,365 @@
+<?php
+/**
+ * e107 website system
+ *
+ * Copyright (C) 2008-2026 e107 Inc (e107.org)
+ * Released under the terms and conditions of the
+ * GNU General Public License (http://www.gnu.org/licenses/gpl.txt)
+ */
+
+if(!defined('e107_INIT'))
+{
+	exit;
+}
+
+
+/**
+ * Derives FULLTEXT index requirements from e_search addon configurations
+ * for use by db_verify to detect and fix missing FULLTEXT indexes.
+ */
+class e_search_fulltext_indexer
+{
+
+	/** @var array Cached search configs keyed by plugin */
+	private $searchConfigs = array();
+
+	/** @var array Derived indexes keyed by table name */
+	private $derivedIndexes = array();
+
+	/**
+	 * Load all e_search addon configurations
+	 *
+	 * This method loads e_search addons safely, handling cases where
+	 * language constants may not be loaded (e.g., in admin db_verify context).
+	 *
+	 * @return array
+	 */
+	public function loadSearchConfigs()
+	{
+		if(!empty($this->searchConfigs))
+		{
+			return $this->searchConfigs;
+		}
+
+		// Load search language file to ensure constants like LAN_SEARCH_* are available
+		// This is needed because e_search addons reference these constants in config()
+		$this->loadSearchLanguage();
+
+		// Load e_search addons safely with error handling for each addon
+		$this->searchConfigs = $this->loadAddonsWithErrorHandling();
+
+		return $this->searchConfigs;
+	}
+
+	/**
+	 * Load the search language file
+	 */
+	private function loadSearchLanguage()
+	{
+		// Try to load the main search language file
+		$langFile = e_LANGUAGEDIR . e_LANGUAGE . '/lan_search.php';
+		if(is_readable($langFile))
+		{
+			e107::includeLan($langFile);
+		}
+		else
+		{
+			// Fallback to English
+			$langFile = e_LANGUAGEDIR . 'English/lan_search.php';
+			if(is_readable($langFile))
+			{
+				e107::includeLan($langFile);
+			}
+		}
+	}
+
+	/**
+	 * Load a plugin's language file
+	 *
+	 * @param string $pluginName
+	 */
+	private function loadPluginLanguage($pluginName)
+	{
+		// Try to load the plugin's global language file
+		$langFile = e_PLUGIN . $pluginName . '/languages/' . e_LANGUAGE . '/' . e_LANGUAGE . '_global.php';
+		if(is_readable($langFile))
+		{
+			e107::includeLan($langFile);
+			return;
+		}
+
+		// Fallback to English
+		$langFile = e_PLUGIN . $pluginName . '/languages/English/English_global.php';
+		if(is_readable($langFile))
+		{
+			e107::includeLan($langFile);
+		}
+	}
+
+	/**
+	 * Load e_search addons with individual error handling
+	 *
+	 * This reimplements the core of e107::getAddonConfig('e_search') but with
+	 * try-catch around each addon to gracefully skip addons that fail to load.
+	 *
+	 * @return array
+	 */
+	private function loadAddonsWithErrorHandling()
+	{
+		$configs = array();
+		$elist = e107::getPref('e_search_list');
+
+		if(empty($elist))
+		{
+			return $configs;
+		}
+
+		foreach(array_keys($elist) as $pluginName)
+		{
+			$addonFile = e_PLUGIN . $pluginName . '/e_search.php';
+
+			if(!is_readable($addonFile))
+			{
+				continue;
+			}
+
+			try
+			{
+				// Load the plugin's language file before instantiating
+				// This ensures constants like LAN_PLUGIN_*_NAME are defined
+				$this->loadPluginLanguage($pluginName);
+
+				// Include the addon file
+				include_once($addonFile);
+
+				$className = $pluginName . '_search';
+
+				if(!class_exists($className))
+				{
+					continue;
+				}
+
+				$obj = new $className();
+
+				if(!method_exists($obj, 'config'))
+				{
+					continue;
+				}
+
+				$config = $obj->config();
+
+				if(!empty($config))
+				{
+					$configs[$pluginName] = $config;
+				}
+			}
+			catch(\Error $e)
+			{
+				// PHP 7+ Error (including undefined constants in PHP 8+)
+				// Log and skip this addon
+				e107::getLog()->add('SEARCH_FULLTEXT_INDEXER', 'Failed to load e_search addon: ' . $pluginName . ' - ' . $e->getMessage(), E_LOG_INFORMATIVE);
+			}
+			catch(\Exception $e)
+			{
+				// Legacy Exception handling
+				e107::getLog()->add('SEARCH_FULLTEXT_INDEXER', 'Failed to load e_search addon: ' . $pluginName . ' - ' . $e->getMessage(), E_LOG_INFORMATIVE);
+			}
+		}
+
+		return $configs;
+	}
+
+	/**
+	 * Parse table aliases from a FROM/JOIN clause
+	 *
+	 * @param string $tableClause e.g., 'news AS n LEFT JOIN #news_category AS c ON ...'
+	 * @return array ['alias' => 'table_name', ...]
+	 */
+	public function parseTableAliases($tableClause)
+	{
+		$aliases = array();
+
+		// Normalize whitespace (handle multi-line table definitions)
+		$tableClause = preg_replace('/\s+/', ' ', trim($tableClause));
+
+		// Match patterns like:
+		// - table_name AS alias
+		// - #table_name AS alias
+		// - table_name alias (without AS keyword)
+		// - table_name (no alias - use table as its own alias)
+		$pattern = '/(?:^|(?:LEFT|RIGHT|INNER|OUTER|CROSS)?\s*JOIN\s+)#?(\w+)(?:\s+(?:AS\s+)?(\w+))?/i';
+
+		preg_match_all($pattern, $tableClause, $matches, PREG_SET_ORDER);
+
+		foreach($matches as $match)
+		{
+			$table = $match[1];
+			$alias = isset($match[2]) && !empty($match[2]) ? $match[2] : $table;
+
+			// Skip if alias looks like a SQL keyword (ON, WHERE, etc.)
+			if(in_array(strtoupper($alias), array('ON', 'WHERE', 'AND', 'OR', 'LEFT', 'RIGHT', 'INNER', 'OUTER', 'JOIN')))
+			{
+				$alias = $table;
+			}
+
+			$aliases[$alias] = $table;
+		}
+
+		return $aliases;
+	}
+
+	/**
+	 * Map search fields to actual table.column pairs
+	 *
+	 * @param array $searchFields e.g., ['n.news_title' => '1.2', 'n.news_body' => '0.6']
+	 * @param array $tableAliases e.g., ['n' => 'news', 'c' => 'news_category']
+	 * @return array ['table_name' => ['column1', 'column2'], ...]
+	 */
+	public function mapSearchFields($searchFields, $tableAliases)
+	{
+		$mapped = array();
+
+		foreach(array_keys($searchFields) as $field)
+		{
+			// Split alias.column
+			if(strpos($field, '.') !== false)
+			{
+				list($alias, $column) = explode('.', $field, 2);
+
+				if(isset($tableAliases[$alias]))
+				{
+					$table = $tableAliases[$alias];
+					if(!isset($mapped[$table]))
+					{
+						$mapped[$table] = array();
+					}
+					if(!in_array($column, $mapped[$table]))
+					{
+						$mapped[$table][] = $column;
+					}
+				}
+			}
+			else
+			{
+				// No alias - assume first/primary table
+				$primaryTable = reset($tableAliases);
+				if($primaryTable)
+				{
+					if(!isset($mapped[$primaryTable]))
+					{
+						$mapped[$primaryTable] = array();
+					}
+					if(!in_array($field, $mapped[$primaryTable]))
+					{
+						$mapped[$primaryTable][] = $field;
+					}
+				}
+			}
+		}
+
+		return $mapped;
+	}
+
+	/**
+	 * Generate FULLTEXT index definition for a column
+	 *
+	 * The format matches db_verify::getIndex() output where:
+	 * - 'keyname' = column name(s) (content in parentheses)
+     * 
+	 * - 'field' = index name (used as array key and in backticks)
+	 *
+	 * toMysql() produces: FULLTEXT `field` (keyname)
+	 *
+	 * @param string $tableName
+	 * @param string $columnName
+	 * @return array Index definition compatible with db_verify::getIndex() output
+	 */
+	public function generateIndexDefinition($tableName, $columnName)
+	{
+		$indexName = 'ft_' . $tableName . '_' . $columnName;
+
+		return array(
+			'type'    => 'FULLTEXT',
+			'keyname' => $columnName,  // column name (goes in parentheses)
+			'field'   => $indexName,   // index name (goes in backticks, used as array key)
+		);
+	}
+
+	/**
+	 * Get all derived FULLTEXT indexes for a specific table
+	 *
+	 * @param string $tableName Table name without prefix
+	 * @return array Array of index definitions keyed by index name
+	 */
+	public function getIndexesForTable($tableName)
+	{
+		// Build indexes if not cached
+		if(empty($this->derivedIndexes))
+		{
+			$this->buildAllDerivedIndexes();
+		}
+
+		return isset($this->derivedIndexes[$tableName])
+			? $this->derivedIndexes[$tableName]
+			: array();
+	}
+
+	/**
+	 * Get all derived FULLTEXT indexes for all tables
+	 *
+	 * @return array Array keyed by table name, each containing index definitions
+	 */
+	public function getAllDerivedIndexes()
+	{
+		if(empty($this->derivedIndexes))
+		{
+			$this->buildAllDerivedIndexes();
+		}
+
+		return $this->derivedIndexes;
+	}
+
+	/**
+	 * Build all derived indexes from all e_search configs
+	 */
+	private function buildAllDerivedIndexes()
+	{
+		$this->derivedIndexes = array();
+		$configs = $this->loadSearchConfigs();
+
+		foreach($configs as $config)
+		{
+			if(empty($config['table']) || empty($config['search_fields']))
+			{
+				continue;
+			}
+
+			$tableAliases = $this->parseTableAliases($config['table']);
+			$fieldMapping = $this->mapSearchFields($config['search_fields'], $tableAliases);
+
+			foreach($fieldMapping as $table => $columns)
+			{
+				if(!isset($this->derivedIndexes[$table]))
+				{
+					$this->derivedIndexes[$table] = array();
+				}
+
+				foreach($columns as $column)
+				{
+					$indexDef = $this->generateIndexDefinition($table, $column);
+					$indexKey = $indexDef['field'];
+					$this->derivedIndexes[$table][$indexKey] = $indexDef;
+				}
+			}
+		}
+	}
+
+	/**
+	 * Clear cached data (useful for testing or after plugin changes)
+	 */
+	public function clearCache()
+	{
+		$this->searchConfigs = array();
+		$this->derivedIndexes = array();
+	}
+}

--- a/e107_tests/tests/unit/e_search_fulltext_indexerTest.php
+++ b/e107_tests/tests/unit/e_search_fulltext_indexerTest.php
@@ -1,0 +1,377 @@
+<?php
+/**
+ * e107 website system
+ *
+ * Copyright (C) 2008-2026 e107 Inc (e107.org)
+ * Released under the terms and conditions of the
+ * GNU General Public License (http://www.gnu.org/licenses/gpl.txt)
+ */
+
+
+class e_search_fulltext_indexerTest extends \Codeception\Test\Unit
+{
+
+	/** @var e_search_fulltext_indexer */
+	private $indexer;
+
+	protected function _before()
+	{
+
+		require_once(e_HANDLER . "e_search_fulltext_indexer_class.php");
+		try
+		{
+			$this->indexer = new e_search_fulltext_indexer();
+		}
+		catch(Exception $e)
+		{
+			self::fail("Couldn't load e_search_fulltext_indexer object");
+		}
+	}
+
+	/**
+	 * Test parsing a simple table name with no alias
+	 */
+	public function testParseTableAliasesSimpleTable()
+	{
+
+		$tableClause = 'user';
+		$expected = array('user' => 'user');
+
+		$actual = $this->indexer->parseTableAliases($tableClause);
+		self::assertEquals($expected, $actual);
+	}
+
+	/**
+	 * Test parsing a table with prefix marker
+	 */
+	public function testParseTableAliasesWithPrefix()
+	{
+
+		$tableClause = '#user';
+		$expected = array('user' => 'user');
+
+		$actual = $this->indexer->parseTableAliases($tableClause);
+		self::assertEquals($expected, $actual);
+	}
+
+	/**
+	 * Test parsing a table with AS alias
+	 */
+	public function testParseTableAliasesWithAsAlias()
+	{
+
+		$tableClause = 'news AS n';
+		$expected = array('n' => 'news');
+
+		$actual = $this->indexer->parseTableAliases($tableClause);
+		self::assertEquals($expected, $actual);
+	}
+
+	/**
+	 * Test parsing a table with implicit alias (no AS keyword)
+	 */
+	public function testParseTableAliasesWithImplicitAlias()
+	{
+
+		$tableClause = 'news n';
+		$expected = array('n' => 'news');
+
+		$actual = $this->indexer->parseTableAliases($tableClause);
+		self::assertEquals($expected, $actual);
+	}
+
+	/**
+	 * Test parsing complex JOIN clause
+	 */
+	public function testParseTableAliasesComplexJoin()
+	{
+
+		$tableClause = 'forum_thread AS t LEFT JOIN #user AS u ON t.thread_user = u.user_id';
+		$expected = array(
+			't' => 'forum_thread',
+			'u' => 'user',
+		);
+
+		$actual = $this->indexer->parseTableAliases($tableClause);
+		self::assertEquals($expected, $actual);
+	}
+
+	/**
+	 * Test parsing multiple JOINs
+	 */
+	public function testParseTableAliasesMultipleJoins()
+	{
+
+		$tableClause = 'news AS n LEFT JOIN #news_category AS c ON n.news_category = c.category_id LEFT JOIN #user AS u ON n.news_author = u.user_id';
+		$expected = array(
+			'n' => 'news',
+			'c' => 'news_category',
+			'u' => 'user',
+		);
+
+		$actual = $this->indexer->parseTableAliases($tableClause);
+		self::assertEquals($expected, $actual);
+	}
+
+	/**
+	 * Test parsing multi-line table definition
+	 */
+	public function testParseTableAliasesMultiLine()
+	{
+
+		$tableClause = "news AS n\n\t\tLEFT JOIN #news_category AS c ON n.news_category = c.category_id";
+		$expected = array(
+			'n' => 'news',
+			'c' => 'news_category',
+		);
+
+		$actual = $this->indexer->parseTableAliases($tableClause);
+		self::assertEquals($expected, $actual);
+	}
+
+	/**
+	 * Test mapping search fields with aliased columns
+	 */
+	public function testMapSearchFieldsWithAliases()
+	{
+
+		$searchFields = array(
+			'n.news_title' => '1.2',
+			'n.news_body'  => '0.6',
+		);
+		$tableAliases = array('n' => 'news');
+		$expected = array(
+			'news' => array('news_title', 'news_body'),
+		);
+
+		$actual = $this->indexer->mapSearchFields($searchFields, $tableAliases);
+		self::assertEquals($expected, $actual);
+	}
+
+	/**
+	 * Test mapping search fields to multiple tables
+	 */
+	public function testMapSearchFieldsMultipleTables()
+	{
+
+		$searchFields = array(
+			't.thread_name' => '1.0',
+			'p.post_entry'  => '0.8',
+		);
+		$tableAliases = array(
+			't' => 'forum_thread',
+			'p' => 'forum_post',
+		);
+		$expected = array(
+			'forum_thread' => array('thread_name'),
+			'forum_post'   => array('post_entry'),
+		);
+
+		$actual = $this->indexer->mapSearchFields($searchFields, $tableAliases);
+		self::assertEquals($expected, $actual);
+	}
+
+	/**
+	 * Test mapping search fields without alias (uses primary table)
+	 */
+	public function testMapSearchFieldsNoAlias()
+	{
+
+		$searchFields = array(
+			'page_title' => '1.0',
+			'page_text'  => '0.8',
+		);
+		$tableAliases = array('page' => 'page');
+		$expected = array(
+			'page' => array('page_title', 'page_text'),
+		);
+
+		$actual = $this->indexer->mapSearchFields($searchFields, $tableAliases);
+		self::assertEquals($expected, $actual);
+	}
+
+	/**
+	 * Test mapping search fields with unknown alias (should be skipped)
+	 */
+	public function testMapSearchFieldsUnknownAlias()
+	{
+
+		$searchFields = array(
+			'x.unknown_field' => '1.0',
+			'n.news_title'    => '1.0',
+		);
+		$tableAliases = array('n' => 'news');
+		$expected = array(
+			'news' => array('news_title'),
+		);
+
+		$actual = $this->indexer->mapSearchFields($searchFields, $tableAliases);
+		self::assertEquals($expected, $actual);
+	}
+
+	/**
+	 * Test that duplicate columns are not added
+	 */
+	public function testMapSearchFieldsNoDuplicates()
+	{
+
+		$searchFields = array(
+			'n.news_title'    => '1.0',
+			'n.news_title'    => '0.8', // Same field, different weight
+		);
+		$tableAliases = array('n' => 'news');
+
+		$actual = $this->indexer->mapSearchFields($searchFields, $tableAliases);
+		self::assertCount(1, $actual['news']);
+	}
+
+	/**
+	 * Test generating FULLTEXT index definition
+	 */
+	public function testGenerateIndexDefinition()
+	{
+
+		$tableName = 'news';
+		$columnName = 'news_title';
+
+		$expected = array(
+			'type'    => 'FULLTEXT',
+			'keyname' => 'news_title',          // column name (goes in parentheses)
+			'field'   => 'ft_news_news_title',  // index name (goes in backticks)
+		);
+
+		$actual = $this->indexer->generateIndexDefinition($tableName, $columnName);
+		self::assertEquals($expected, $actual);
+	}
+
+	/**
+	 * Test that index naming follows convention
+	 */
+	public function testGenerateIndexDefinitionNamingConvention()
+	{
+
+		$actual = $this->indexer->generateIndexDefinition('forum_post', 'post_entry');
+
+		// Index name should follow ft_{table}_{column} convention
+		self::assertEquals('ft_forum_post_post_entry', $actual['field']);
+		self::assertEquals('FULLTEXT', $actual['type']);
+		self::assertEquals('post_entry', $actual['keyname']);
+	}
+
+	/**
+	 * Test clearing cache
+	 */
+	public function testClearCache()
+	{
+
+		// Access private properties via reflection to verify cache clearing
+		$reflection = new ReflectionClass($this->indexer);
+
+		$searchConfigsProp = $reflection->getProperty('searchConfigs');
+		$searchConfigsProp->setAccessible(true);
+		$searchConfigsProp->setValue($this->indexer, array('test' => 'data'));
+
+		$derivedIndexesProp = $reflection->getProperty('derivedIndexes');
+		$derivedIndexesProp->setAccessible(true);
+		$derivedIndexesProp->setValue($this->indexer, array('test' => 'indexes'));
+
+		// Clear cache
+		$this->indexer->clearCache();
+
+		// Verify cleared
+		self::assertEmpty($searchConfigsProp->getValue($this->indexer));
+		self::assertEmpty($derivedIndexesProp->getValue($this->indexer));
+	}
+
+	/**
+	 * Test getIndexesForTable returns empty array for unknown table
+	 */
+	public function testGetIndexesForTableUnknownTable()
+	{
+
+		// Use reflection to set empty derived indexes
+		$reflection = new ReflectionClass($this->indexer);
+		$derivedIndexesProp = $reflection->getProperty('derivedIndexes');
+		$derivedIndexesProp->setAccessible(true);
+		$derivedIndexesProp->setValue($this->indexer, array('news' => array('test' => 'index')));
+
+		$actual = $this->indexer->getIndexesForTable('nonexistent_table');
+		self::assertEquals(array(), $actual);
+	}
+
+	/**
+	 * Test parsing various JOIN types
+	 */
+	public function testParseTableAliasesVariousJoinTypes()
+	{
+
+		// LEFT JOIN
+		$tableClause = 'news n LEFT JOIN user u ON n.author = u.user_id';
+		$actual = $this->indexer->parseTableAliases($tableClause);
+		self::assertArrayHasKey('n', $actual);
+		self::assertArrayHasKey('u', $actual);
+
+		// INNER JOIN
+		$tableClause = 'news n INNER JOIN user u ON n.author = u.user_id';
+		$actual = $this->indexer->parseTableAliases($tableClause);
+		self::assertArrayHasKey('n', $actual);
+		self::assertArrayHasKey('u', $actual);
+
+		// RIGHT JOIN
+		$tableClause = 'news n RIGHT JOIN user u ON n.author = u.user_id';
+		$actual = $this->indexer->parseTableAliases($tableClause);
+		self::assertArrayHasKey('n', $actual);
+		self::assertArrayHasKey('u', $actual);
+	}
+
+	/**
+	 * Test that SQL keywords are not mistaken for aliases
+	 */
+	public function testParseTableAliasesSqlKeywordsNotTreatedAsAliases()
+	{
+
+		// This clause has 'ON' after the table name - should not be treated as alias
+		$tableClause = 'news ON';
+		$actual = $this->indexer->parseTableAliases($tableClause);
+
+		// 'ON' should not be an alias - the table should use itself as alias
+		self::assertEquals(array('news' => 'news'), $actual);
+	}
+
+	/**
+	 * Integration test: Full workflow from table clause to index definitions
+	 */
+	public function testFullWorkflow()
+	{
+
+		$tableClause = 'news AS n LEFT JOIN #user AS u ON n.news_author = u.user_id';
+		$searchFields = array(
+			'n.news_title'   => '1.2',
+			'n.news_body'    => '0.6',
+			'n.news_summary' => '0.8',
+		);
+
+		// Step 1: Parse table aliases
+		$tableAliases = $this->indexer->parseTableAliases($tableClause);
+		self::assertEquals('news', $tableAliases['n']);
+		self::assertEquals('user', $tableAliases['u']);
+
+		// Step 2: Map search fields
+		$fieldMapping = $this->indexer->mapSearchFields($searchFields, $tableAliases);
+		self::assertArrayHasKey('news', $fieldMapping);
+		self::assertCount(3, $fieldMapping['news']);
+		self::assertContains('news_title', $fieldMapping['news']);
+		self::assertContains('news_body', $fieldMapping['news']);
+		self::assertContains('news_summary', $fieldMapping['news']);
+
+		// Step 3: Generate index definitions
+		foreach($fieldMapping['news'] as $column)
+		{
+			$indexDef = $this->indexer->generateIndexDefinition('news', $column);
+			self::assertEquals('FULLTEXT', $indexDef['type']);
+			self::assertStringStartsWith('ft_news_', $indexDef['field']);
+			self::assertEquals($column, $indexDef['keyname']);
+		}
+	}
+
+}


### PR DESCRIPTION
### Motivation and Context

After the migration from MyISAM to InnoDB (#4501), the search functionality broke with the error:
```
Can't find FULLTEXT index matching the column list
```

This is because InnoDB requires explicit FULLTEXT indexes while MyISAM supported FULLTEXT search implicitly. Users reported that searching for content in news, downloads, forums, and other areas returned no results (#5209).

The workaround was to manually run `ALTER TABLE ... ADD FULLTEXT` for each search field, but this is error-prone and requires database expertise.

Fixes: #5209

### Description

This PR introduces automatic detection and creation of FULLTEXT indexes based on the `search_fields` configuration in `e_search` addons.

**New Components:**
- `e_search_fulltext_indexer_class.php`: Parses `e_search` addon configs to derive required FULLTEXT indexes. Handles complex table aliases and JOIN clauses to map search fields to their actual tables.

**Changes to Existing Components:**

- **`db_verify_class.php`**:
  - Integrates the FULLTEXT indexer into the comparison flow
  - `init(true)` now clears all dependent caches (MySQL table list, core preferences, and db_verify's own cache) for programmatic use
  - Missing FULLTEXT indexes are detected and can be fixed via the existing db_verify repair mechanism

- **`plugin_class.php`**:
  - New `createSearchIndexes()` method called during plugin installation
  - Automatically creates FULLTEXT indexes for plugins with e_search addons immediately after table creation

- **`install.php`**:
  - Creates FULLTEXT indexes for core e_search addons during fresh installation

**How It Works:**

1. When db_verify compares tables, it calls `getSearchFieldIndexes()`
2. The indexer loads all e_search addon configs via `getAddonConfig()`
3. For each config, it parses the `table` clause to extract table/alias mappings (handling JOINs like `news AS n LEFT JOIN #user AS u ON...`)
4. It maps `search_fields` (e.g., `n.news_title`) to actual table.column
5. Generates FULLTEXT index definitions with naming convention `ft_{table}_{column}`
6. These derived indexes are merged with file-defined indexes for comparison

**For Existing Sites:**
Users can go to Admin → Database → Verify SQL, select the affected plugins, and click "Fix Selected Items" to create the missing FULLTEXT indexes.

### How Has This Been Tested?

- **Unit tests**: 19 tests for the FULLTEXT indexer covering:
  - Table alias parsing (simple tables, AS aliases, implicit aliases, complex JOINs)
  - Search field mapping to table.column pairs
  - Index definition generation
  - Full workflow integration

- **Integration test**: Verifies that installing the forum plugin (which has e_search) automatically creates FULLTEXT indexes with no pending migrations afterward

- **Manual testing**:
  - Fresh installation creates FULLTEXT indexes for core search
  - Plugin installation via web interface creates indexes
  - db_verify correctly detects and repairs missing indexes
  - Search functionality works after index creation

### Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist
- [x] My code adheres to the e107 [code style standard](https://github.com/e107inc/e107/wiki/e107-Coding-Standard).
- [x] I have read the [**contributing** document](https://github.com/e107inc/e107/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/e107inc/e107/tree/master/e107_tests) to cover my changes.
- [x] All new and existing tests pass.