### PR TITLE
Prepare for PHP 8.5 and PHP 9.0: NullToStrictStringFuncCallArgRector

### DIFF
--- a/class2.php
+++ b/class2.php
@@ -135,7 +135,7 @@ if(isset($retrieve_prefs) && is_array($retrieve_prefs))
 {
 	foreach ($retrieve_prefs as $key => $pref_name)
 	{
-		 $retrieve_prefs[$key] = preg_replace("/\W/", '', $pref_name);
+		 $retrieve_prefs[$key] = preg_replace("/\W/", '', (string) $pref_name);
 	}
 }
 else
@@ -647,7 +647,7 @@ if(!isset($_E107['no_event']))
 
 if(!defined('SITENAME')) // Allow override by English_custom.php or English_global.php plugin files.
 {
-	define('SITENAME', trim($tp->toHTML($pref['sitename'], '', 'USER_TITLE,er_on,defs')));
+	define('SITENAME', trim((string) $tp->toHTML($pref['sitename'], '', 'USER_TITLE,er_on,defs')));
 }
 
 //
@@ -1195,7 +1195,7 @@ function check_email($email)
 		return false;
 	}
 
-	if(is_numeric(substr($email,-1))) // fix for eCaptcha accidently typed on wrong line.
+	if(is_numeric(substr((string) $email,-1))) // fix for eCaptcha accidently typed on wrong line.
 	{
 		return false;
 	}
@@ -1204,9 +1204,9 @@ function check_email($email)
 	{
 		return $email;	
 	}
-	
+
 	return false; 
-	
+
 	// return preg_match("/^([_a-zA-Z0-9-+]+)(\.[_a-zA-Z0-9-]+)*@([a-zA-Z0-9-]+)(\.[a-zA-Z0-9-]+)*(\.[a-zA-Z]{2,6})$/" , $email) ? $email : false;
 }
 
@@ -1250,14 +1250,14 @@ function check_class($var, $userclass = null, $uid = 0)
 		return false;
 	}
 
-	$class_array = !is_array($userclass) ? explode(',', $userclass) : $userclass;
+	$class_array = !is_array($userclass) ? explode(',', (string) $userclass) : $userclass;
 
 	$varList = !is_array($var) ? explode(',', (string) $var) : $var;
 	$latchedAccess = false;
 
 	foreach ($varList as $v)
 	{
-		$v = trim($v);
+		$v = trim((string) $v);
 		$invert = false;
 		//value to test is a userclass name (or garbage, of course), go get the id
 		if (!is_numeric($v))
@@ -1358,7 +1358,7 @@ function getperms($arg, $ap = null, $path = null)
 		return true;
 	}
 
-	if ($arg === 'P' && preg_match('#(.*?)/' .e107::getFolder('plugins'). '(.*?)/(.*?)#', $path, $matches))
+	if ($arg === 'P' && preg_match('#(.*?)/' .e107::getFolder('plugins'). '(.*?)/(.*?)#', (string) $path, $matches))
 	{
 		$sql = e107::getDb('psql');
 
@@ -1876,7 +1876,7 @@ function session_set($name, $value, $expire='', $path = e_HTTP, $domain = '', $s
 			$path = '/';
 		}
 		
-		setcookie($name, $value, $expire, $path, $domain, $secure, true);
+		setcookie($name, (string) $value, $expire, $path, $domain, $secure, true);
 		$_COOKIE[$name] = $value;
 	}
 }
@@ -1994,7 +1994,7 @@ function force_userupdate($currentUser)
 		}
     }
 
-	if (!e107::getPref('disable_emailcheck',true) && !trim($currentUser['user_email'])) return true;
+	if (!e107::getPref('disable_emailcheck',true) && !trim((string) $currentUser['user_email'])) return true;
 
 	if(e107::getDb()->select('user_extended_struct', 'user_extended_struct_applicable, user_extended_struct_write, user_extended_struct_name, user_extended_struct_type', 'user_extended_struct_required = 1 AND user_extended_struct_applicable != '.e_UC_NOBODY))
 	{
@@ -2068,7 +2068,7 @@ class error_handler
 			return;
 		}
 
-		if ((isset($_SERVER['QUERY_STRING']) && (strpos($_SERVER['QUERY_STRING'], 'debug=') !== false)) || isset($_COOKIE['e107_debug_level']) && ((strpos($_SERVER['QUERY_STRING'], 'debug=-')) === false) )
+		if ((isset($_SERVER['QUERY_STRING']) && (strpos((string) $_SERVER['QUERY_STRING'], 'debug=') !== false)) || isset($_COOKIE['e107_debug_level']) && ((strpos((string) $_SERVER['QUERY_STRING'], 'debug=-')) === false) )
 		{
 		   	$this->debug = true;
 		  	error_reporting(E_ALL);
@@ -2192,7 +2192,7 @@ class error_handler
 				<td>";
 			$text .= !empty($val['class']) ? $val['class']."->" : '';
 			$text .= !empty($val['include_filename']) ? "include: ". str_replace($this->docroot,'', $val['include_filename']) : '';
-			$text .= !empty($val['function']) ? htmlentities($val['function'])."(" : "";
+			$text .= !empty($val['function']) ? htmlentities((string) $val['function'])."(" : "";
 			$text .= !empty($val['params']) ? print_r($val['params'],true) : '';
 			$text .= !empty($val['function']) ? ")" : "";
 			$text .="</td>
@@ -2276,7 +2276,7 @@ class e_http_header
 	
 	function __construct()
 	{
-		if (strpos(varset($_SERVER['HTTP_ACCEPT_ENCODING']), 'gzip') !== false)
+		if (strpos((string) varset($_SERVER['HTTP_ACCEPT_ENCODING']), 'gzip') !== false)
 		{
 			$this->compression_browser_support = true;
 		}
@@ -2313,10 +2313,10 @@ class e_http_header
 		else
 		{
 			$this->content = $content;
-			$this->length = strlen($content);
+			$this->length = strlen((string) $content);
 		}
 
-		$this->etag = md5($this->content);
+		$this->etag = md5((string) $this->content);
 
 	//print_a($this->length);
 
@@ -2341,7 +2341,7 @@ class e_http_header
 			return null;
 		}
 
-		list($key,$val) = explode(':',$header,2);
+		list($key,$val) = explode(':',(string) $header,2);
 		$this->headers[$key] = $val;
 		header($header, $force, $response_code);
 	}
@@ -2367,7 +2367,7 @@ class e_http_header
 		$server = array();
 		foreach($_SERVER as $k=>$v)
 		{
-			if(strncmp($k, 'HTTP', 4) === 0)
+			if(strncmp((string) $k, 'HTTP', 4) === 0)
 			{
 				$server[$k] = $v;	
 			}	
@@ -2423,7 +2423,7 @@ class e_http_header
 		if($this->compress_output !== false)
 		{
 			$this->setHeader('ETag: "'.$this->etag.'-gzip"', true);
-			$this->content = gzencode($this->content, $this->compression_level);
+			$this->content = gzencode((string) $this->content, $this->compression_level);
 			$this->length = strlen($this->content);
 			$this->setHeader('Content-Encoding: gzip', true);
 			$this->setHeader("Content-Length: ".$this->length, true);

--- a/comment.php
+++ b/comment.php
@@ -43,7 +43,7 @@ if(e_AJAX_REQUEST) // TODO improve security
 	// Comment Pagination 
 	if(varset($_GET['mode']) == 'list' && vartrue($_GET['id']) && vartrue($_GET['type']))
 	{
-		$clean_type = preg_replace("/[^\w\d]/","",$_GET['type']);
+		$clean_type = preg_replace("/[^\w\d]/","",(string) $_GET['type']);
 		
 		$tmp = e107::getComment()->getComments($clean_type,intval($_GET['id']),intval($_GET['from']));
 		echo $tmp['comments'];
@@ -303,13 +303,13 @@ if ($redirectFlag)
 		$plugin_redir = TRUE;
 		$reply_location = str_replace('{NID}', $redirectFlag, $e_comment[$table]['reply_location']);
 	}
-	
+
 	if ($plugin_redir)
 	{
 		echo "<script>document.location.href='{$reply_location}'</script>\n";
 		exit;
 	}
-	
+
 	// No redirect found if we get here.
 }
 

--- a/contact.php
+++ b/contact.php
@@ -40,7 +40,7 @@ class contact_front
 		$pref = e107::pref();
 
 		$active = varset($pref['contact_visibility'], e_UC_PUBLIC);
-		$contactInfo = trim(SITECONTACTINFO);
+		$contactInfo = trim((string) SITECONTACTINFO);
 		$pref = e107::getPref();
 
 		if(!check_class($active) && empty($contactInfo) && empty($pref['contact_info']))
@@ -106,13 +106,13 @@ class contact_front
 
 		if(!empty($contact_filter))
 		{
-			$tmp = explode("\n", $contact_filter);
+			$tmp = explode("\n", (string) $contact_filter);
 
 			if(!empty($tmp))
 			{
 				foreach($tmp as $filterItem)
 				{
-					if(strpos($_POST['body'], $filterItem) !== false)
+					if(strpos((string) $_POST['body'], $filterItem) !== false)
 					{
 						$ignore = true;
 						break;
@@ -127,7 +127,7 @@ class contact_front
 		$sender_name = $tp->toEmail($_POST['author_name'], true, 'RAWTEXT');
 		$sender = check_email($_POST['email_send']);
 		$subject = $tp->toEmail($_POST['subject'], true, 'RAWTEXT');
-		$body = nl2br($tp->toEmail(strip_tags($_POST['body']), true, 'RAWTEXT'));
+		$body = nl2br((string) $tp->toEmail(strip_tags((string) $_POST['body']), true, 'RAWTEXT'));
 
 		$email_copy = !empty($_POST['email_copy']) ? 1 : 0;
 
@@ -144,12 +144,12 @@ class contact_front
 		}
 
 		// Check subject line.
-		if(isset($_POST['subject']) && strlen(trim($subject)) < 2)
+		if(isset($_POST['subject']) && strlen(trim((string) $subject)) < 2)
 		{
 			$error .= LAN_CONTACT_13 . "\n";
 		}
 
-		if(!strpos(trim($sender), "@"))
+		if(!strpos(trim((string) $sender), "@"))
 		{
 			$error .= LAN_CONTACT_11 . "\n";
 		}
@@ -231,7 +231,7 @@ class contact_front
 				{
 					foreach($_POST as $k => $v)
 					{
-						$scKey = strtoupper($k);
+						$scKey = strtoupper((string) $k);
 						$vars[$scKey] = $tp->toEmail($v, true, 'RAWTEXT');
 					}
 				}

--- a/e107_admin/admin_log.php
+++ b/e107_admin/admin_log.php
@@ -63,7 +63,7 @@ function loadEventTypes($table)
 			continue; 
 		}
 		$id = $val['dblog_eventcode'];
-		$def = strpos($val['dblog_title'], "LAN") !== false ? $id : $val['dblog_title'];
+		$def = strpos((string) $val['dblog_title'], "LAN") !== false ? $id : $val['dblog_title'];
 		$eventTypes[$id] = str_replace(': [x]', '', deftrue($val['dblog_title'],$def));
 	}
 
@@ -336,7 +336,7 @@ class admin_log_ui extends e_admin_ui
 			$action = '';
 
 		//	print_a($_POST);
-			
+
 			if(!empty($_POST['deleteoldadmin']) && isset($_POST['rolllog_clearadmin']))
 			{
 				$back_count = intval($_POST['rolllog_clearadmin']);
@@ -371,8 +371,8 @@ class admin_log_ui extends e_admin_ui
 			*/
 
 			$old_date = strtotime($back_count.' days ago');
-			
-			
+
+
 			// Actually delete back events - admin or user audit log
 			if(($action == "backdel") && isset($_POST['backdeltype']))
 			{
@@ -418,7 +418,7 @@ class admin_log_ui extends e_admin_ui
 				}
 
 			}
-			
+
 			// Prompt to delete back events
 			/*
 			if(($action == "confdel") || ($action == "auditdel"))
@@ -442,12 +442,12 @@ class admin_log_ui extends e_admin_ui
 							</div>
 						</fieldset>
 					</form>
-			
+
 				";
-			
+
 				$ns->tablerender(LAN_CONFDELETE, $text);
 			}	
-			
+
 			*/
 			
 		}
@@ -615,16 +615,16 @@ class admin_log_form_ui extends e_admin_form_ui
 
 
 
-				$val = trim($curVal);
+				$val = trim((string) $curVal);
 				if(defined($val))
 				{
 					$val = constant($val);
 				}
 
-				if(strpos($val,'[x]') !== false)
+				if(strpos((string) $val,'[x]') !== false)
 				{
 					$remark = $this->getController()->getListModel()->get('dblog_remarks');
-					preg_match("/\[table\]\s=&gt;\s([\w]*)/i",$remark, $match);
+					preg_match("/\[table\]\s=&gt;\s([\w]*)/i",(string) $remark, $match);
 
 					if(!empty($match[1]))
 					{
@@ -632,7 +632,7 @@ class admin_log_form_ui extends e_admin_form_ui
 					}
 					else
 					{
-						preg_match("/\[!br!\]TABLE: ([\w]*)/i", $remark, $m);
+						preg_match("/\[!br!\]TABLE: ([\w]*)/i", (string) $remark, $m);
 						if(!empty($m[1]))
 						{
 							$val = $tp->lanVars($val, '<b>'.$m[1].'</b>');
@@ -681,7 +681,7 @@ class admin_log_form_ui extends e_admin_form_ui
 		{
 			case 'read': // List Page
 			
-				$text = preg_replace_callback("#\[!(\w+?)(=.+?)?!]#", 'log_process', $curVal);
+				$text = preg_replace_callback("#\[!(\w+?)(=.+?)?!]#", 'log_process', (string) $curVal);
 				$text = $tp->toHTML($text,false,'E_BODY');
 				
 				if(strpos($text,'Array')!==false || strlen($text)>300)
@@ -727,9 +727,9 @@ class admin_log_form_ui extends e_admin_form_ui
 		{
 			case 'read': // List Page
 				$val =$curVal;
-				if((strpos($val, '|') !== FALSE) && (strpos($val, '@') !== FALSE))
+				if((strpos((string) $val, '|') !== FALSE) && (strpos((string) $val, '@') !== FALSE))
 				{
-					list($file, $rest) = explode('|', $val);
+					list($file, $rest) = explode('|', (string) $val);
 					list($routine, $rest) = explode('@', $rest);
 					$val = $file.'<br />Function: '.$routine.'<br />Line: '.$rest;
 				}
@@ -750,7 +750,7 @@ class admin_log_form_ui extends e_admin_form_ui
 				
 class audit_log_ui extends e_admin_ui
 {
-			
+
 		protected $pluginTitle		=  ADLAN_155;
 		protected $pluginName		= 'core';
 		protected $table			= 'audit_log';
@@ -758,7 +758,7 @@ class audit_log_ui extends e_admin_ui
 		protected $perPage 			= 10;
 		protected $listOrder        = 'dblog_id DESC';
 		protected $batchDelete		= true;
-			
+
 		protected $fields 		= array (  
 		'checkboxes' =>   array ( 'title' => '', 'type' => null, 'data' => null, 'width' => '5%', 'thclass' => 'center', 'forced' => '1', 'class' => 'center', 'toggle' => 'e-multiselect',  ),
 		  'dblog_id' 			=>   array ( 'title' => LAN_ID, 'data' => 'int', 'width' => '5%', 'help' => '', 'readParms' => '', 'writeParms' => '', 'class' => 'left', 'thclass' => 'left',  ),
@@ -772,9 +772,9 @@ class audit_log_ui extends e_admin_ui
 		  'dblog_remarks' 		=>   array ( 'title' => 'Remarks', 'type' => 'method', 'data' => 'str', 'width' => '30%', 'help' => '', 'readParms' => '', 'writeParms' => '', 'class' => 'left', 'thclass' => 'left',  ),
 		  'options' 			=>   array ( 'title' => LAN_OPTIONS, 'type' => null,  'nolist'=>true, 'data' => null, 'width' => '10%', 'thclass' => 'center last', 'class' => 'center last', 'forced' => '1',  ),
 		);		
-		
+
 		protected $fieldpref = array('dblog_id', 'dblog_datestamp', 'dblog_microtime', 'dblog_eventcode', 'dblog_user_id', 'dblog_user_name', 'dblog_ip', 'dblog_title','dblog_remarks');
-		
+
 		public $eventTypes = array();
 
 		// optional
@@ -791,7 +791,7 @@ class audit_log_ui extends e_admin_ui
 			$ns = e107::getRender();
 			$text = 'Hello World!';
 			$ns->tablerender('Hello',$text);	
-			
+
 		}
 	*/
 			
@@ -855,7 +855,7 @@ class dblog_ui extends e_admin_ui
 				case 'br':
 					return '<br />';
 				case 'link':
-					$temp = substr($matches[2], 1);
+					$temp = substr((string) $matches[2], 1);
 					return "<a href='{$temp}'>{$temp}</a>";
 				case 'test':
 					return '----TEST----';

--- a/e107_admin/auth.php
+++ b/e107_admin/auth.php
@@ -37,7 +37,7 @@ if($adminTheme !== 'bootstrap3' /*&& $adminTheme !== 'bootstrap5'*/)
 	e107::getRedirect()->redirect(e_SELF);		
 }
 
-$admincss = trim($core->get('admincss'));
+$admincss = trim((string) $core->get('admincss'));
 if(empty($admincss) || $admincss === 'style.css'|| $admincss === 'admin_dark.css' || $admincss === 'admin_light.css')
 {
 	$core->update('admincss','css/modern-light.css');
@@ -50,7 +50,7 @@ if(USER && !getperms('0') && vartrue($pref['multilanguage']) && !getperms(e_LANG
 {
 	$lng = e107::getLanguage();
 
-	$tmp = explode(".",ADMINPERMS);
+	$tmp = explode(".",(string) ADMINPERMS);
 
 	foreach($tmp as $ln)
 	{
@@ -86,10 +86,10 @@ if (ADMIN)
 		if(e107::getUser()->getSessionDataAs())
 		{  
 			$asuser = e107::getSystemUser(e107::getUser()->getSessionDataAs(), false);
-			
+
 			$lanVars = array ('x' => ($asuser->getId() ? $asuser->getName().' ('.$asuser->getValue('email').')' : 'unknown')) ;
 			e107::getMessage()->addInfo(e107::getParser()->lanVars(ADLAN_164, $lanVars).' <a href="'.e_ADMIN_ABS.'users.php?mode=main&amp;action=logoutas">['.LAN_LOGOUT.']</a>');
-			
+
 		}
 		// NEW, legacy 3rd party code fix, header called inside the footer o.O
 		if(deftrue('e_ADMIN_UI'))

--- a/e107_admin/banlist.php
+++ b/e107_admin/banlist.php
@@ -594,7 +594,7 @@ class banlist_ui extends e_admin_ui
 				$mes->addSuccess(str_replace('[y]', $result, BANLAN_48));
 			}
 
-			list($ban_access_guest, $ban_access_member) = explode(',', varset($pref['ban_max_online_access'], '100,200'));
+			list($ban_access_guest, $ban_access_member) = explode(',', (string) varset($pref['ban_max_online_access'], '100,200'));
 			$ban_access_member = max($ban_access_guest, $ban_access_member);
 
 
@@ -720,7 +720,7 @@ class banlist_form_ui extends e_admin_form_ui
 
 		if(!empty($curVal))
 		{
-			$tmp = explode(":",$curVal);
+			$tmp = explode(":",(string) $curVal);
 
 			if(count($tmp) === 8)
 			{

--- a/e107_admin/banlist_export.php
+++ b/e107_admin/banlist_export.php
@@ -56,7 +56,7 @@ if (!empty($_POST['ban_types']))
 	$spacer = '';
 	foreach($_POST['ban_types'] as $b)
 	{
-		$b = trim($b);
+		$b = trim((string) $b);
 		if (is_numeric($b) && in_array($b, $validBanTypes))
 		{
 			$type_list .= $spacer.($b);
@@ -124,7 +124,7 @@ function do_export($filename, $type_list='',$format_array=array(), $sep = ',', $
 
 		//Secure https check
 		if (isset($_SERVER['HTTP_USER_AGENT']) && $_SERVER['HTTP_USER_AGENT']=='contype') header('Pragma: public');
-		if (isset($_SERVER['HTTP_USER_AGENT']) && strpos($_SERVER['HTTP_USER_AGENT'],'MSIE'))
+		if (isset($_SERVER['HTTP_USER_AGENT']) && strpos((string) $_SERVER['HTTP_USER_AGENT'],'MSIE'))
 			header('Content-Type: application/force-download');
 		else
 			header('Content-Type: application/octet-stream');

--- a/e107_admin/boot.php
+++ b/e107_admin/boot.php
@@ -213,7 +213,7 @@ e107::coreLan('footer', true);
 	if(strpos(e_REQUEST_URI,$plugDir) !== false && !deftrue('e_ADMIN_UI') && !empty($_plugins) && !empty($_globalLans) && is_array($_plugins) && (count($_plugins) > 0))
 	{
 		$_plugins = array_keys($_plugins);
-		
+
 		foreach ($_plugins as $_p) 
 		{
 			if(defset('e_CURRENT_PLUGIN') != $_p)
@@ -225,7 +225,7 @@ e107::coreLan('footer', true);
 			{
 				continue;
 			}
-			
+
 			e107::getDebug()->logTime('[boot.php: Loading LANS for '.$_p.']');
 			e107::loadLanFiles($_p, 'admin');
 		}

--- a/e107_admin/cpage.php
+++ b/e107_admin/cpage.php
@@ -181,11 +181,11 @@ class page_chapters_ui extends e_admin_ui
 		protected $listOrder		= 'Sort,chapter_order ';
 	//	protected $listOrder 	= ' COALESCE(NULLIF(chapter_parent,0), chapter_id), chapter_parent > 0, chapter_order '; //FIXME works with parent/child but doesn't respect parent order.
 		protected $url         	= array('route'=>'page/chapter/index', 'vars' => array('id' => 'chapter_id', 'name' => 'chapter_sef'), 'name' => 'chapter_name', 'description' => ''); // 'link' only needed if profile not provided. 
-	
+
 		protected $sortField	= 'chapter_order';
 		protected $sortParent   = 'chapter_parent';
 	//	protected $orderStep 	= 10;
-		
+
 		protected $fields = array(
 			'checkboxes'				=> array('title'=> '',						'type' => null, 			'width' =>'5%', 'forced'=> TRUE, 'thclass'=>'center', 'class'=>'center'),
 			'chapter_id'				=> array('title'=> 'LAN_ID',					'type' => 'number',			'width' =>'5%', 'forced'=> TRUE, 'readonly'=>TRUE),
@@ -207,13 +207,13 @@ class page_chapters_ui extends e_admin_ui
 			'chapter_image' 	        => array('title'=> 'LAN_IMAGE',			    'type' => 'image', 			'data' => 'str',		'width' => '100px',	'thclass' => 'center', 'class'=>'center',  'readParms'=>'thumb=140&thumb_urlraw=0&thumb_aw=140', 'writeParms'=>'', 'readonly'=>FALSE,	'batch' => FALSE, 'filter'=>FALSE),
 
 			'options' 					=> array('title'=> 'LAN_OPTIONS',				'type' => 'method',			'width' => '10%', 'forced'=>TRUE, 'thclass' => 'center last', 'class' => 'left', 'readParms'=>'sort=1')
-		
+
 		);
 
 		protected $fieldpref = array('checkboxes', 'chapter_icon', 'chapter_id', 'chapter_page_count','chapter_name', 'chapter_description','chapter_template', 'chapter_visibility', 'chapter_order', 'options');
 
 		protected $books = array();
-	
+
 		function init()
 		{
 			$this->addTitle(CUSLAN_63);
@@ -234,33 +234,33 @@ class page_chapters_ui extends e_admin_ui
 			$sql = e107::getDb();
 			$sql->gen("SELECT chapter_id,chapter_name FROM #page_chapters WHERE chapter_parent =0");
 			$this->books[0] = CUSLAN_5;
-			
+
 			while($row = $sql->fetch())
 			{
 				$bk = $row['chapter_id'];
 				$this->books[$bk] = $row['chapter_name'];
 			}
-			
+
 			asort($this->books);
-			
+
 			$this->fields['chapter_parent']['writeParms'] = $this->books;	
-			
-			
+
+
 			$tmp = e107::getLayouts('', 'chapter', 'front', '', true, false);
 			$tmpl = array();
 			foreach($tmp as $key=>$val)
 			{
-				if(substr($key,0,3) != 'nav')
+				if(substr((string) $key,0,3) != 'nav')
 				{
 					$tmpl[$key] = $val;	
 				}	
 			}
-			
+
 			$this->fields['chapter_template']['writeParms'] = $tmpl; // e107::getLayouts('', 'chapter', 'front', '', true, false); // e107::getLayouts('', 'page', 'books', 'front', true, false); 
-			
+
 		}
-		
-		
+
+
 		public function beforeCreate($new_data, $old_data)
 		{
 			if(empty($new_data['chapter_sef']))
@@ -271,9 +271,9 @@ class page_chapters_ui extends e_admin_ui
 			{
 				$new_data['chapter_sef'] = eHelper::secureSef($new_data['chapter_sef']);
 			}
-			
+
 			$sef = e107::getParser()->toDB($new_data['chapter_sef']);
-			
+
 			if(e107::getDb()->count('page_chapters', '(*)', "chapter_sef='{$sef}'"))
 			{
 				e107::getMessage()->addError(CUSLAN_57);
@@ -281,11 +281,11 @@ class page_chapters_ui extends e_admin_ui
 			}
 
 			$new_data = e107::getCustomFields()->processConfigPost('chapter_fields', $new_data);
-			
+
 			return $new_data;	
 		}
-		
-		
+
+
 		public function beforeUpdate($new_data, $old_data, $id)
 		{	
 			// return $this->beforeCreate($new_data);
@@ -815,7 +815,7 @@ class page_admin_ui extends e_admin_ui
 			$tmpl = array();
 			foreach($tmp as $key=>$val)
 			{
-				if(substr($key,0,3) != 'nav')
+				if(substr((string) $key,0,3) != 'nav')
 				{
 					$tmpl[$key] = $val;	
 				}	
@@ -1084,7 +1084,7 @@ class page_admin_ui extends e_admin_ui
 
 			$new_data = e107::getCustomFields()->processDataPost('page_fields',$new_data);
 
-			$new_data['menu_name'] = preg_replace('/[^\w\-*]/','-',$new_data['menu_name']);
+			$new_data['menu_name'] = preg_replace('/[^\w\-*]/','-',(string) $new_data['menu_name']);
 
 			if(empty($new_data['page_sef']))
 			{

--- a/e107_admin/cron.php
+++ b/e107_admin/cron.php
@@ -192,7 +192,7 @@ class cron_admin_ui extends e_admin_ui
 	
 			if(!vartrue($_GET['action']) || $_GET['action'] == 'refresh')
 			{
-				
+
 				$this->cronImport($cronDefaults);	// import Core Crons (if missing)
 				$this->cronImport(e107::getAddonConfig('e_cron'));	// Import plugin Crons
 				$this->cronImportLegacy(); // Import Legacy Cron Tab Settings	
@@ -438,7 +438,7 @@ class cron_admin_ui extends e_admin_ui
 			}
 
 			
-			list($class_name, $method_name) = explode("::", $class_func);
+			list($class_name, $method_name) = explode("::", (string) $class_func);
 			$mes = e107::getMessage();
 			$taskName = $class_name;
 			
@@ -535,7 +535,7 @@ class cron_admin_form_ui extends e_admin_form_ui
 		if($mode == 'read')
 		{
 			$sep = array();
-			list($min, $hour, $day, $month, $weekday) = explode(" ", $curVal);
+			list($min, $hour, $day, $month, $weekday) = explode(" ", (string) $curVal);
 			$text = (isset($this->min_options[$min])) ? $this->min_options[$min] : LAN_CRON_50 ." ". $min;	// Minute(s)
 			$text .= "<br />";
 			$text .= (isset($this->hour_options[$hour])) ? $this->hour_options[$hour] : LAN_CRON_51 ." ". $hour;	// Hour(s)		
@@ -599,7 +599,7 @@ class cron_admin_form_ui extends e_admin_form_ui
 		{
 			$func = $this->getController()->getFieldVar('cron_function');
 		//
-			if(substr($func,0,7) === '_system')
+			if(substr((string) $func,0,7) === '_system')
 			{
 				$att['readParms'] = array('disabled'=>'disabled');
 			}
@@ -618,7 +618,7 @@ class cron_admin_form_ui extends e_admin_form_ui
 	function editTab($curVal)
 	{
 		$sep = array();
-		list($sep['minute'], $sep['hour'], $sep['day'], $sep['month'], $sep['weekday']) = explode(" ", $curVal);
+		list($sep['minute'], $sep['hour'], $sep['day'], $sep['month'], $sep['weekday']) = explode(" ", (string) $curVal);
 
 		foreach ($sep as $key => $value)
 		{

--- a/e107_admin/db.php
+++ b/e107_admin/db.php
@@ -35,12 +35,12 @@ $mes = e107::getMessage();
 
 if(isset($_GET['mode']))
 {
-    $_GET['mode'] = preg_replace('/[^\w\-]/', '', $_GET['mode']);
+    $_GET['mode'] = preg_replace('/[^\w\-]/', '', (string) $_GET['mode']);
 }
 
 if(isset($_GET['type']))
 {
-    $_GET['type'] = preg_replace('/[^\w\-]/', '', $_GET['type']);
+    $_GET['type'] = preg_replace('/[^\w\-]/', '', (string) $_GET['type']);
 }
 
 /*
@@ -479,24 +479,24 @@ class system_tools
 	{	
 		$sql 		= e107::getDb('new');
 		$mes 		= e107::getMessage();
-		
+
 		$user 		= $_POST['name'];
 		$pass 		= $_POST['password'];
 		$server 	= e107::getMySQLConfig('server'); // $_POST['server'];
 		$database 	= $_POST['db'];
 		$prefix		= $_POST['prefix'];
-			
+
 		if($connect = $sql->connect($server,$user, $pass, true))
 		{
 			$mes->addSuccess(DBLAN_74);
-			
+
 			if(vartrue($_POST['createdb']))
 			{
-			
+
 				if($sql->gen("CREATE DATABASE ".$database." CHARACTER SET `utf8mb4`"))
 				{
 					$mes->addSuccess(DBLAN_75);
-					
+
 				//	$sql->gen("CREATE USER ".$user."@'".$server."' IDENTIFIED BY '".$pass."';");
 					$sql->gen("GRANT ALL ON `".$database."`.* TO ".$user."@'".$server."';");
 					$sql->gen("FLUSH PRIVILEGES;");		
@@ -507,32 +507,32 @@ class system_tools
 					return;
 				}
 			}
-			
+
 			if(!$sql->database($database))
 			{
 				$mes->addError(DBLAN_76);
 			}
-					
+
 			$mes->addSuccess(DBLAN_76);
-					
+
 			if($this->multiSiteCreateTables($sql, $prefix))
 			{
 				$coreConfig = e_CORE. "xml/default_install.xml";		
 				$ret = e107::getXml()->e107Import($coreConfig, 'add', true, false, $sql); // Add core pref values
 				$mes->addInfo(print_a($ret,true));
 			}	
-				
+
 		}
 		else
 		{
 			$mes->addSuccess(DBLAN_74);
 		}
-		
+
 		if($error = $sql->getLastErrorText())
 		{
 			$mes->addError($error);
 		}
-			
+
 		//	print_a($_POST);
 
 		
@@ -555,7 +555,7 @@ class system_tools
 			$mes->addError(DBLAN_77);
 		}
 
-		preg_match_all("/create(.*?)(?:myisam|innodb);/si", $sql_data, $result );
+		preg_match_all("/create(.*?)(?:myisam|innodb);/si", (string) $sql_data, $result );
 
 
 		$sql->gen('SET NAMES `utf8mb4`');
@@ -954,12 +954,12 @@ class system_tools
 
 	function getQueries($query)
 	{
-		
+
 		$mes = e107::getMessage();
 		$sql = e107::getDb('utf8-convert');
 
 		$qry = [];
-		
+
 		if($sql->gen($query))
 		{
 			while ($row = $sql->fetch('num'))
@@ -973,8 +973,8 @@ class system_tools
 		}
 
 		return $qry;
-		
-		
+
+
 		/*
 		if(!$result = mysql_query($query))
 		{
@@ -1415,13 +1415,13 @@ class system_tools
 
 	private function getPrefConfig($type)
 	{
-		if(strpos($type,'plugin_') === 0)
+		if(strpos((string) $type,'plugin_') === 0)
 		{
-			$config = e107::getPlugConfig(substr($type,7));
+			$config = e107::getPlugConfig(substr((string) $type,7));
 		}
-		elseif(strpos($type,'theme_') === 0)
+		elseif(strpos((string) $type,'theme_') === 0)
 		{
-			$config = e107::getThemeConfig(substr($type,6));
+			$config = e107::getThemeConfig(substr((string) $type,6));
 		}
 		else
 		{
@@ -1514,7 +1514,7 @@ class system_tools
 			}
 			else
 			{
-				$ptext = htmlspecialchars($val, ENT_QUOTES, 'utf-8');
+				$ptext = htmlspecialchars((string) $val, ENT_QUOTES, 'utf-8');
 			}
 
 			$ptext = $tp->textclean($ptext, 80);
@@ -1577,7 +1577,7 @@ class system_tools
 		{
 			foreach($fList as $file)
 			{
-				$scList[] = strtoupper(substr($file['fname'], 0, -4));
+				$scList[] = strtoupper(substr((string) $file['fname'], 0, -4));
 			}
 			$scList = implode(',', $scList);
 		}
@@ -1590,7 +1590,7 @@ class system_tools
 		{
 			foreach($fList as $file)
 			{
-				$scList[] = substr($file['fname'], 0, -4);
+				$scList[] = substr((string) $file['fname'], 0, -4);
 			}
 			$scList = implode(',', $scList);
 		}
@@ -1815,7 +1815,7 @@ function exportXmlFile($prefs,$tables=array(),$plugPrefs=array(), $themePrefs=ar
 		{
 			foreach($xml->fileConvertLog as $oldfile)
 			{
-				$file = basename($oldfile);
+				$file = basename((string) $oldfile);
 				$newfile = $desinationFolder.$file;
 				if($oldfile == $newfile || (copy($oldfile,$newfile)))
 				{

--- a/e107_admin/docs.php
+++ b/e107_admin/docs.php
@@ -120,7 +120,7 @@ class docs_ui extends e_admin_ui
 			}
 
 			$tmp = preg_replace('/Q\>(.*?)A>/si', "###QSTART###<div class='qitem'>" . $iconQ . "\\1</div>###QEND###", $tmp);
-			$tmp = preg_replace('/###QEND###(.*?)###QSTART###/si', "<div class='aitem'>" . $iconA . "\\1</div>", $tmp);
+			$tmp = preg_replace('/###QEND###(.*?)###QSTART###/si', "<div class='aitem'>" . $iconA . "\\1</div>", (string) $tmp);
 			$tmp = str_replace(array('###QSTART###', '###QEND###'), array('', "<div class='aitem'>" . $iconA), $tmp) . "</div>";
 
 			$id = 'doc-' . $key;

--- a/e107_admin/emoticon.php
+++ b/e107_admin/emoticon.php
@@ -62,28 +62,28 @@ $filtered = e107::getParser()->filter($_POST);
 // Check for pack-related buttons pressed
 foreach ($filtered as $key => $value)
 {
-	if (strpos($key, "subPack_") !== false)
+	if (strpos((string) $key, "subPack_") !== false)
 	{
 		$subpack = str_replace("subPack_", "", $key);
 		$emote->emoteConf($subpack);
 		break;
 	}
 
-	if (strpos($key, "XMLPack_") !== false)
+	if (strpos((string) $key, "XMLPack_") !== false)
 	{
 		$subpack = str_replace("XMLPack_", "", $key);
 		$emote->emoteXML($subpack);
 		break;
 	}
 
-	if (strpos($key, "defPack_") !== false)
+	if (strpos((string) $key, "defPack_") !== false)
 	{
 		e107::getConfig()->set('emotepack', str_replace("defPack_", "", $key))->save(true, true, true);
 		e107::getLog()->add('EMOTE_01', $pref['emotepack'], E_LOG_INFORMATIVE, '');
 		break;
 	}
 
-	if (strpos($key, "scanPack_") !== false)
+	if (strpos((string) $key, "scanPack_") !== false)
 	{
 		$one_pack = str_replace("scanPack_", "", $key);
 		break;
@@ -204,9 +204,9 @@ class emotec
 
 			foreach ($emoteArray as $emote)
 			{
-				if (strpos($emote['fname'], ".pak") !== false
-					|| strpos($emote['fname'], ".xml") !== false
-					|| strpos($emote['fname'], "phpBB") !== false)
+				if (strpos((string) $emote['fname'], ".pak") !== false
+					|| strpos((string) $emote['fname'], ".xml") !== false
+					|| strpos((string) $emote['fname'], "phpBB") !== false)
 				{
 					$can_scan = true;        // Allow re-scan of config files
 				}
@@ -377,7 +377,7 @@ class emotec
 			$evalue = str_replace(".", "!", $emote);
 			if ($strip_xtn)
 			{
-				$ename = substr($emote, 0, strrpos($emote, '.'));
+				$ename = substr((string) $emote, 0, strrpos((string) $emote, '.'));
 			}
 			$f_string .= "<emoticon file=\"{$ename}\">\n";
 			foreach (explode(' ', $tp->toForm($emotecode[$evalue])) as $v)
@@ -455,13 +455,13 @@ class emotec
 		{
 			while ($row = $sql->fetch())
 			{
-				$pack_local[substr($row['e107_name'], 6)] = true;
+				$pack_local[substr((string) $row['e107_name'], 6)] = true;
 			}
 		}
 
 		foreach ($this->packArray as $value)
 		{
-			if (strpos($value, ' ') !== false)
+			if (strpos((string) $value, ' ') !== false)
 			{    // Highlight any directory names containing spaces - not allowed
 				$msg = "
 					<strong>" . EMOLAN_17 . "</strong> " . EMOLAN_18 . ":
@@ -488,15 +488,15 @@ class emotec
 				$confFile = '';
 				foreach ($fileArray as $k => $file)
 				{
-					if (strpos($file['fname'], ".xml") !== false)
+					if (strpos((string) $file['fname'], ".xml") !== false)
 					{
 						$confFile = array('file' => $file['fname'], 'type' => "xml");
 					}
-					elseif (strpos($file['fname'], ".pak") !== false)
+					elseif (strpos((string) $file['fname'], ".pak") !== false)
 					{
 						$confFile = array('file' => $file['fname'], 'type' => "pak");
 					}
-					elseif (strpos($file['fname'], ".php") !== false)
+					elseif (strpos((string) $file['fname'], ".php") !== false)
 					{
 						$confFile = array('file' => $file['fname'], 'type' => "php");
 					}
@@ -606,7 +606,7 @@ class emotec
 							{ // Check that the file exists
 								if (strpos($e_file, ".") === false)
 								{  // File extension not specified - accept any file extension for match
-									if (strpos($emote['fname'], $e_file . ".") === 0)
+									if (strpos((string) $emote['fname'], $e_file . ".") === 0)
 									{
 										$file = str_replace(".", "!", $emote['fname']);
 										break;

--- a/e107_admin/eurl.php
+++ b/e107_admin/eurl.php
@@ -76,7 +76,7 @@ class eurl_admin_ui extends e_admin_controller_ui
 			{
 				$cfg = e107::getConfig();
 
-				list($plug,$key) = explode("|", $_POST['pk']);
+				list($plug,$key) = explode("|", (string) $_POST['pk']);
 
 				if(is_string($cfg->get('e_url_alias')))
 				{
@@ -125,7 +125,7 @@ class eurl_admin_ui extends e_admin_controller_ui
 		if(isset($_POST['rebuild']) && is_array($_POST['rebuild']))
 		{
 			$table = key($_POST['rebuild']);
-			list($primary, $input, $output) = explode("::",$_POST['rebuild'][$table]);
+			list($primary, $input, $output) = explode("::",(string) $_POST['rebuild'][$table]);
 			$this->rebuild($table, $primary, $input, $output);	
 		}
 
@@ -169,7 +169,7 @@ class eurl_admin_ui extends e_admin_controller_ui
 		foreach($data as $row)
 		{
 			$sef = eHelper::title2sef($row[$input]);
-			
+
 			if($sql->update($table, $output ." = '".$sef."' WHERE ".$primary. " = ".intval($row[$primary]). " LIMIT 1")!==false)
 			{
 				$success++;
@@ -178,7 +178,7 @@ class eurl_admin_ui extends e_admin_controller_ui
 			{
 				$failed++;
 			}
-			
+
 			// echo $row[$input]." => ".$output ." = '".$sef."'  WHERE ".$primary. " = ".intval($row[$primary]). " LIMIT 1 <br />";
 
 		}
@@ -314,7 +314,7 @@ class eurl_admin_ui extends e_admin_controller_ui
 				//	$sefurl         = (!empty($alias)) ? str_replace('{alias}', $alias, $v['sef']) : $v['sef'];
 					$pid            = $plug."|".$k;
 
-					$v['regex'] =   preg_replace("/^\^/",$home,$v['regex']);
+					$v['regex'] =   preg_replace("/^\^/",$home,(string) $v['regex']);
 					$aliasForm      = $frm->renderInline('e_url_alias['.$plug.']['.$k.']', $pid, 'e_url_alias['.$plug.']['.$k.']', $alias, $alias,'text',null,array('title'=>LAN_EDIT." (Language-specific)", 'url'=>e_REQUEST_SELF));
 					$aliasRender    = str_replace('{alias}', $aliasForm, $v['regex']);
 
@@ -408,7 +408,7 @@ class eurl_admin_ui extends e_admin_controller_ui
 				foreach ($als as $module => $alias) 
 				{
 					$alias = trim($alias);
-					$module = trim($module);
+					$module = trim((string) $module);
 					if($module !== $alias) 
 					{
 						$cindex = array_search($module, $locations);
@@ -486,7 +486,7 @@ class eurl_admin_ui extends e_admin_controller_ui
 			$config = is_array($_POST['eurl_config']) ? e107::getParser()->post_toForm($_POST['eurl_config']) : '';
 			$modules = eRouter::adminReadModules();
 			$locations = eRouter::adminBuildLocations($modules);
-			
+
 			$aliases = eRouter::adminSyncAliases(e107::getPref('url_aliases'), $config);
 
 			if(!empty($_POST['eurl_profile']))
@@ -517,7 +517,7 @@ class eurl_admin_ui extends e_admin_controller_ui
 
 		//	var_dump($_POST['eurl_config']);
 
-				
+
 			eRouter::clearCache();
 			e107::getCache()->clearAll('content'); // clear content - it may be using old url scheme.
 
@@ -869,7 +869,7 @@ class eurl_admin_form_ui extends e_admin_form_ui
 				}
 				    
 
-				$label = vartrue($section['label'], $index == 0 ? LAN_EURL_DEFAULT : eHelper::labelize(ltrim(strstr($location, '/'), '/')));
+				$label = vartrue($section['label'], $index == 0 ? LAN_EURL_DEFAULT : eHelper::labelize(ltrim(strstr((string) $location, '/'), '/')));
 			//	$cssClass = $checked ? 'e-showme' : 'e-hideme';
 				$cssClass = 'e-hideme'; // always hidden for now, some interface changes could come after pre-alpha
 
@@ -1027,7 +1027,7 @@ class eurl_admin_form_ui extends e_admin_form_ui
 		{
 			$cfg = $obj->config->config();
 			if(isset($cfg['config']['noSingleEntry']) && $cfg['config']['noSingleEntry']) continue;
-			
+
 			if($module == 'index')
 			{
 				$text .= "
@@ -1063,7 +1063,7 @@ class eurl_admin_form_ui extends e_admin_form_ui
 			$url = e107::getUrl()->create($module, '', array('full' => 1, 'encode' => 0));
 			$defVal = isset($currentAliases[$lan]) && in_array($module, $currentAliases[$lan]) ? array_search($module, $currentAliases[$lan]) : $module; 
 			$section = vartrue($admin['labels'], array());
-			
+
 			$text .= "
 				<tr>
 					<td>
@@ -1074,9 +1074,9 @@ class eurl_admin_form_ui extends e_admin_form_ui
 					</td>
 					<td>
 			";
-			
 
-			
+
+
 			// default language
 			$text .= "<table class='table table-striped table-bordered' style='margin-bottom:0'>
 <colgroup>
@@ -1152,7 +1152,7 @@ class eurl_admin_form_ui extends e_admin_form_ui
 				</td></tr>";
 
 
-			
+
 			/*$text .= "
 					</td>
 					<td>

--- a/e107_admin/fileinspector.php
+++ b/e107_admin/fileinspector.php
@@ -51,7 +51,7 @@ $css .= ".d { margin: 2px 0px 1px 8px; cursor: default; white-space: nowrap }
     .e { width: 9px; height: 9px }
     i.fa-folder-open-o, i.fa-times-circle-o { cursor:pointer }
     span.tree-node { cursor: pointer } 
-    
+
 ";
 
 e107::css('inline', $css);
@@ -376,9 +376,9 @@ class file_inspector {
 
 		$this->root_dir = $e107 -> file_path;
 
-		if(substr($this->root_dir, -1) == '/')
+		if(substr((string) $this->root_dir, -1) == '/')
 		{
-			$this->root_dir = substr($this->root_dir, 0, -1);
+			$this->root_dir = substr((string) $this->root_dir, 0, -1);
 		}
 
 		if(isset($_POST['core']) && $_POST['core'] == 'integrity_fail_only')
@@ -388,7 +388,7 @@ class file_inspector {
 
 		if(MAGIC_QUOTES_GPC && vartrue($_POST['regex']))
 		{
-			$_POST['regex'] = stripslashes($_POST['regex']);
+			$_POST['regex'] = stripslashes((string) $_POST['regex']);
 		}
 
 		if(!empty($_POST['regex']))
@@ -541,7 +541,7 @@ class file_inspector {
 			".FC_LAN_18.":
 			</td>
 			<td colspan='2' style='width: 65%'>
-			#<input class='tbox' type='text' name='regex' size='40' value='".htmlentities($_POST['regex'], ENT_QUOTES)."' />#<input class='tbox' type='text' name='mod' size='5' value='".$_POST['mod']."' />
+			#<input class='tbox' type='text' name='regex' size='40' value='".htmlentities((string) $_POST['regex'], ENT_QUOTES)."' />#<input class='tbox' type='text' name='mod' size='5' value='".$_POST['mod']."' />
 			</td>
 			</tr>";
 
@@ -618,7 +618,7 @@ class file_inspector {
             if ($file->isDir()) continue;
 
             $absolutePath = $file->getRealPath();
-            $relativePath = preg_replace("/^" . preg_quote($absoluteBase . "/", "/") . "/", "", $absolutePath);
+            $relativePath = preg_replace("/^" . preg_quote($absoluteBase . "/", "/") . "/", "", (string) $absolutePath);
 
             if (empty($relativePath) || $relativePath == $absolutePath) continue;
 
@@ -695,7 +695,7 @@ class file_inspector {
 
         if($fileName === 'error_log')
         {
-            $hash = md5($relativePath);
+            $hash = md5((string) $relativePath);
             e107::getSession()->set('fileinspector_error_log_'. $hash, $relativePath);
 
 
@@ -983,7 +983,7 @@ class file_inspector {
 		if($this->opt('type') == 'tree')
 		{
 			$text .= "<tr><th class='text-left f' >".FR_LAN_3."</th>
-			<th class='s text-right' style='padding-right: 4px' onclick=\"sh('f_".dechex(crc32($this->root_dir))."')\">
+			<th class='s text-right' style='padding-right: 4px' onclick=\"sh('f_".dechex(crc32((string) $this->root_dir))."')\">
 			<b class='caret'></b></th></tr>";
 		}
 		else
@@ -1080,7 +1080,7 @@ class file_inspector {
                 list($icon, $title) = $this->getGlyphForValidationCode($validation);
                 $text .= '<tr><td class="text-left f" title="'.$title.'">';
                 $text .= "$icon ";
-                $text .= htmlspecialchars($relativePath);
+                $text .= htmlspecialchars((string) $relativePath);
                 $text .= '</td><td class="s">';
                 $text .= isset($this->fileSizes[$relativePath]) ? $this->parsesize($this->fileSizes[$relativePath]) : '';
                 $oldVersion = $this->getOldVersionOfPath($relativePath, $validation);
@@ -1300,7 +1300,7 @@ i.fa-folder-open-o, i.fa-times-circle-o { cursor:pointer }
 
     private static function exitOnEvilScanId($scanId)
     {
-        if (!preg_match('/^[0-9A-F]+$/i', $scanId)) exit(1);
+        if (!preg_match('/^[0-9A-F]+$/i', (string) $scanId)) exit(1);
     }
 
     private static function pruneOldProgressFiles()

--- a/e107_admin/footer.php
+++ b/e107_admin/footer.php
@@ -91,7 +91,7 @@ if (varset($e107_popup) != 1)
 			}
 		}
 	}
-	
+
 	//
 	// B.2 Send footer template, stop timing, send simple page stats
 	//
@@ -101,7 +101,7 @@ if (varset($e107_popup) != 1)
 		$ADMIN_FOOTER = e107::getCoreTemplate('admin', 'footer', false);
 		e107::renderLayout($ADMIN_FOOTER, ['sc'=>'admin']);
 	}
-	
+
 	$eTimingStop = microtime();
 	global $eTimingStart;
 	$clockTime = e107::getSingleton('e107_traffic')->TimeDelta($eTimingStart, $eTimingStop);
@@ -112,7 +112,7 @@ if (varset($e107_popup) != 1)
 	$dbPercent = number_format($dbPercent); // DB as percent of clock
 	$memuse = eHelper::getMemoryUsage(); // Memory at end, in B/KB/MB/GB ;)
 	$rinfo = '';
-	
+
 	if (function_exists('getrusage') && !empty($eTimingStartCPU))
 	{
 		$ru = getrusage();
@@ -124,7 +124,7 @@ if (varset($e107_popup) != 1)
 		$cpuTot = $cpuUTime + $cpuSTime;
 		$cpuTime = $cpuTot - $cpuStart;
 		$cpuPct = 100.0 * $cpuTime / $rendertime; /* CPU load during known clock time */
-		
+
 		// Format for display or logging (Uncomment as needed for logging)
 		// User cpu
 		//$cpuUTime = number_format($cpuUTime, 3);
@@ -132,7 +132,7 @@ if (varset($e107_popup) != 1)
 		//$cpuSTime = number_format($cpuSTime, 3);
 		// Total (User+System)
 		//$cpuTot = number_format($cpuTot, 3);
-		
+
 		$cpuStart = number_format($cpuStart, 3); // Startup time (i.e. CPU used before class2.php)
 		$cpuTime = number_format($cpuTime, 3); // CPU while we were measuring the clock (cpuTot-cpuStart)
 		$cpuPct = number_format($cpuPct); // CPU Load (CPU/Clock)
@@ -143,7 +143,7 @@ if (varset($e107_popup) != 1)
 	//
 	//	$logname = "/home/mysite/public_html/queryspeed.log";
 	//	$logfp = fopen($logname, 'a+'); fwrite($logfp, "$cpuTot,$cpuPct,$cpuStart,$rendertime,$db_time\n"); fclose($logfp);
-	
+
 	if ($pref['displayrendertime'])
 	{
 		$rinfo .= CORE_LAN11;
@@ -166,7 +166,7 @@ if (varset($e107_popup) != 1)
 	{
 		$rinfo .= $cachestring.".";
 	}
-	
+
 	if (function_exists('theme_renderinfo'))
 	{
 		theme_renderinfo($rinfo);
@@ -179,7 +179,7 @@ if (varset($e107_popup) != 1)
 			echo($rinfo ? "\n<div class='e-footer-info muted center' style='padding-bottom:20px; margin-top:10px'><small>{$rinfo}</small></div>\n" : "");
 		}
 	}
-	
+
 } // End of regular-page footer (the above NOT done for popups)
 
 //
@@ -299,11 +299,11 @@ if (isset($footer_js) && is_array($footer_js))
 if (is_array($pref['e_footer_list']))
 {
 //	ob_start();
-	
+
 	foreach($pref['e_footer_list'] as $val)
 	{		
 		$fname = e_PLUGIN.$val."/e_footer.php"; // Do not place inside a function - BC $pref required. . 
-		
+
 		if(is_readable($fname))
 		{
 			$ret = (deftrue('e_DEBUG') || isset($_E107['debug'])) ? include_once($fname) : @include_once($fname);

--- a/e107_admin/frontpage.php
+++ b/e107_admin/frontpage.php
@@ -151,7 +151,7 @@ if (!empty($_POST))
 {
 
 	// avoid endless loop.
-	if(varset($_POST['frontpage']) == 'other' && (trim($_POST['frontpage_other']) == 'index.php' || trim($_POST['frontpage_other']) == '{e_BASE}index.php'))
+	if(varset($_POST['frontpage']) == 'other' && (trim((string) $_POST['frontpage_other']) == 'index.php' || trim((string) $_POST['frontpage_other']) == '{e_BASE}index.php'))
 	{
 		$_POST['frontpage'] = 'wmessage';
 		$_POST['frontpage_other'] = '';
@@ -160,8 +160,8 @@ if (!empty($_POST))
 
 	foreach ($_POST as $k => $v)
 	{
-		$incDec = substr($k, 0, 6);
-		$idNum = substr($k, 6);
+		$incDec = substr((string) $k, 0, 6);
+		$idNum = substr((string) $k, 6);
 		if ($incDec == 'fp_inc')
 		{
 			$mv = intval($idNum);
@@ -217,7 +217,7 @@ if(isset($_POST['fp_save_new']))
 
 	if($_POST['frontpage'] == 'other')
 	{
-		$_POST['frontpage_other'] = trim($tp->toForm($_POST['frontpage_other']));
+		$_POST['frontpage_other'] = trim((string) $tp->toForm($_POST['frontpage_other']));
 		$frontpage_value = $_POST['frontpage_other'] ? $_POST['frontpage_other'] : 'news.php';
 	}
 	else
@@ -234,7 +234,7 @@ if(isset($_POST['fp_save_new']))
 
 	if($_POST['fp_force_page'] == 'other')
 	{
-		$_POST['fp_force_page_other'] = trim($tp->toForm($_POST['fp_force_page_other']));
+		$_POST['fp_force_page_other'] = trim((string) $tp->toForm($_POST['fp_force_page_other']));
 		$forcepage_value = $_POST['fp_force_page_other']; // A null value is allowable here
 	}
 	else
@@ -249,7 +249,7 @@ if(isset($_POST['fp_save_new']))
 		}
 	}
 
-	$temp = array('order' => intval($_POST['fp_order']), 'class' => $_POST['class'], 'page' => $frontpage_value, 'force' => trim($forcepage_value));
+	$temp = array('order' => intval($_POST['fp_order']), 'class' => $_POST['class'], 'page' => $frontpage_value, 'force' => trim((string) $forcepage_value));
 
 	if($temp['order'] == 0) // New index to add
 	{

--- a/e107_admin/header.php
+++ b/e107_admin/header.php
@@ -208,9 +208,9 @@ else
 // possibility to overwrite some CSS definition according to TEXTDIRECTION
 // especially usefull for rtl.css
 // see _blank theme for examples
-if(defined('TEXTDIRECTION') && file_exists(THEME . '/' . strtolower(TEXTDIRECTION) . '.css'))
+if(defined('TEXTDIRECTION') && file_exists(THEME . '/' . strtolower((string) TEXTDIRECTION) . '.css'))
 {
-	$e_js->themeCSS(strtolower(TEXTDIRECTION) . '.css');
+	$e_js->themeCSS(strtolower((string) TEXTDIRECTION) . '.css');
 }
 
 

--- a/e107_admin/history.php
+++ b/e107_admin/history.php
@@ -54,7 +54,7 @@ class history_adminArea extends e_admin_dispatcher
 				
 class admin_history_ui extends e_admin_ui
 {
-			
+
 		protected $pluginTitle		= 'History';
 		protected $pluginName		= 'myplugin';
 	//	protected $eventName		= 'myplugin-admin_history'; // remove comment to enable event triggers in admin. 		
@@ -66,11 +66,11 @@ class admin_history_ui extends e_admin_ui
 		protected $batchCopy		= false;
 
 	//	protected $tabs				= array('tab1'=>'Tab 1', 'tab2'=>'Tab 2'); // Use 'tab'=>'tab1'  OR 'tab'=>'tab2' in the $fields below to enable. 
-		
+
 	//	protected $listQry      	= "SELECT * FROM `#tableName` WHERE field != '' "; // Example Custom Query. LEFT JOINS allowed. Should be without any Order or Limit.
-	
+
 		protected $listOrder		= 'history_id DESC';
-	
+
 		protected $fields 		= array (
 			'checkboxes'              => array ( 'title' => '', 'type' => null, 'data' => null, 'width' => '5%', 'thclass' => 'center', 'forced' => 'value', 'class' => 'center', 'toggle' => 'e-multiselect', 'readParms' => [], 'writeParms' => [],),
 		//	'history_id'              => array ( 'title' => LAN_ID, 'type' => 'number', 'data' => 'int', 'width' => '5%', 'help' => '', 'readParms' => [], 'writeParms' => [], 'class' => 'left', 'thclass' => 'left',),
@@ -84,15 +84,15 @@ class admin_history_ui extends e_admin_ui
 
 			'options'                 => array ( 'title' => LAN_OPTIONS, 'type' => 'method', 'data' => null, 'width' => '10%', 'thclass' => 'center last', 'class' => 'center last', 'forced' => 'value', 'readParms' => [], 'writeParms' => [],),
 		);		
-		
+
 		protected $fieldpref = array( 'history_datestamp', 'history_table', 'history_record_id','history_action', 'history_data', 'history_user_id', 'history_restored');
-	
+
 
 	//	protected $preftabs        = array('General', 'Other' );
 		protected $prefs = array(
 		); 
 
-	
+
 		public function init()
 		{
 				$this->fields['history_action']['writeParms']['optArray'] = [
@@ -134,7 +134,7 @@ class admin_history_ui extends e_admin_ui
 			if ($historyRow)
 			{
 				$originalTable = $historyRow['history_table'];                  // The table where this record belongs
-				$originalData = json_decode($historyRow['history_data'], true);
+				$originalData = json_decode((string) $historyRow['history_data'], true);
 				$pid = $historyRow['history_pid'];
 				$recordId = $historyRow['history_record_id'];
 
@@ -190,34 +190,34 @@ class admin_history_ui extends e_admin_ui
 
 
 		// ------- Customize Create --------
-		
+
 		public function beforeCreate($new_data,$old_data)
 		{
 			return $new_data;
 		}
-	
 
-		
+
+
 		// left-panel help menu area. (replaces e_help.php used in old plugins)
 	public function renderHelp()
 	{
 		$caption = LAN_HELP;
 		$text = "
         <p>This page allows you to view the <strong>history of changes</strong> made to records in the system and restore records to a previous state when needed.</p>
-        
+
         <h4>Features of this page:</h4>
         <ul>
             <li><strong>View Changes:</strong> See details of updates and deletions, including who made the changes and when.</li>
             <li><strong>Revert Changes:</strong> Restore a record to its earlier version, undoing accidental or undesired modifications.</li>
             <li><strong>Audit Trail:</strong> Track all actions performed on records for accountability and transparency.</li>
         </ul>
-        
+
         <p>Use the filters to narrow down the history logs or locate specific changes. If a record can be restored, an option will be available in the Options menu.</p>
     ";
 
 		return ['caption' => $caption, 'text' => $text];
 	}
-			
+
 	/*	
 		// optional - a custom page.  
 		public function customPage()
@@ -253,10 +253,10 @@ class admin_history_ui extends e_admin_ui
 			$text .= $frm->close();
 
 			return $text;
-			
+
 		}
-		
-	
+
+
 	 // Handle batch options as defined in admin_history_form_ui::history_data;  'handle' + action + field + 'Batch'
 	 // @important $fields['history_data']['batch'] must be true for this method to be detected. 
 	 // @param $selected
@@ -283,7 +283,7 @@ class admin_history_ui extends e_admin_ui
 
 	}
 
-	
+
 	 // Handle filter options as defined in admin_history_form_ui::history_data;  'handle' + action + field + 'Filter'
 	 // @important $fields['history_data']['filter'] must be true for this method to be detected. 
 	 // @param $selected
@@ -292,7 +292,7 @@ class admin_history_ui extends e_admin_ui
 	{
 
 		$this->listOrder = 'history_data ASC';
-	
+
 		switch($type)
 		{
 			case 'customfilter_1':
@@ -309,9 +309,9 @@ class admin_history_ui extends e_admin_ui
 
 
 	}
-	
-		
-		
+
+
+
 	*/
 			
 }

--- a/e107_admin/image.php
+++ b/e107_admin/image.php
@@ -341,16 +341,16 @@ class media_cat_form_ui extends e_admin_form_ui
 		{
 			return;
 		}	
-		
+
 		$owner = $this->getController()->getListModel()->get('media_cat_owner');	
 		if(!in_array($owner,$this->restrictedOwners))
 		{
 
 			return $this->renderValue('options',$value,null,$id);
 		}
-			
-		
-		
+
+
+
 
 	//	$save = ($_GET['bbcode']!='file')  ? "e-dialog-save" : "";
 	// e-dialog-close
@@ -386,8 +386,8 @@ class media_form_ui extends e_admin_form_ui
 
 
 		}
-		
-		
+
+
 		if(!empty($_POST['multiselect']) && varset($_POST['e__execute_batch']) && (varset($_POST['etrigger_batch']) == 'options__resize_2048' ))
 		{
 			$type = str_replace('options__','',$_POST['etrigger_batch']);
@@ -408,22 +408,22 @@ class media_form_ui extends e_admin_form_ui
 			$ids = implode(",", e107::getParser()->filter($_POST['multiselect'],'int'));
 			$this->convertImagesToJpeg($ids,'all');
 		}*/
-		
+
 	}
-	
+
 	function resize_method($curval)
 	{
 		$frm = e107::getForm();
-		
+
 		$options = array(
 			'gd1' => 'gd1',
 			'gd2' => 'gd2',
 			'ImageMagick' => 'ImageMagick'
 		);
-		
+
 		return $frm->selectbox('resize_method',$options,$curval)."<div class='field-help'>".IMALAN_4. '</div>';
 	}
-	
+
 	public function rotateImages($ids,$type)
 	{
 		$sql = e107::getDb();
@@ -431,13 +431,13 @@ class media_form_ui extends e_admin_form_ui
 		$mes = e107::getMessage();
 		ini_set('memory_limit', '150M');
 		ini_set('gd.jpeg_ignore_warning', 1);
-		
+
 		$degrees = ($type === 'rotate_cw') ? 270 : 90;
-		
+
 	//	$mes->addDebug("Rotate Mode Set: ".$type);
-		
+
 		//TODO GIF and PNG rotation. 
-		
+
 		if($sql->select('core_media', 'media_url', 'media_id IN (' .$ids.") AND media_type = 'image/jpeg' "))
 		{
 			while($row = $sql->fetch())
@@ -445,9 +445,9 @@ class media_form_ui extends e_admin_form_ui
 				$original = $tp->replaceConstants($row['media_url']);
 
 				$mes->addDebug("Attempting to rotate by {$degrees} degrees: ".basename($original));
-				
+
 				$source = imagecreatefromjpeg($original);
-							
+
 				try 
 				{
 					$rotate = imagerotate($source, $degrees, 0);
@@ -457,10 +457,10 @@ class media_form_ui extends e_admin_form_ui
 					$mes->addError(LAN_IMA_002. ': ' .basename($original));
 					return null;
 				}  
-							
+
 				$srch = array('.jpg', '.jpeg');
 				$cacheFile = str_replace($srch, '',strtolower(basename($original)))."_(.*)\.cache\.bin";
-				
+
 				try 
 				{
 					imagejpeg($rotate,$original,80);
@@ -498,17 +498,17 @@ class media_form_ui extends e_admin_form_ui
 
 	public function resizeImages($ids,$type)
 	{
-		
+
 		$sql = e107::getDb();
 		$sql2 = e107::getDb('sql2');
 		$mes = e107::getMessage();
 		$tp = e107::getParser();
 		$fl = e107::getFile();
-				
+
 		// Max size is 6 megapixel. 
 		$img_import_w = 2816;
 		$img_import_h = 2112; 
-			
+
 		if($sql->select('core_media', 'media_id,media_url', 'media_id IN (' .$ids.") AND media_type = 'image/jpeg' "))
 		{
 			while($row = $sql->fetch())
@@ -516,10 +516,10 @@ class media_form_ui extends e_admin_form_ui
 				$path = $tp->replaceConstants($row['media_url']);
 
 				$mes->addDebug('Attempting to resize: ' .basename($path));
-				
+
 				if($this->resizeImage($path,$img_import_w,$img_import_h))
 				{
-					
+
 					$info = $fl->getFileInfo($path);
 					$mes->addSuccess(LAN_IMA_004. ': ' .basename($path));
 					$mes->addSuccess(print_a($info,true));
@@ -532,9 +532,9 @@ class media_form_ui extends e_admin_form_ui
 				}	
 			}
 		}		
-		
-		
-		
+
+
+
 	}
 
 	public function convertImagesToJpeg($ids,$mode=null)
@@ -585,15 +585,15 @@ class media_form_ui extends e_admin_form_ui
 
 
 	}
-	
-	
+
+
 	public function resize_dimensions($curval) // ie. never manually resize another image again!
 	{
 
 		$text = '';
 
 		$pref 	= e107::getPref();
-		
+
 	//	$options = array(
 	//		"news-image" 			=> LAN_IMA_O_001,
 	//		"news-bbcode" 			=> LAN_IMA_O_002,
@@ -609,7 +609,7 @@ class media_form_ui extends e_admin_form_ui
 		{
 			foreach($pref['e_imageresize'] as $k=>$val)
 			{
-				$options[$k]		= ucfirst($k). ' ' .defset('LAN_IMA_O_006');
+				$options[$k]		= ucfirst((string) $k). ' ' .defset('LAN_IMA_O_006');
 			}
 		}
 
@@ -628,7 +628,7 @@ class media_form_ui extends e_admin_form_ui
 			$title = ucwords(str_replace('-', ' ',$key));
 			$valW = !empty($curval[$key]['w']) ? $curval[$key]['w'] : 400;
 			$valH = !empty($curval[$key]['h']) ? $curval[$key]['h'] : 400;
-		
+
 			$text .= "<tr><td style='width:45%'>".$title."</td><td class='text-right'>";
 			$text .= "<input class='e-tip e-spinner input-small' placeholder='ex. 400' style='text-align:right' type='text' name='resize_dimensions[{$key}][w]' value='$valW' size='5' title='maximum width in pixels' />";
 			$text .= "</td><td class='text-right'><input class='e-tip e-spinner input-small' placeholder='ex. 400' style='text-align:right' type='text' name='resize_dimensions[{$key}][h]' value='$valH' size='5' title='maximum height in pixels' />";
@@ -636,14 +636,14 @@ class media_form_ui extends e_admin_form_ui
 
 		}
 		$text .= '</table>';
-		
+
 	//	$text .= "<div><br />Warning: This feature is experimental.</div>";
-		
+
 		return $text;
-		
-		
+
+
 	}
-	
+
 
 	function options($parms, $value, $id)
 	{
@@ -664,12 +664,12 @@ class media_form_ui extends e_admin_form_ui
 
 			return $arr;
 		}
-		
+
 		if($_GET['action'] === 'edit')
 		{
 			return null;
 		}	
-		
+
 		$tagid = vartrue($_GET['tagid']);
 		$tagid = e107::getParser()->filter($tagid);
 		$model =  $this->getController()->getListModel();
@@ -677,12 +677,12 @@ class media_form_ui extends e_admin_form_ui
 		$title = $model->get('media_name');
 		$id = $model->get('media_id');
 
-		$preview = basename($path);
-		
+		$preview = basename((string) $path);
+
 		$bbcode = (vartrue($_GET['bbcode']) === 'file')  ? 'file' : '';
 	//	$save = ($_GET['bbcode']!='file')  ? "e-dialog-save" : "";
 	// e-dialog-close
-	
+
 		$for = (string) $this->getController()->getQuery('for');
 
 
@@ -713,7 +713,7 @@ class media_form_ui extends e_admin_form_ui
 			$att = ['query' => e_QUERY."&after=".$action];
 
 			$url = $this->media_sef('', 'read', ['url'=>1]);
-			$modal = (strpos($type, 'application') === false) ? 'e-modal' : '';
+			$modal = (strpos((string) $type, 'application') === false) ? 'e-modal' : '';
 
 			if($action === 'grid')
 			{
@@ -737,15 +737,15 @@ class media_form_ui extends e_admin_form_ui
 		}
 
 		return "<div class='nowrap'>".$text. '</div>';
-		
+
 	}
 
 
 	private function getMediaType()
 	{
-		list($type,$extra) 	= explode('/',$this->getController()->getFieldVar('media_type'));
+		list($type,$extra) 	= explode('/',(string) $this->getController()->getFieldVar('media_type'));
 		$category = $this->getController()->getFieldVar('media_category');
-		if(strpos($category, '_icon') === 0)
+		if(strpos((string) $category, '_icon') === 0)
 		{
 			$type = 'icon';
 		}
@@ -821,9 +821,9 @@ class media_form_ui extends e_admin_form_ui
 /*
 	function media_category($curVal,$mode) // not really necessary since we can use 'dropdown' - but just an example of a custom function.
 	{
-		
+
 		$curVal = explode(",",$curVal);
-		
+
 		if($mode == 'read')
 		{
 			return $this->getController()->getMediaCategory($curVal);
@@ -843,7 +843,7 @@ class media_form_ui extends e_admin_form_ui
 
 		$text = "<select class='tbox' name='media_category[]' multiple='multiple'>";
 		$cats = $this->getController()->getMediaCategory();
-		
+
 		foreach($cats as $key => $val)
 		{
 			$selected = (in_array($key,$curVal)) ? "selected='selected'" : "";
@@ -1215,7 +1215,7 @@ class media_admin_ui extends e_admin_ui
 	/** Wildcard support for media-type filter  */
 	function handleGridMediaTypeFilter($var)
 	{
-		if(strpos($var,'%') !== false)
+		if(strpos((string) $var,'%') !== false)
 		{
 			return "m.media_type LIKE '".$var."'";
 		}
@@ -1287,7 +1287,7 @@ class media_admin_ui extends e_admin_ui
 	public function ListAjaxObserver()
 	{
 		$cat = $this->getQuery('for');
-		$file	= (preg_match('/_file(_[\d]{1,2})?$/',$cat)) ? true : false;
+		$file	= (preg_match('/_file(_[\d]{1,2})?$/',(string) $cat)) ? true : false;
 
 		if($file === true) // Make sure dialog mode is used when ajax searches occur.
 		{
@@ -1375,7 +1375,7 @@ class media_admin_ui extends e_admin_ui
 
 
 		$cat = $this->getQuery('for');		
-		$file	= (preg_match('/_file(_[\d]{1,2})?$/',$cat)) ? true : false;
+		$file	= (preg_match('/_file(_[\d]{1,2})?$/',(string) $cat)) ? true : false;
 		$mes = e107::getMessage();
 		$mes->addDebug('For:' .$cat);
 		$mes->addDebug('Bbcode: ' .$this->getQuery('bbcode'));
@@ -1512,7 +1512,7 @@ class media_admin_ui extends e_admin_ui
 
 		$cat = $this->getQuery('for');
 
-		$cat = urldecode($cat);
+		$cat = urldecode((string) $cat);
 
 		$tabOptions = array(
 			'core-media-icon'   => array('caption'=> $tp->toGlyph('fa-file-photo-o').IMALAN_72,     'method' => 'iconTab' ),
@@ -1941,7 +1941,7 @@ class media_admin_ui extends e_admin_ui
 					'saveValue'		=> $val['media_url'],
 					'thumbUrl'		=> $val['media_url'],
 					'title'			=> $val['media_name'],
-					'tooltip'       => basename($val['media_url']). ' (' .$val['media_dimensions']. ')',
+					'tooltip'       => basename((string) $val['media_url']). ' (' .$val['media_dimensions']. ')',
 					'slideCaption'	=> '',
 					'slideCategory'	=> 'bootstrap',
 					'mime'          => $val['media_type']
@@ -1959,7 +1959,7 @@ class media_admin_ui extends e_admin_ui
 			{
 				foreach($items as $v)
 				{
-					if(strpos($v['title'], $option['search'])!==false)
+					if(strpos((string) $v['title'], (string) $option['search'])!==false)
 					{
 						$filtered[] = $v;
 					}
@@ -2025,7 +2025,7 @@ class media_admin_ui extends e_admin_ui
 					'saveValue'		=> $val['media_url'],
 					'thumbUrl'		=> $tp->thumbUrl($val['media_url'], array('w'=>340, 'h'=>220)),
 					'title'			=> $val['media_name'],
-					'tooltip'       => basename($val['media_url']). ' (' .$val['media_dimensions']. ')',
+					'tooltip'       => basename((string) $val['media_url']). ' (' .$val['media_dimensions']. ')',
 					'slideCaption'	=> '',
 					'slideCategory'	=> 'bootstrap',
 					'mime'          => $val['media_type'],
@@ -2042,7 +2042,7 @@ class media_admin_ui extends e_admin_ui
 			{
 				foreach($items as $v)
 				{
-					if(strpos($v['title'], $option['search'])!==false)
+					if(strpos((string) $v['title'], (string) $option['search'])!==false)
 					{
 						$filtered[] = $v;
 					}
@@ -2117,7 +2117,7 @@ class media_admin_ui extends e_admin_ui
 			{
 				foreach($items as $v)
 				{
-					if(strpos($v['title'], $parm['search'])!==false)
+					if(strpos((string) $v['title'], (string) $parm['search'])!==false)
 					{
 						$filtered[] = $v;
 					}
@@ -2167,7 +2167,7 @@ class media_admin_ui extends e_admin_ui
 					'saveValue'		=> $val['media_url'],
 					'thumbUrl'		=> $val['media_url'],
 					'title'			=> $val['media_name'],
-					'tooltip'       => basename($val['media_url']). ' (' .$size. ')',
+					'tooltip'       => basename((string) $val['media_url']). ' (' .$size. ')',
 					'slideCaption'	=> '',
 					'slideCategory'	=> 'bootstrap',
 					'mime'          => $val['media_type'],
@@ -2184,7 +2184,7 @@ class media_admin_ui extends e_admin_ui
 			{
 				foreach($items as $v)
 				{
-					if(strpos($v['title'], $parm['search'])!==false)
+					if(strpos((string) $v['title'], (string) $parm['search'])!==false)
 					{
 						$filtered[] = $v;
 					}
@@ -2337,7 +2337,7 @@ class media_admin_ui extends e_admin_ui
 							'saveValue'		=> $val.'.glyph',
 							'thumbUrl'		=> $val,
 							'title'			=> $val,
-							'slideCaption'	=> ucfirst($glyphConfig['name']),
+							'slideCaption'	=> ucfirst((string) $glyphConfig['name']),
 							'slideCategory'	=> $glyphConfig['name']
 						);
 
@@ -2365,7 +2365,7 @@ class media_admin_ui extends e_admin_ui
 			{
 				foreach($items as $v)
 				{
-					if(strpos($v['title'], $parm['search'])!==false)
+					if(strpos((string) $v['title'], (string) $parm['search'])!==false)
 					{
 						$v['slideCaption'] = '';
 						$filtered[] = $v;
@@ -2423,7 +2423,7 @@ class media_admin_ui extends e_admin_ui
 
 		$searchQry = $this->getQuery('search');
 
-		if(strpos($searchQry, 'url:') === 0)
+		if(strpos((string) $searchQry, 'url:') === 0)
 		{
 			$searchQry = $this->getYouTubeCode($searchQry);
 
@@ -2431,9 +2431,9 @@ class media_admin_ui extends e_admin_ui
 
 		if(!empty($searchQry)) // -- Search Active.
 		{
-			if(strpos($searchQry, 'video:') === 0 || strpos($searchQry, 'v=') === 0) // YouTube video code
+			if(strpos((string) $searchQry, 'video:') === 0 || strpos((string) $searchQry, 'v=') === 0) // YouTube video code
 			{
-				$searchQry = (strpos($searchQry, 'v=') === 0) ? trim(substr($searchQry,2)) : trim(substr($searchQry,6));
+				$searchQry = (strpos((string) $searchQry, 'v=') === 0) ? trim(substr((string) $searchQry,2)) : trim(substr((string) $searchQry,6));
 				$extension = 'youtube';
 			//	$feed = "https://www.googleapis.com/youtube/v3/videos?part=snippet&id=".urlencode($searchQry)."&key=".$apiKey;
 
@@ -2442,12 +2442,12 @@ class media_admin_ui extends e_admin_ui
 				$data['items'][0]['snippet']['thumbnails']['medium']['url'] = 'https://i.ytimg.com/vi/' .$searchQry. '/mqdefault.jpg';
 				$data['items'][0]['snippet']['title'] = 'Specified Video';
 			}
-			elseif(strpos($searchQry, 'playlist:') === 0) // playlist
+			elseif(strpos((string) $searchQry, 'playlist:') === 0) // playlist
 			{
 
 				if(empty($apiKey))
 				{
-					$playlistID = substr($searchQry,9);
+					$playlistID = substr((string) $searchQry,9);
 					$data = array();
 					$data['items'][0]['id']['videoId'] = $playlistID;
 					$data['items'][0]['snippet']['thumbnails']['medium']['url'] = e_IMAGE_ABS. 'generic/playlist_120.png'; // "http://i.ytimg.com/vi/".$playlistID."/mqdefault.jpg"; // not really possible, so it will show a generic grey image.
@@ -2455,21 +2455,21 @@ class media_admin_ui extends e_admin_ui
 				}
 				else
 				{
-					$searchQry = trim(substr($searchQry,9));
+					$searchQry = trim(substr((string) $searchQry,9));
 					$feed = 'https://www.googleapis.com/youtube/v3/search?part=snippet&q=' .urlencode($searchQry). '&type=playlist&maxResults=1&key=' .$apiKey;
 				}
 
 				$extension = 'youtubepl';
 			}
-			elseif(strpos($searchQry, 'channel:') === 0)
+			elseif(strpos((string) $searchQry, 'channel:') === 0)
 			{
-				$searchQry = trim(substr($searchQry,8));
+				$searchQry = trim(substr((string) $searchQry,8));
 				$extension = 'youtube';
 				$feed = 'https://www.googleapis.com/youtube/v3/search?part=snippet&channelId=' .urlencode($searchQry). '&type=video&maxResults=20&key=' .$apiKey;
 			}
 			else
 			{
-				$feed = 'https://www.googleapis.com/youtube/v3/search?part=snippet&q=' .urlencode($searchQry). '&type=video&maxResults=20&key=' .$apiKey;
+				$feed = 'https://www.googleapis.com/youtube/v3/search?part=snippet&q=' .urlencode((string) $searchQry). '&type=video&maxResults=20&key=' .$apiKey;
 				$extension = 'youtube';
 			}
 
@@ -2615,7 +2615,7 @@ class media_admin_ui extends e_admin_ui
 
 		if(!empty($_POST['upload_remote_url']))
 		{
-			$fileName = basename($_POST['upload_url']);
+			$fileName = basename((string) $_POST['upload_url']);
 
 			if(strpos($fileName,'?')!==false)
 			{
@@ -2662,7 +2662,7 @@ class media_admin_ui extends e_admin_ui
 		$sql = e107::getDb();
 		$ns = e107::getRender();
 		$mes = e107::getMessage();
-	
+
 		if(function_exists('gd_info'))
 		{
 			$gd_info = gd_info();
@@ -2676,11 +2676,11 @@ class media_admin_ui extends e_admin_ui
         $folder1 = e107::getFolder('imagemagick');
         if($pref['resize_method'] === 'ImageMagick' && (!vartrue($folder1)))
 		{
-			
+
 			$mes->addWarning('Please add: <b>$IMAGEMAGICK_DIRECTORY="'.$pref['im_path'].'";</b> to your e107_config.php file');	
 		}
-		
-			
+
+
 		//$IM_NOTE = "";
         $folder = e107::getFolder('imagemagick');
         $im_path = vartrue($folder);
@@ -2696,19 +2696,19 @@ class media_admin_ui extends e_admin_ui
 			{
 				$cmd = "{$im_file} -version";
 				$tmp = `$cmd`;
-				if(strpos($tmp, 'ImageMagick') === FALSE)
+				if(strpos((string) $tmp, 'ImageMagick') === FALSE)
 				{
 					//$IM_NOTE = "<span class='error'>".IMALAN_53."</span>";
 					$mes->addWarning(IMALAN_53);
 				}
 			}
 		}
-	
 
-	
-	
-	
-	
+
+
+
+
+
 		$text = "
 			<form method='post' action='".e_SELF. '?' .e_QUERY."'>
 				<fieldset id='core-image-settings'>
@@ -2739,7 +2739,7 @@ class media_admin_ui extends e_admin_ui
 									<div class='field-help'>".IMALAN_11. '</div>
 								</td>
 							</tr>
-	
+
 							<tr>
 								<td>
 									' .IMALAN_12. '
@@ -2752,9 +2752,9 @@ class media_admin_ui extends e_admin_ui
 									<div class='field-help'>".IMALAN_13. '</div>
 								</td>
 							</tr>';
-							
-							list($img_import_w,$img_import_h) = explode('x',$pref['img_import_resize']);
-							
+
+							list($img_import_w,$img_import_h) = explode('x',(string) $pref['img_import_resize']);
+
 							$text .= '
 							<tr>
 								<td>' .IMALAN_105."<div class='label-note'>".IMALAN_106. '</div></td>
@@ -2762,7 +2762,7 @@ class media_admin_ui extends e_admin_ui
 									' .$frm->text('img_import_resize_w', $img_import_w,4). 'px X ' .$frm->text('img_import_resize_h', $img_import_h,4). 'px
 								</td>
 							</tr>
-	
+
 							<tr>
 								<td>' .IMALAN_3."<div class='label-note'>".IMALAN_54." {$gd_version}</div></td>
 								<td>
@@ -2784,11 +2784,11 @@ class media_admin_ui extends e_admin_ui
 									<div class='field-help'>".IMALAN_6."</div>
 								</td>
 							</tr>";		
-							
+
 				// Removed as IE6 should no longer be supported. A 3rd-party plugin can be made for this functionality if really needed. 			
-				
-							
-				
+
+
+
 							$text .= "
 										<tr>
 											<td>".IMALAN_34."
@@ -2800,12 +2800,12 @@ class media_admin_ui extends e_admin_ui
 												</div>
 											</td>
 										</tr>";
-										
+
 							*/
-							
-							
+
+
 			$text .= '
-	
+
 							<tr>
 								<td>' .IMALAN_36. '</td>
 								<td>
@@ -2819,7 +2819,7 @@ class media_admin_ui extends e_admin_ui
 					</div>
 				</fieldset>
 			</form>';
-	
+
 			echo $mes->render().$text;
 			return;
 		//	$ns->tablerender(LAN_MEDIAMANAGER." :: ".IMALAN_7, $mes->render().$text);
@@ -2841,7 +2841,7 @@ class media_admin_ui extends e_admin_ui
 
 				foreach ($actions as $todel)
 				{
-					list($usr,$path) = explode('#', $todel);
+					list($usr,$path) = explode('#', (string) $todel);
 
 				//	$path = basename($path);
 
@@ -3240,9 +3240,9 @@ class media_admin_ui extends e_admin_ui
 				return FALSE;
 			}
 			
-			$fname = basename($new_data['media_url']);
+			$fname = basename((string) $new_data['media_url']);
 			// move to the required place
-			if(strpos($new_data['media_url'], '{e_IMPORT}') !== FALSE)
+			if(strpos((string) $new_data['media_url'], '{e_IMPORT}') !== FALSE)
 		//	if(strpos($new_data['media_url'], '{e_MEDIA}temp/') !== FALSE)
 			{
 				$tp = e107::getParser();
@@ -3263,7 +3263,7 @@ class media_admin_ui extends e_admin_ui
 
 			if(!varset($new_data['media_name']))
 			{
-				$img_data['media_name'] = basename($new_data['media_url']);
+				$img_data['media_name'] = basename((string) $new_data['media_url']);
 			}
 
 
@@ -3466,7 +3466,7 @@ class media_admin_ui extends e_admin_ui
 		$this->cats['_avatars_public'] = IMALAN_178;
 		$this->cats['_avatars_private'] = IMALAN_179;
 
-		if(!isset($_POST['batch_category']) && strpos($lastMime, 'image') === 0)
+		if(!isset($_POST['batch_category']) && strpos((string) $lastMime, 'image') === 0)
 		{
 			$_POST['batch_category'] = '_common_image';
 		}
@@ -3501,10 +3501,10 @@ class media_admin_ui extends e_admin_ui
 	// Check for matching XML file name and if found, return data from it during import. 
 	function getFileXml($imgFile)
 	{
-		list($file,$ext) = explode('.',$imgFile);
-		
+		list($file,$ext) = explode('.',(string) $imgFile);
+
 		$xmlFile = e_IMPORT.$file. '.xml';
-		
+
 		if(is_readable($xmlFile))
 		{
 			$data = file_get_contents($xmlFile);
@@ -3512,7 +3512,7 @@ class media_admin_ui extends e_admin_ui
 			preg_match("/email=(?:'|\")([^'\"]*)/i",$data,$authorEmail);
 			preg_match("/<title>(.*)<\/title>/i",$data,$title);
 			preg_match("/<description>(.*)<\/description>/i",$data,$diz);
-			
+
 			return array(
 				'title'			=> $title[1],
 				'description'	=> $diz[1],
@@ -3520,18 +3520,18 @@ class media_admin_ui extends e_admin_ui
 				'authorEmail'	=> $authorEmail[1]
 			);				
 		}
-			
+
 		$srch = array('_', '-');
 		$description = str_replace($srch, ' ',$file);
-		
+
 		$file = utf8_encode($file);
 		$description = utf8_encode($description); 
-			
+
 		return array('title'=>basename($file),'description'=>$description,'authorName'=>USERNAME,'authorEmail'=>'');
-		
+
 		/*
 		Example: matchingfilename.xml (ie. same name as jpg|.gif|.png etc)
-		 
+
 		<?xml version='1.0' encoding='utf-8' ?>
 		<e107Media>
 			<item file='filename.jpg' date='2012-10-25'>
@@ -3550,7 +3550,7 @@ class media_admin_ui extends e_admin_ui
 
 	function deleteFileXml($imgFile)
 	{
-		list($file,$ext) = explode('.',$imgFile);
+		list($file,$ext) = explode('.',(string) $imgFile);
 		
 		$xmlFile = e_IMPORT.$file. '.xml';
 		
@@ -3567,7 +3567,7 @@ class media_admin_ui extends e_admin_ui
 
 		foreach($_POST['batch_selected'] as $key=>$file)
 		{
-			if(trim($file) == '')
+			if(trim((string) $file) == '')
 			{
 				continue;
 			}	
@@ -3704,7 +3704,7 @@ class media_admin_ui extends e_admin_ui
 
 	function preview($f)
 	{
-		list($type,$tmp) = explode('/',$f['mime']);
+		list($type,$tmp) = explode('/',(string) $f['mime']);
 
 		if($type === 'image')
 		{
@@ -3756,7 +3756,7 @@ class media_admin_ui extends e_admin_ui
 		$tmp = array();
 		$tmp['image_post']                  = (int) $_POST['image_post'];
 		$tmp['resize_method']               = $tp->toDB($_POST['resize_method']);
-		$tmp['im_path']                     = trim($tp->toDB($_POST['im_path']));
+		$tmp['im_path']                     = trim((string) $tp->toDB($_POST['im_path']));
 		$tmp['image_post_class']            = (int) $_POST['image_post_class'];
 		$tmp['image_post_disabled_method']  = (int) $_POST['image_post_disabled_method'];
 		$tmp['enable_png_image_fix']        = (int) $_POST['enable_png_image_fix'];
@@ -3881,7 +3881,7 @@ if (isset($_POST['submit_avdelete_multi']))
 			if (vartrue($search_users[$uid]))
 			{
 				$avname = avatar($search_users[$uid]['user_image']);
-				if (strpos($avname, 'http://') === FALSE)
+				if (strpos((string) $avname, 'http://') === FALSE)
 				{ // Internal file, so unlink it
 					@unlink($avname);
 				}
@@ -3960,7 +3960,7 @@ if (isset($_POST['check_avatar_sizes']))
 		{
 			//Check size
 			$avname=avatar($row['user_image']);
-			if (strpos($avname, 'http://')!==FALSE)
+			if (strpos((string) $avname, 'http://')!==FALSE)
 			{
 				$iAVexternal++;
 				$bAVext=TRUE;

--- a/e107_admin/includes/flexpanel.php
+++ b/e107_admin/includes/flexpanel.php
@@ -629,7 +629,7 @@ class adminstyle_flexpanel extends adminstyle_infopanel
 		$files = $fl->get_files(e_ADMIN . 'includes/layouts/', "flexpanel_(.*).php", "standard", 1);
 		foreach($files as $num => $val)
 		{
-			$filename = basename($val['fname']);
+			$filename = basename((string) $val['fname']);
 			$layout = str_replace('flexpanel_', '', $filename);
 			$layout = str_replace('.php', '', $layout);
 

--- a/e107_admin/includes/infopanel.php
+++ b/e107_admin/includes/infopanel.php
@@ -24,9 +24,9 @@ define('ADMINFEEDMORE', 'https://e107.org/blog');
 
 class adminstyle_infopanel
 {
-	
+
 	private $iconlist = array();
-	
+
 	function __construct()
 	{
 
@@ -45,13 +45,13 @@ class adminstyle_infopanel
 			$coreUpdateCheck = "
 				$('#e-admin-core-update').html('<i title=\"".LAN_CHECKING_FOR_UPDATES."\" class=\"fa fa-spinner fa-spin\"></i>');
   		    	$.get('".e_ADMIN."admin.php?mode=core&type=update', function( data ) {
- 		    	
+
   		    	var res = $.parseJSON(data);
-		    
+
   		    	if(res === true)
   		    	{
   		    	    $('#e-admin-core-update').html('<span class=\"text-info\"><i class=\"fa fa-database\"></i></span>');
-  		    	    
+
   		    	     $('[data-toggle=\"popover\"]').popover('show');
 	                 $('.popover').on('click', function() 
 	                 {
@@ -63,9 +63,9 @@ class adminstyle_infopanel
   		    	    // Hide li element.
   		    		$('#e-admin-core-update').parent().hide();
   		    	}
-			   
+
 			});
-			
+
 			";
 
 		}
@@ -85,10 +85,10 @@ class adminstyle_infopanel
   			$('#e-adminfeed').load('".e_ADMIN."admin.php?mode=core&type=feed');
   		    $('#e-adminfeed-plugin').load('".e_ADMIN."admin.php?mode=addons&type=plugin');
   		    $('#e-adminfeed-theme').load('".e_ADMIN."admin.php?mode=addons&type=theme');
-  		    
+
   		    ".$coreUpdateCheck."
   		    ".$addonUpdateCheck."
-		
+
 		});
 		";
 
@@ -98,9 +98,9 @@ class adminstyle_infopanel
 
 
 
-		
+
 		e107::js('inline',$code,'jquery');
-		
+
 		if (isset($_POST['submit-mye107']) || varset($_POST['submit-mymenus']))
 		{
 			$this->savePref('core-infopanel-mye107', $_POST['e-mye107']);
@@ -171,7 +171,7 @@ class adminstyle_infopanel
 	{
 		return $this->iconlist;
 	}
-	
+
 	function render()
 	{
 		$tp = e107::getParser();
@@ -180,8 +180,8 @@ class adminstyle_infopanel
 		$mes = e107::getMessage();
 		$pref = e107::getPref();
 		$frm = e107::getForm();
-		
-		
+
+
 	//	XXX Check Bootstrap bug is fixed. 
 	/*
 		echo '
@@ -231,15 +231,15 @@ class adminstyle_infopanel
 		{
 			$user_pref['core-infopanel-mye107'] = e107::getNav()->getDefaultAdminPanelArray();
 		}
-		
+
 
 	//	"<form method='post' action='".e_SELF."?".e_QUERY."'>";
-		
+
 		$tp->parseTemplate("{SETSTYLE=core-infopanel}");
 
 		// Personalized Panel 
 		// Rendering the saved configuration.
-		
+
 		$mainPanel = "
 		<div id='core-infopanel_mye107' >
 		";
@@ -263,10 +263,10 @@ class adminstyle_infopanel
 					break;
 				}
 			}
-	
+
 			// $mainPanel .= "<div class='clear'>&nbsp;</div>";
 			$mainPanel .= "</div>
-	      
+
 			</div>";
 
 	//	e107::getDebug()->log($this->iconlist);
@@ -276,8 +276,8 @@ class adminstyle_infopanel
 		$text3 = $this->renderAddonDashboards();
 
 		$text = $ns->tablerender($caption, $mainPanel, "core-infopanel_mye107",true);
-		
-	
+
+
 	//  ------------------------------- e107 News --------------------------------
 
 		$newsTabs = array();
@@ -286,44 +286,44 @@ class adminstyle_infopanel
 		$newsTabs['themeFeed'] = array('caption'=>LAN_THEMES,'text'=>"<div id='e-adminfeed-theme'></div>");
 
 		$text2 = $ns->tablerender(LAN_LATEST_e107_NEWS,e107::getForm()->tabs($newsTabs, array('active'=>'coreFeed')),"core-infopanel_news",true);
-	
-	
-	
-	
+
+
+
+
 	// ---------------------Latest Stuff ---------------------------
-	
+
 		//require_once (e_CORE."shortcodes/batch/admin_shortcodes.php");
 		e107::getScBatch('admin');
-		
 
 
-		
+
+
 	//	$text3 .= $ns->tablerender(LAN_WEBSITE_STATUS, $this->renderWebsiteStatus(),"",true);
 
 
-		
-		
+
+
 	//	$text .= $ns->tablerender(ADLAN_LAT_1,$tp->parseTemplate("{ADMIN_LATEST=norender}"),"core-infopanel_latest",true);
 	//	$text .= $ns->tablerender(LAN_STATUS,$tp->parseTemplate("{ADMIN_STATUS=norender}"),"core-infopanel_latest",true);
 	/*
-	
+
 			$text .= "<li class='span6'>
 				".$tp->parseTemplate("{ADMIN_LATEST=norender}").
 				$tp->parseTemplate("{ADMIN_STATUS=norender}")."
 						</div>";
-		
+
 		*/
-	
-	
+
+
 	$text .= $this->renderLatestComments();
-	
-	
+
+
 	// ---------------------- Who's Online  ------------------------
 	// TODO Could use a new _menu item instead.
-	
-	
+
+
 	//	$text2 .= $ns->tablerender('Visitors Online : '.vartrue($nOnline), $panelOnline,'core-infopanel_online',true);
-		
+
 	// --------------------- User Selected Menus -------------------
 
 
@@ -345,21 +345,21 @@ class adminstyle_infopanel
 				$text .= $inc;
 			}
 		}
-	
-	
-		
-		
-		
-		
-		
+
+
+
+
+
+
+
 	//	$text .= "<div class='clear'>&nbsp;</div>";
-		
+
 		$text .= $this->render_infopanel_options();
-		
-		
-		
+
+
+
 	//	$text .= "</div>";
-		
+
 		if(vartrue($_GET['mode']) != 'customize')
 		{
 			// $ns->tablerender(ADLAN_47." ".ADMINNAME, $emessage->render().$text);	
@@ -386,8 +386,8 @@ class adminstyle_infopanel
 				 </div>
 			</div>
 			<!--  -->  
-			 
-			 
+
+
 			 ';
 		}
 		else
@@ -401,7 +401,7 @@ class adminstyle_infopanel
 /*
 	private function renderChart()
 	{
-	
+
 
 		// REQUIRES Log Plugin to be installed. 		
 		if (e107::isInstalled('log')) 
@@ -413,7 +413,7 @@ class adminstyle_infopanel
 		{
 			return $this->renderStats('demo');
 		}
-		
+
 	}*/
 
 
@@ -447,7 +447,7 @@ class adminstyle_infopanel
 				}
 				else
 				{
-					$cap = defset('LAN_PLUGIN_'.strtoupper($plug).'_NAME', ucfirst($plug));
+					$cap = defset('LAN_PLUGIN_'.strtoupper((string) $plug).'_NAME', ucfirst((string) $plug));
 				}
 
 				foreach($val as $k=>$item)
@@ -521,24 +521,24 @@ class adminstyle_infopanel
 	//	{
 	//		return;
 	//	}
-				
+
 		if(!$rows = $sql->retrieve('comments','*','comment_blocked=2 ORDER BY comment_id DESC LIMIT 25',true) )
 		{
 			return null;
 		}
-		
+
 
 		$sc = e107::getScBatch('comment');
-				
+
 		$text = '
 		  <ul class="media-list unstyled list-unstyled">';
 		// <button class='btn btn-mini'><i class='icon-pencil'></i> Edit</button> 
-		
+
 		//XXX Always keep template hardcoded here - heavy use of ajax and ids. 
 		$count = 1;
 
 		$lanVar = array('x' =>'{USERNAME}', 'y'=>'{TIMEDATE=relative}');
-				
+
 		foreach($rows as $row) 
 		{
 			$hide = ($count > 3) ? ' hide' : '';
@@ -555,12 +555,12 @@ class adminstyle_infopanel
 					<p>{COMMENT}</p> 
 				</div>
 				</li>";
-			
+
 			$sc->setVars($row);  
 		 	$text .= $tp->parseTemplate($TEMPLATE,true,$sc);
 			$count++;
 		}
-        
+
 
     	$text .= '
      		</ul>
@@ -569,35 +569,35 @@ class adminstyle_infopanel
 		    </div>
 		 ';		
 		// $text .= "<small class='text-center text-warning'>Note: Not fully functional at the moment.</small>";
-		
+
 		$ns = e107::getRender();
 		return $ns->tablerender(LAN_LATEST_COMMENTS,$text,'core-infopanel_online',true);		
 	}
-		
-		
-		
-	
-	
-	
-	
-	
-	
+
+
+
+
+
+
+
+
+
 	function render_info_panel($caption, $text)
 	{
 		return "<div class='main_caption bevel left'><b>".$caption."</b></div>
 	    <div class='left block-text' >".$text."</div>";
 	}
-	
-	
-	
-	
-		
+
+
+
+
+
 	function render_infopanel_options($render = false)
 	{
 		$frm = e107::getForm();
 		$mes = e107::getMessage();
 		$ns = e107::getRender();
-		
+
 	    if($render == false){ return ""; }
 
 		$text2 = $ns->tablerender(LAN_PERSONALIZE_ICONS, $this->render_infopanel_icons(),'personalize',true);
@@ -614,7 +614,7 @@ class adminstyle_infopanel
 
 	function render_infopanel_icons()
 	{
-	
+
 		$frm = e107::getForm();
 		$user_pref = $this->getUserPref();
 
@@ -643,8 +643,8 @@ class adminstyle_infopanel
 			);
 			$user_pref['core-infopanel-mye107'] = $defArray;
 		}
-	
-	
+
+
 		foreach ($this->iconlist as $key=>$icon)
 		{
 			if (getperms($icon['perms']))
@@ -652,10 +652,10 @@ class adminstyle_infopanel
 				$checked = (varset($user_pref['core-infopanel-mye107']) && in_array($key, $user_pref['core-infopanel-mye107'])) ? true : false;
 				$text .= "<div class='left f-left list field-spacer form-inline' style='display:block;height:24px;width:200px;'>
 		                        ".$icon['icon'].' '.$frm->checkbox_label($icon['title'], 'e-mye107[]', $key, $checked)."</div>";
-								
+
 			}
 		}
-		
+
 		if (isset($pluglist) && is_array($pluglist))
 		{
 			foreach ($pluglist as $key=>$icon)
@@ -684,12 +684,12 @@ class adminstyle_infopanel
 
 		$frm = e107::getForm();
 		$user_pref = $this->getUserPref();
-		
-	
+
+
 		$text = "<div style='padding-left:20px'>";
 		$menu_qry = 'SELECT * FROM #menus WHERE menu_id!= 0  GROUP BY menu_name ORDER BY menu_name';
 		$settings = varset($user_pref['core-infopanel-menus'],array());
-	
+
 		if (e107::getDb()->gen($menu_qry))
 		{
 			while ($row = e107::getDb()->fetch())
@@ -712,21 +712,21 @@ class adminstyle_infopanel
 				$text .= "</div>";
 			}
 		}
-		
+
 		$text .= "</div><div class='clear'>&nbsp;</div>";
 		return $text;
 	}
-	
 
-	
 
-	
+
+
+
 /*	private function renderStats($type)
 	{
 
 		$data = $this->getStats($type);
 
-		
+
 		$cht = e107::getChart();
 		$cht->setType('line');
 		$cht->setOptions(array(
@@ -735,8 +735,8 @@ class adminstyle_infopanel
 		));
 		$cht->setData($data,'canvas');
 		$text = $cht->render('canvas');
-	
-			
+
+
 		if($type == 'demo')
 		{
 			$text .= "<div class='center'><small>".ADLAN_170."<a class='btn btn-xs btn-mini' href='".e_ADMIN."plugin.php?avail'>".ADLAN_171."</a></small></div>";
@@ -748,10 +748,10 @@ class adminstyle_infopanel
 			<span style='color:rgba(151,187,205,1)'>&diams;</span>".ADLAN_169."
 			</small></div>";
 		}
-		
-		
+
+
 		return $text;
-		
+
 	}*/
 	
 }

--- a/e107_admin/lancheck.php
+++ b/e107_admin/lancheck.php
@@ -382,7 +382,7 @@ class lancheck
 		// Edit the Language File.
 		if($mode == 'edit' && vartrue($file) && !empty($lan) && in_array($lan, $acceptedLans))
 		{
-			
+
 			if (empty($_GET['type']))
 			{
 				$dir1 =  e_LANGUAGEDIR."English/";
@@ -394,13 +394,13 @@ class lancheck
 			{
 				$fullpath_orig = $tp->toDB($file);
 				$fullpath_trans = str_replace("English", $lan, $tp->toDB($file));
-		
-				$f1 = basename($fullpath_orig);
+
+				$f1 = basename((string) $fullpath_orig);
 				$f2 = basename($fullpath_trans);
-				$dir1 = dirname($fullpath_orig)."/";
+				$dir1 = dirname((string) $fullpath_orig)."/";
 				$dir2 = dirname($fullpath_trans)."/";
 			}
-			
+
 			return $this->edit_lanfiles($dir1,$dir2,$f1,$f2,$lan, varset($_GET['type']));
 			// return true;
 		}	
@@ -632,7 +632,7 @@ class lancheck
 
 
 		require_once(e_HANDLER.'pclzip.lib.php');
-		list($ver, $tmp) = explode(" ", e_VERSION);
+		list($ver, $tmp) = explode(" ", (string) e_VERSION);
 		if(!$locale = $this->findLocale($language))
 		{
 			$ret['error'] = TRUE;
@@ -768,7 +768,7 @@ class lancheck
 		{
 			$fullpath = $p['path'].$p['fname'];
 
-			if (strpos($fullpath, $language) !== false)
+			if (strpos($fullpath, (string) $language) !== false)
 			{
 				$pzip[] = $fullpath;
 			}
@@ -869,10 +869,10 @@ class lancheck
 
 		if(!empty($version))
 		{
-			$tmp = explode("-", $version);
+			$tmp = explode("-", (string) $version);
 			$ver = varset($tmp[0]); 
 
-			$feed .= "?ver=". preg_replace('/[^\d\.]/','', $ver);
+			$feed .= "?ver=". preg_replace('/[^\d\.]/','', (string) $ver);
 		}
 
 		e107::getDebug()->log("Language Pack Feed: ".$feed);
@@ -903,11 +903,11 @@ class lancheck
 				$id = $att['name'];
 
 				// fix github double url bug...
-				if (stripos($att['url'], 'https://github.comhttps://github.com') !== false)
+				if (stripos((string) $att['url'], 'https://github.comhttps://github.com') !== false)
 				{
 					$att['url'] = str_ireplace('https://github.comhttps://github.com', 'https://github.com', $att['url']);
 				}
-				if (stripos($att['infourl'], 'https://github.comhttps://github.com') !== false)
+				if (stripos((string) $att['infourl'], 'https://github.comhttps://github.com') !== false)
 				{
 					$att['infourl'] = str_ireplace('https://github.comhttps://github.com', 'https://github.com', $att['infourl']);
 				}
@@ -953,7 +953,7 @@ class lancheck
 			echo "debug: ".__METHOD__." missing \$lan";
 			return false;
 		}
-			
+
 	//	$lan = key($_POST['language_sel']);
 
 		$_SESSION['lancheck'][$lan] = array();
@@ -962,14 +962,14 @@ class lancheck
 		$_SESSION['lancheck'][$lan]['bom']	= 0;
 		$_SESSION['lancheck'][$lan]['utf']	= 0;
 		$_SESSION['lancheck'][$lan]['total']	= 0;
-	
-	
+
+
 		$core_text 	= $this->check_core_lanfiles($lan);
 		$core_admin = $this->check_core_lanfiles($lan,"admin/");
 		$plug_text = "";
 		$theme_text = "";
-	
-	
+
+
 		// Plugins -------------
 		$plug_header = "<table class='table table-striped'>
 		<tr>
@@ -977,7 +977,7 @@ class lancheck
 		<td class='fcaption'>".LAN_CHECK_16."</td>
 		<td class='fcaption'>".$lan."</td>
 		<td class='fcaption'>".LAN_OPTIONS."</td></tr>";
-	
+
 		foreach($this->core_plugins as $plugs)
 		{
 			if(is_readable(e_PLUGIN.$plugs))
@@ -985,9 +985,9 @@ class lancheck
 				$plug_text .= $this->check_lanfiles('P',$plugs,"English",$lan);
 			}
 		}
-		
+
 		$plug_footer = "</table>";
-	
+
 		// Themes  -------------
 		$theme_header = "<table class='table table-striped'>
 		<tr>
@@ -1003,32 +1003,32 @@ class lancheck
 			}
 		}
 		$theme_footer = "</table>";
-		
-		// -------------------------
-		
 
-		
-		
+		// -------------------------
+
+
+
+
 		if($mode != 'render')
 		{
 			 return null;
 		}
-	
+
 		$message = "
 		<form id='lancheck' method='post' action='".e_ADMIN."language.php?mode=main&action=tools'>
 		<div>\n";
-		
+
 	//	$icon = ($_SESSION['lancheck'][$lan]['total']>0) ? ADMIN_FALSE_ICON : ADMIN_TRUE_ICON;
-		
-		
+
+
 		$errors_diz = (deftrue('LAN_CHECK_23')) ? LAN_CHECK_23 : "Errors Found";
 
 		$message .= $errors_diz.": ".$_SESSION['lancheck'][$lan]['total'];
-	
+
 		$just_go_diz = (deftrue('LAN_CHECK_20')) ? LAN_CHECK_20 : "Generate Language Pack";
 		$lang_sel_diz = (deftrue('LAN_CHECK_21')) ? LAN_CHECK_21 : "Verify Again";
 		$lan_pleasewait = (deftrue('LAN_PLEASEWAIT')) ? LAN_PLEASEWAIT : "Please Wait";
-		
+
 		$message .= "
 		<br /><br />
 		<input type='hidden' name='language' value='".$lan."' />
@@ -1038,16 +1038,16 @@ class lancheck
 		</div>
 	    </form>
 		";
-		
+
 //	print_a($_SESSION['lancheck'][$lan]);
 
 		$plug_text = ($plug_text) ? $plug_header.$plug_text.$plug_footer : "<div class='alert alert-success'>".LAN_OK."</div>";
 		$theme_text = ($theme_text) ? $theme_header.$theme_text.$theme_footer : "<div class='alert alert-success'>".LAN_OK."</div>";
 
 		$mesStatus = ($_SESSION['lancheck'][$lan]['total']>0) ? E_MESSAGE_INFO : E_MESSAGE_SUCCESS;
-			
+
 		$mes->add($message, $mesStatus);	
-			
+
 	//	$ns -> tablerender(LAN_SUMMARY.": ".$lan,$message);
 
 
@@ -1151,11 +1151,11 @@ class lancheck
 		{
 			$notdef_start = "";
 			$notdef_end = "\n";
-			$deflang = (MAGIC_QUOTES_GPC === TRUE) ? stripslashes($_POST['newlang'][$i]) : $_POST['newlang'][$i];
+			$deflang = (MAGIC_QUOTES_GPC === TRUE) ? stripslashes((string) $_POST['newlang'][$i]) : $_POST['newlang'][$i];
 			$func = "define";
 			$quote = chr(34);
 	
-			if (strpos($_POST['newdef'][$i],"ndef++") !== FALSE )
+			if (strpos((string) $_POST['newdef'][$i],"ndef++") !== FALSE )
 			{
 				$defvar = str_replace("ndef++","",$_POST['newdef'][$i]);
 				$notdef_start = "if (!defined(".chr(34).$defvar.chr(34).")) {";
@@ -1173,12 +1173,12 @@ class lancheck
 	
 			if($_POST['newdef'][$i] == "LC_ALL" && vartrue($_SESSION['lancheck-edit-file']))
 			{
-				$message .= $notdef_start.'setlocale('.htmlentities($defvar).','.$deflang.');<br />'.$notdef_end;
+				$message .= $notdef_start.'setlocale('.htmlentities((string) $defvar).','.$deflang.');<br />'.$notdef_end;
 				$input .= $notdef_start."setlocale(".$defvar.",".$deflang.");".$notdef_end;
 			}
 			else
 			{
-				$message .= $notdef_start.$func.'('.$quote.htmlentities($defvar).$quote.',"'.$deflang.'");<br />'.$notdef_end;
+				$message .= $notdef_start.$func.'('.$quote.htmlentities((string) $defvar).$quote.',"'.$deflang.'");<br />'.$notdef_end;
 				$input .= $notdef_start.$func."(".$quote.$defvar.$quote.", ".chr(34).$deflang.chr(34).");".$notdef_end;
 			}
 		}
@@ -1355,7 +1355,7 @@ class lancheck
 		$error = array();
 		$warning = array();
 			
-		if((is_array($translation) && !array_key_exists($def,$translation) && $eng_line != "") || (trim($trans_line) == "" && $eng_line != ""))
+		if((is_array($translation) && !array_key_exists($def,$translation) && $eng_line != "") || (trim((string) $trans_line) == "" && $eng_line != ""))
 		{
 			$this->checkLog('def',1);
 			return $def.": ".LAN_CHECK_5."<br />";
@@ -1366,33 +1366,33 @@ class lancheck
 			$warning[] = "<span class='text-warning'>".$def. ": ".LAN_CHECK_29."</span>";
 		}
 		
-		if((strpos($eng_line,"[link=")!==FALSE && strpos($trans_line,"[link=")===FALSE) || (strpos($eng_line,"[b]")!==FALSE && strpos($trans_line,"[b]")===FALSE))
+		if((strpos((string) $eng_line,"[link=")!==FALSE && strpos((string) $trans_line,"[link=")===FALSE) || (strpos((string) $eng_line,"[b]")!==FALSE && strpos((string) $trans_line,"[b]")===FALSE))
 		{
 			$error[] = $def. ": ".LAN_CHECK_30;
 		}
-		elseif((strpos($eng_line,"[")!==FALSE && strpos($trans_line,"[")===FALSE) || (strpos($eng_line,"]")!==FALSE && strpos($trans_line, "]")===FALSE))
+		elseif((strpos((string) $eng_line,"[")!==FALSE && strpos((string) $trans_line,"[")===FALSE) || (strpos((string) $eng_line,"]")!==FALSE && strpos((string) $trans_line, "]")===FALSE))
 		{
 			$error[] = $def. ": ".LAN_CHECK_31;
 		}
 		
-		if((strpos($eng_line,"--LINK--")!==false && strpos($trans_line,"--LINK--")===false))
+		if((strpos((string) $eng_line,"--LINK--")!==false && strpos((string) $trans_line,"--LINK--")===false))
 		{
 			$error[] = $def. ": Missing --LINK--";
 		}
 		
-		if((strpos($eng_line,"e107.org")!==false && strpos($trans_line,"e107.org")===false))
+		if((strpos((string) $eng_line,"e107.org")!==false && strpos((string) $trans_line,"e107.org")===false))
 		{
 			$error[] = $def. ": Missing e107.org URL";
 		}
 		
-		if((strpos($eng_line,"e107coders.org")!==FALSE && strpos($trans_line,"e107coders.org")===false))
+		if((strpos((string) $eng_line,"e107coders.org")!==FALSE && strpos((string) $trans_line,"e107coders.org")===false))
 		{
 			$error[] = $def. ": Missing e107coders.org URL";
 		}
 		
-		if(strip_tags($eng_line) != $eng_line)
+		if(strip_tags((string) $eng_line) != $eng_line)
 		{
-			$stripped = strip_tags($trans_line);
+			$stripped = strip_tags((string) $trans_line);
 					
 			if(($stripped == $trans_line))
 			{					
@@ -1497,12 +1497,12 @@ class lancheck
 
 
 
-		if(strpos($comp_dir,e_LANGUAGEDIR) !== false)
+		if(strpos((string) $comp_dir,e_LANGUAGEDIR) !== false)
 		{
 			$regexp = "#.php#";
 			$mode = 'core';
 		}
-		elseif(strpos($comp_dir,e_THEME) !== false)
+		elseif(strpos((string) $comp_dir,e_THEME) !== false)
 		{
 			$regexp = "#".$lang."#";
 			$mode = 'themes';
@@ -1769,19 +1769,19 @@ class lancheck
 			$dir1 = e_THEME.$dir1;
 			$dir2 = e_THEME.$dir2;
 		}
-		
+
 	//	$ns = e107::getRender();
 		$sql = e107::getDb();
 
-	
+
 		/*    echo "<br />dir1 = $dir1";
 		echo "<br />file1 = $f1";
-	
+
 		echo "<br />dir2 = $dir2";
 		echo "<br />file2 = $f2";*/
-		
-	
-	
+
+
+
 		if($dir2.$f2 == e_LANGUAGEDIR.$lan."/English.php") // it's a language config file.
 		{
 			$f2 = $lan.".php";
@@ -1791,7 +1791,7 @@ class lancheck
 		{
 			$root_file = $dir2.$f2;
 		}
-	
+
 		if($dir2.$f2 == e_LANGUAGEDIR.$lan."/English_custom.php") // it's a language config file.
 		{
 			$f2 = $lan."_custom.php";
@@ -1810,7 +1810,7 @@ class lancheck
 
 		$keys = array_keys($trans);
 		sort($keys);
-	
+
 		$text = "<div style='text-align:center'>
 		<form method='post' action='".e_SELF."?".e_QUERY."' id='transform'>
 		<table class='table table-striped'>
@@ -1821,11 +1821,11 @@ class lancheck
 			<th>".$lan."</th>
 		</tr>
 		</thead><tbody>";
-	
+
 		$subkeys = array_keys($trans['orig']);
 		foreach($subkeys as $sk)
 		{
-			$rowamount = round(strlen($trans['orig'][$sk])/34)+1;
+			$rowamount = round(strlen((string) $trans['orig'][$sk])/34)+1;
 			$hglt1=""; $hglt2="";
 			if(empty($trans['tran'][$sk]) && !empty($trans['orig'][$sk]))
 			{
@@ -1838,14 +1838,14 @@ class lancheck
 				$hglt2="</span>";
 			}
 			$text .="<tr>
-			<td style='width:10%;vertical-align:top'>".$hglt1.htmlentities($sk).$hglt2."</td>
+			<td style='width:10%;vertical-align:top'>".$hglt1.htmlentities((string) $sk).$hglt2."</td>
 			<td style='width:40%;vertical-align:top'>".htmlentities(str_replace("ndef++","",$trans['orig'][$sk])) ."</td>";
 			$text .= "<td class='forumheader3' style='width:50%;vertical-align:top'>";
 			$text .= ($writable) ? "<textarea  class='input-xxlarge' name='newlang[]' rows='$rowamount' cols='45' style='height:100%'>" : "";
 			$text .= htmlentities(str_replace("ndef++","", varset($trans['tran'][$sk])));
 			$text .= ($writable) ? "</textarea>" : "";
 			//echo "orig --> ".$trans['orig'][$sk]."<br />";
-			if (strpos($trans['orig'][$sk],"ndef++") !== false)
+			if (strpos((string) $trans['orig'][$sk],"ndef++") !== false)
 			{
 				//echo "+orig --> ".$trans['orig'][$sk]." <> ".strpos($trans['orig'][$sk],"ndef++")."<br />";
 				$text .= "<input type='hidden' name='newdef[]' value='ndef++".$sk."' />";
@@ -1856,39 +1856,39 @@ class lancheck
 			}
 			$text .="</td></tr>";
 		}
-	
+
 		unset($_SESSION['lancheck-edit-file']);
-	
+
 		//Check if directory is writable
-		
+
 		$text .= "</tbody></table>";
-		
+
 		if($writable)
 		{
 			$text .= '<div class="buttons-bar center">
 			<input type="hidden" name="lan" value="'.$lan.'" />
 			<button id="etrigger-submit" class="btn btn-warning" type="submit" name="saveLanguageFile" value="1" >'.LAN_SAVE.' '.str_replace($dir2,'',$root_file).'</button>
 			</div>';
-	
+
 			if($root_file)
 			{			
 				$_SESSION['lancheck-edit-file'] = $root_file;
 			}
-	
-			
+
+
 		}
-	
+
 		$text .= "
-		
+
 		</form>
 		</div>";
-	
+
 		$text .= "<form method='post' action='".e_SELF."?tools' id='select_lang'>
 		<div style='text-align:center'><br />";
 		$text .= (!$writable) ? "<br />".$dir2.$f2.LAN_NOTWRITABLE : "";
 	//	$text .= "<br /><br /><input class='btn' type='submit' name='language_sel[{$lan}]' value=\"".LAN_BACK."\" />";
 		$text .= "</div></form>";
-	
+
 		$capFile = str_replace("../","",$dir2.$f2);
 		$caption = LANG_LAN_21.SEP.$lan.SEP.LAN_CHECK_2.SEP.LAN_EDIT.SEP.$capFile;
 
@@ -1904,35 +1904,35 @@ class lancheck
 	function fill_phrases_array($data,$type)
 	{	
 		$retloc = array();
-		
-		if(preg_match_all('/(\/\*[\s\S]*?\*\/)/i',$data, $multiComment))
+
+		if(preg_match_all('/(\/\*[\s\S]*?\*\/)/i',(string) $data, $multiComment))
 		{
 			$data = str_replace($multiComment[1],'',$data);	// strip multi-line comments. 	
 		}
-					
-		if(preg_match('/^\s*?setlocale\s*?\(\s*?([\w]+)\s*?,\s*?(.+)\s*?\)\s*?;/im',$data,$locale)) // check for setlocale();
+
+		if(preg_match('/^\s*?setlocale\s*?\(\s*?([\w]+)\s*?,\s*?(.+)\s*?\)\s*?;/im',(string) $data,$locale)) // check for setlocale();
 		{
 			$retloc[$type][$locale[1]]= $locale[2];	
 		}
-				
-		if(preg_match_all('/^\s*?define\s*?\(\s*?(\'|\")([\w]+)(\'|\")\s*?,\s*?(\'|\")([\s\S]*?)\s*?(\'|\")\s*?\)\s*?;/imu',$data,$matches))
+
+		if(preg_match_all('/^\s*?define\s*?\(\s*?(\'|\")([\w]+)(\'|\")\s*?,\s*?(\'|\")([\s\S]*?)\s*?(\'|\")\s*?\)\s*?;/imu',(string) $data,$matches))
 		{
 			$def = $matches[2];
 			$values = $matches[5];	
-	
+
 			foreach($def as $k=>$d)
 			{
 				$retloc[$type][$d]= $values[$k];
 			}	
 		}
-			
+
 		return $retloc;
-		
+
 		/*
 		echo "<h2>Raw Data ".$type."</h2><pre>";
 		echo htmlentities($data);
 		echo "</pre>";	
-	
+
 		*/
 			
 	}
@@ -1951,7 +1951,7 @@ class lancheck
 			return TRUE;
 		}
 	
-		return (preg_match('/^./us',$str,$ar) == 1);
+		return (preg_match('/^./us',(string) $str,$ar) == 1);
 	}
 	
 

--- a/e107_admin/language.php
+++ b/e107_admin/language.php
@@ -271,7 +271,7 @@ if(!empty($_GET['iframe']))
 		//	if(is_readable(e_ADMIN."ver.php"))
 			{
 			//	include(e_ADMIN."ver.php");
-				list($ver, $tmp) = explode(" ", e_VERSION);
+				list($ver, $tmp) = explode(" ", (string) e_VERSION);
 			}
 
 			$lck = e107::getSingleton('lancheck', e_ADMIN."lancheck.php");
@@ -438,7 +438,7 @@ if(!empty($_GET['iframe']))
 					<td class='text-left'>".$value['date']."</td>
 					<td class='text-left'>".$value['version'];
 
-					if(strpos($value['tag'],'-') !==false)
+					if(strpos((string) $value['tag'],'-') !==false)
 					{
 						$text .= " <span class='label label-warning'>".LANG_LAN_153."</span>";
 					}
@@ -505,7 +505,7 @@ if(!empty($_GET['iframe']))
 			// ----------------- delete tables ---------------------------------------------
 			if (isset($_POST['del_existing']) && $_POST['lang_choices'] && getperms('0'))
 			{
-				$lang = strtolower($_POST['lang_choices']);
+				$lang = strtolower((string) $_POST['lang_choices']);
 
 				$_POST['lang_choices'] = e107::getParser()->filter($_POST['lang_choices'],'w');
 
@@ -543,7 +543,7 @@ if(!empty($_GET['iframe']))
 
 				foreach ($tabs as $value)
 				{
-					$lang = strtolower($_POST['language']);
+					$lang = strtolower((string) $_POST['language']);
 					if (isset($_POST[$value]))
 					{
 						$copdata = ($_POST['copydata_'.$value]) ? 1 : 0;
@@ -916,7 +916,7 @@ class lanDeveloper
 				$mes->addError(LANG_LAN_136.$disUnusedLanFile);//Couldn't overwrite
 			}
 
-			$ns->tablerender(LANG_LAN_137.SEP.$disUnusedLanFile,$mes->render()."<pre>".htmlentities($new)."</pre>");//Processed
+			$ns->tablerender(LANG_LAN_137.SEP.$disUnusedLanFile,$mes->render()."<pre>".htmlentities((string) $new)."</pre>");//Processed
 		}
 
 
@@ -940,17 +940,17 @@ class lanDeveloper
 
 			foreach($script as $k=>$scr)
 			{
-				if(strpos($scr,e_ADMIN)!==false) // CORE
+				if(strpos((string) $scr,e_ADMIN)!==false) // CORE
 				{
 					$mes->addDebug("Mode: Core Admin Calculated");
 					//$scriptname = str_replace("lan_","",basename($lanfile));
-					$lanfile[$k] = e_LANGUAGEDIR.e_LANGUAGE."/admin/lan_".basename($scr);
+					$lanfile[$k] = e_LANGUAGEDIR.e_LANGUAGE."/admin/lan_".basename((string) $scr);
 					$this->adminFile = true;
 				}
 				else  // Root
 				{
 					$mes->addDebug("Mode: Search Core Root lan calculated");
-					$lanfile[$k] = e_LANGUAGEDIR.e_LANGUAGE."/lan_".basename($scr);
+					$lanfile[$k] = e_LANGUAGEDIR.e_LANGUAGE."/lan_".basename((string) $scr);
 					$lanfile[$k] = str_replace("lan_install", "lan_installer", $lanfile[$k]); //quick fix.,
 
 					//$lanfile = $this->findIncludedFiles($script,vartrue($_POST['deprecatedLansReverse']));
@@ -1034,12 +1034,12 @@ class lanDeveloper
 			return array('define'=>$line,'value'=>'-');
 		}
 
-		if(preg_match("#\"(.*?)\".*?\"(.*)\"#",$line,$match) ||
-			preg_match("#\'(.*?)\'.*?\"(.*)\"#",$line,$match) ||
-			preg_match("#\"(.*?)\".*?\'(.*)\'#",$line,$match) ||
-			preg_match("#\'(.*?)\'.*?\'(.*)\'#",$line,$match) ||
-			preg_match("#\((.*?)\,.*?\"(.*)\"#",$line,$match) ||
-			preg_match("#\((.*?)\,.*?\'(.*)\'#",$line,$match))
+		if(preg_match("#\"(.*?)\".*?\"(.*)\"#",(string) $line,$match) ||
+			preg_match("#\'(.*?)\'.*?\"(.*)\"#",(string) $line,$match) ||
+			preg_match("#\"(.*?)\".*?\'(.*)\'#",(string) $line,$match) ||
+			preg_match("#\'(.*?)\'.*?\'(.*)\'#",(string) $line,$match) ||
+			preg_match("#\((.*?)\,.*?\"(.*)\"#",(string) $line,$match) ||
+			preg_match("#\((.*?)\,.*?\'(.*)\'#",(string) $line,$match))
 		{
 
 			return array('define'=>$match[1],'value'=>$match[2]);
@@ -1106,7 +1106,7 @@ class lanDeveloper
 
 		foreach($lans as $script => $lan)
 		{
-			if(in_array(basename($lan), $exclude))
+			if(in_array(basename((string) $lan), $exclude))
 			{
 				continue;
 			}
@@ -1121,7 +1121,7 @@ class lanDeveloper
 
 		foreach($root as $script => $lan)
 		{
-			if(in_array(basename($lan), $exclude))
+			if(in_array(basename((string) $lan), $exclude))
 			{
 				continue;
 			}
@@ -1135,7 +1135,7 @@ class lanDeveloper
 		$text .= "<optgroup label='" . LAN_TEMPLATES . "'>";
 		foreach($templates as $script => $lan)
 		{
-			if(in_array(basename($lan), $exclude))
+			if(in_array(basename((string) $lan), $exclude))
 			{
 				continue;
 			}
@@ -1148,7 +1148,7 @@ class lanDeveloper
 		$text .= "<optgroup label='" . LAN_SHORTCODES . "'>";
 		foreach($shortcodes as $script => $lan)
 		{
-			if(in_array(basename($lan), $exclude))
+			if(in_array(basename((string) $lan), $exclude))
 			{
 				continue;
 			}
@@ -1182,7 +1182,7 @@ class lanDeveloper
 		asort($_SESSION['languageTools_lanFileList']);
 		foreach($_SESSION['languageTools_lanFileList'] as $val)
 		{
-			if(strpos($val, e_SYSTEM) !== false)
+			if(strpos((string) $val, e_SYSTEM) !== false)
 			{
 				continue;
 			}
@@ -1250,7 +1250,7 @@ class lanDeveloper
 		foreach($haystack as $file => $content)
 		{
 			$count = 1;
-			$lines = explode("\n",$content);
+			$lines = explode("\n",(string) $content);
 			foreach($lines as $ln)
 			{
 				if(preg_match("/\b".$needle."\b/i",$ln, $mtch))
@@ -1290,9 +1290,9 @@ class lanDeveloper
 		// Check if a common phrases was used.
 		foreach($ar as $def=>$common)
 		{
-			similar_text($value, $common, $p);
+			similar_text((string) $value, (string) $common, $p);
 
-			if(strtoupper(trim($value)) == strtoupper($common))
+			if(strtoupper(trim((string) $value)) == strtoupper((string) $common))
 			{
 				//$text .= "<div style='color:yellow'><b>$common</b></div>";
 
@@ -1404,7 +1404,7 @@ class lanDeveloper
 			// return "<tr><td style='width:25%;'>".$needle .$disabled. "</td><td></td></tr>";
 		}
 
-		elseif($foundSimilar && $found && substr($def,0,4) == "LAN_")
+		elseif($foundSimilar && $found && substr((string) $def,0,4) == "LAN_")
 		{
 			// $color = "background-color:#E9EAF2";
 			$label .= "  <span class='label label-warning' style='cursor:help' title=\"".$common."\">".round($p)."% like ".$def."</span> ";
@@ -1644,12 +1644,12 @@ class lanDeveloper
 			$reverse = false;
 		}
 
-		$dir = dirname($script);
+		$dir = dirname((string) $script);
 
 		$dir = str_replace("/includes","",$dir);
 		$plugin = basename($dir);
 
-		if(strpos($script,'admin')!==false || strpos($script,'includes')!==false) // Admin Language files.
+		if(strpos((string) $script,'admin')!==false || strpos((string) $script,'includes')!==false) // Admin Language files.
 		{
 
 			$newLangs = array(

--- a/e107_admin/links.php
+++ b/e107_admin/links.php
@@ -585,9 +585,9 @@ class links_model_admin_tree extends e_admin_tree_model
 	
 	function bcClean($link_name)
 	{
-		if(substr($link_name, 0,8) == 'submenu.') // BC Fix. 
+		if(substr((string) $link_name, 0,8) == 'submenu.') // BC Fix. 
 		{
-			list($tmp,$tmp2,$link) = explode('.', $link_name, 3);	
+			list($tmp,$tmp2,$link) = explode('.', (string) $link_name, 3);	
 		}
 		else
 		{
@@ -789,7 +789,7 @@ class links_admin_form_ui extends e_admin_form_ui
 
 			foreach($config as $k=>$v)
 			{
-				if($k == 'index' || (strpos($v['regex'],'(') === false)) // only provide urls without dynamic elements.
+				if($k == 'index' || (strpos((string) $v['regex'],'(') === false)) // only provide urls without dynamic elements.
 				{
 					$opts[] = $k;
 				}
@@ -809,7 +809,7 @@ class links_admin_form_ui extends e_admin_form_ui
 			$owner = $this->getController()->getListModel()->get('link_owner');
 			$sef =  $this->getController()->getListModel()->get('link_sefurl');
 
-			if($curVal[0] !== '{' && substr($curVal,0,4) != 'http' && $mode == 'link_id')
+			if($curVal[0] !== '{' && substr((string) $curVal,0,4) != 'http' && $mode == 'link_id')
 			{
 				$curVal = '{e_BASE}'.$curVal;
 			}
@@ -895,7 +895,7 @@ class links_admin_form_ui extends e_admin_form_ui
 
 		foreach ($search[$parent_id] as $id => $title)
 		{
-			$src[$id] = str_repeat($strpad, $level).($level != 0 ? '-&nbsp;' : '').$title;
+			$src[$id] = str_repeat((string) $strpad, $level).($level != 0 ? '-&nbsp;' : '').$title;
 			$this->_parent_select_array($id, $search, $src, $strpad, $level + 1);
 		}
 	}

--- a/e107_admin/mailout.php
+++ b/e107_admin/mailout.php
@@ -572,7 +572,7 @@ class mailout_main_ui extends e_admin_ui
 		$mes = e107::getMessage();
 		$pref = e107::getPref();
 		
-		if(trim($_POST['testaddress']) == '')
+		if(trim((string) $_POST['testaddress']) == '')
 		{
 			$mes->addError(LAN_MAILOUT_19);
 			return null;
@@ -583,7 +583,7 @@ class mailout_main_ui extends e_admin_ui
 			$pref['bulkmailer'] = $pref['mailer'];
 		}
 
-		$add = ($pref['bulkmailer']) ? " (".strtoupper($pref['bulkmailer']).") " : ' (PHP)';
+		$add = ($pref['bulkmailer']) ? " (".strtoupper((string) $pref['bulkmailer']).") " : ' (PHP)';
 
 		if($pref['bulkmailer'] == 'smtp')
 		{
@@ -591,7 +591,7 @@ class mailout_main_ui extends e_admin_ui
 			$add .= " - ".str_replace("secure=", "", $pref['smtp_options']);
 		}
 
-		$sendto = trim($_POST['testaddress']);
+		$sendto = trim((string) $_POST['testaddress']);
 
 		$subjectSitename = ($_POST['testtemplate'] == 'textonly') ? SITENAME : '';
 			
@@ -798,7 +798,7 @@ class mailout_main_ui extends e_admin_ui
 		if(is_numeric($id))
 		{
 			$mailData = e107::getDb()->retrieve('mail_content','*','mail_source_id='.intval($id)." LIMIT 1");
-			
+
 			$shortcodes = array(
 				'USERNAME'          => 'John Example',
 			    'DISPLAYNAME'       => 'John Example',
@@ -813,7 +813,7 @@ class mailout_main_ui extends e_admin_ui
 			if(!empty($user))
 			{
 				$userData = e107::getDb()->retrieve('mail_recipients','*', 'mail_detail_id = '.intval($id).' AND mail_recipient_id = '.intval($user).' LIMIT 1');
-				$shortcodes = e107::unserialize(stripslashes($userData['mail_target_info']));
+				$shortcodes = e107::unserialize(stripslashes((string) $userData['mail_target_info']));
 			}
 
 			if(!isset($shortcodes['MAILREF']))
@@ -821,9 +821,9 @@ class mailout_main_ui extends e_admin_ui
 				$shortcodes['MAILREF'] =  intval($_GET['id']);
 			}
 
-						
+
 			$data = $this->mailAdmin->dbToMail($mailData);
-	
+
 			$eml = array(
 				'subject'		=> $data['mail_subject'],
 				'body' 			=> $data['mail_body'],
@@ -831,7 +831,7 @@ class mailout_main_ui extends e_admin_ui
 				'shortcodes'	=> $shortcodes,
 				'media'			=> $data['mail_media'],
 			);
-			
+
 		//	return print_a($data,true);
 		}
 		else
@@ -926,7 +926,7 @@ class mailout_main_ui extends e_admin_ui
 		$other['mail_selectors'] = $this->mailAdmin->getAllSelectors();
 		
 		
-		$ret['mail_attach']			= trim($new_data['mail_attach']);
+		$ret['mail_attach']			= trim((string) $new_data['mail_attach']);
 		$ret['mail_send_style'] 	= varset($new_data['mail_send_style'],'textonly');
 		$ret['mail_include_images'] = (isset($new_data['mail_include_images']) ? 1 : 0);
 		$ret['mail_other'] 			= $other;		// type is set to 'array' in $fields. 	
@@ -1117,11 +1117,11 @@ class mailout_main_ui extends e_admin_ui
 		{
 			return;
 		}
-		
+
 		$mes = e107::getMessage();
 		$ns = e107::getRender();
 		$frm = e107::getForm();
-		
+
 		$text = "
 				<form action='".e_SELF."?mode=maint' id='email_maint' method='post'>
 				<fieldset id='email-maint'>
@@ -1130,17 +1130,17 @@ class mailout_main_ui extends e_admin_ui
 					<col class='col-label' />
 					<col class='col-control' />
 				</colgroup>
-				
+
 				<tbody>";
 
 		$text .= "<tr><td>".LAN_MAILOUT_182."</td><td>
-		
+
 		".$frm->admin_button('email_dross','no-value','delete', LAN_RUN)."
 		<br /><span class='field-help'>".LAN_MAILOUT_252."</span></td></tr>";
 		$text .= "</tbody></table>\n</fieldset></form>";
 
 		return $text;
-		
+
 		// return $ns->tablerender(ADLAN_136.SEP.ADLAN_40, $text, 'maint',true);
 		
 	}
@@ -1156,7 +1156,7 @@ class mailout_main_ui extends e_admin_ui
 	$frm = e107::getForm();
 	$mes = e107::getMessage();
 	$ns = e107::getRender();
-	
+
 	if($pref['mail_bounce'] == 'auto' && !empty($pref['mail_bounce_email']) && !is_executable(e_HANDLER."bounce_handler.php"))
 	{
 		$mes->addWarning('Your bounce_handler.php file is NOT executable');	
@@ -1166,7 +1166,7 @@ class mailout_main_ui extends e_admin_ui
 	e107::getCache()->CachePageMD5 = '_';
 	$lastload = e107::getCache()->retrieve('emailLastBounce',FALSE,TRUE,TRUE);
 	$lastBounce = round((time() - $lastload) / 60);
-	
+
 	$lastBounceText = ($lastBounce > 1256474) ? "<span class='label label-important label-danger'>Never</span>" : "<span class='label label-success'>".$lastBounce . " minutes ago.</span>";
 
 	$text = "
@@ -1190,9 +1190,9 @@ class mailout_main_ui extends e_admin_ui
 		<tr>
 		<td>".LAN_MAILOUT_77."</td>
 		<td> ";
-		
-		$mail_enable = explode(',',vartrue($pref['mailout_enabled'],'core'));
-		
+
+		$mail_enable = explode(',',(string) vartrue($pref['mailout_enabled'],'core'));
+
 		$coreCheck = (in_array('core',$mail_enable)) ? "checked='checked'" : "";
 	//	$text .= $frm->checkbox('mail_mailer_enabled[]','core', $coreCheck, 'users');
 
@@ -1211,16 +1211,16 @@ class mailout_main_ui extends e_admin_ui
 
 
 		$text .= "</td></tr>
-		
-		
+
+
 		<tr>
 		<td style='vertical-align:top'>".LAN_MAILOUT_115."<br /></td>
 		<td>";
 
 
 		$text .= mailoutAdminClass::mailerPrefsTable($pref, 'bulkmailer');
-		
-	
+
+
 	/* FIXME - posting SENDMAIL path triggers Mod-Security rules. 
 	// Sendmail. -------------->
 		$senddisp = ($pref['mailer'] != 'sendmail') ? "style='display:none;'" : '';
@@ -1232,7 +1232,7 @@ class mailout_main_ui extends e_admin_ui
 		<input class='tbox' type='text' name='sendmail' size='60' value=\"".(!$pref['sendmail'] ? "/usr/sbin/sendmail -t -i -r ".$pref['siteadminemail'] : $pref['sendmail'])."\" maxlength='80' />
 		</td>
 		</tr>
-	
+
 		</table></div>";
 	*/
 
@@ -1249,7 +1249,7 @@ class mailout_main_ui extends e_admin_ui
 		</td>
 	</tr>\n
 
-	
+
 	<tr>
 		<td>".LAN_MAILOUT_25."</td>
 		<td class='form-inline'> ".LAN_MAILOUT_26." ".$frm->number('mail_pause', $pref['mail_pause'])." ".LAN_MAILOUT_27." ".
@@ -1257,23 +1257,23 @@ class mailout_main_ui extends e_admin_ui
 		<span class='field-help'>".LAN_MAILOUT_30."</span>
 		</td>
 	</tr>\n
-	
+
 	<tr>
 		<td>".LAN_MAILOUT_156."</td>
 		<td>".$frm->number('mail_workpertick',varset($pref['mail_workpertick'],5))."<span class='field-help'>".LAN_MAILOUT_157."</span>
 		</td>
 	</tr>
-	
-	
+
+
 	";
 
-	list($mail_log_option,$mail_log_email) = explode(',',varset($pref['mail_log_options'],'0,0'));
-	
+	list($mail_log_option,$mail_log_email) = explode(',',(string) varset($pref['mail_log_options'],'0,0'));
+
 	$check = ($mail_log_email == 1) ? " checked='checked'" : "";
-	
-	
+
+
 	$logOptions = array(LAN_MAILOUT_73,LAN_MAILOUT_74,LAN_MAILOUT_75,LAN_MAILOUT_119);
-	
+
 	$text .= "<tr>
 		<td>".LAN_MAILOUT_72."</td>
 		<td class='form-inline'>
@@ -1316,7 +1316,7 @@ class mailout_main_ui extends e_admin_ui
 		<tbody>
 	<tr>
 		<td>".LAN_MAILOUT_231."</td><td>";
-		
+
 	// bounce divs = mail_bounce_none, mail_bounce_auto, mail_bounce_mail
 	$autoDisp = ($pref['mail_bounce'] != 'auto') ? "style='display:none;'" : '';
 	$autoMail = ($pref['mail_bounce'] != 'mail') ? "style='display:none;'" : '';
@@ -1340,20 +1340,20 @@ class mailout_main_ui extends e_admin_ui
 		<tr>
 			<td>".LAN_EMAIL."</td>
 			<td><div class='input-append'>".$frm->text('mail_bounce_email2', $pref['mail_bounce_email'], 40, 'size=xlarge');
-			
+
 			if(!empty($pref['mail_bounce_email']))
 			{
 				$text .= $frm->admin_button('send_bounce_test','Send Test','primary','Test');	
 			}
-			
+
 			$text .= "</div></td>
 		</tr>
-	
+
 	<tr>
 		<td>".LAN_MAILOUT_233."</td><td><b>".(e_ROOT).e107::getFolder('handlers')."bounce_handler.php</b>";
-	
+
 	$status = '';
-	
+
 	if(!is_readable(e_HANDLER.'bounce_handler.php'))
 	{
 		$status = LAN_MAILOUT_161;
@@ -1363,17 +1363,17 @@ class mailout_main_ui extends e_admin_ui
 		$status = LAN_MAILOUT_162;
 	}
 
-	
+
 	if(!empty($status))
 	{
 		$text .= "&nbsp;&nbsp;<span class='label label-warning'>".$status."</span>"; 
 	}
-			
-		
-	
+
+
+
 	$text .= "<div>".LAN_MAILOUT_235."</div>
-	
-	
+
+
 	</td></tr>
 	<tr><td>".LAN_MAILOUT_236."</td><td>".$lastBounceText."</td></tr>";
 
@@ -1392,14 +1392,14 @@ class mailout_main_ui extends e_admin_ui
 			<col class='col-control' />
 		</colgroup>
 		<tbody>";
-	
+
 	$bouncePrefs = array('mail_bounce_email'=>LAN_EMAIL, 'mail_bounce_pop3'=>LAN_MAILOUT_33, 'mail_bounce_user'=>LAN_MAILOUT_34, 'mail_bounce_pass'=>LAN_PASSWORD);
-	
+
 	foreach($bouncePrefs as $key =>$label)
 	{
 		$text .= "<tr><td>".$label."</td><td>".$frm->text($key,$pref[$key],40,'size=xlarge')."</td></tr>";
 	}	
-	
+
 	/*	
 	$text .= "
 		<tr><td>".LAN_MAILOUT_32."</td><td><input class='tbox' size='40' type='text' name='mail_bounce_email' value=\"".$pref['mail_bounce_email']."\" /></td></tr>
@@ -1408,7 +1408,7 @@ class mailout_main_ui extends e_admin_ui
 		<tr><td>".LAN_PASSWORD."</td><td><input class='tbox' size='40' type='text' name='mail_bounce_pass' value=\"".$pref['mail_bounce_pass']."\" /></td></tr>
 	";
 	*/
-		
+
 	$text .= "	
 		<tr><td>".LAN_MAILOUT_120."</td><td><select class='tbox' name='mail_bounce_type'>\n
 			<option value=''>&nbsp;</option>\n
@@ -1470,7 +1470,7 @@ class mailout_main_ui extends e_admin_ui
 		//$temp['mailer'] = $_POST['mailer'];
 
 		// Allow qmail as an option as well - works much as sendmail
-		if ((strpos($_POST['sendmail'],'sendmail') !== FALSE) || (strpos($_POST['sendmail'],'qmail') !== FALSE))
+		if ((strpos((string) $_POST['sendmail'],'sendmail') !== FALSE) || (strpos((string) $_POST['sendmail'],'qmail') !== FALSE))
 		{
 			$temp['sendmail'] = $tp->toDB($_POST['sendmail']);
 		}
@@ -1480,13 +1480,13 @@ class mailout_main_ui extends e_admin_ui
 		}
 
 		$temp['bulkmailer']     = $tp->filter($_POST['bulkmailer']);
-		$temp['smtp_server'] 	= $tp->toDB(trim($_POST['smtp_server']));
-		$temp['smtp_username'] 	= $tp->toDB(trim($_POST['smtp_username']));
-		$temp['smtp_password'] 	= $tp->toDB(trim($_POST['smtp_password']));
+		$temp['smtp_server'] 	= $tp->toDB(trim((string) $_POST['smtp_server']));
+		$temp['smtp_username'] 	= $tp->toDB(trim((string) $_POST['smtp_username']));
+		$temp['smtp_password'] 	= $tp->toDB(trim((string) $_POST['smtp_password']));
 		$temp['smtp_port'] 	    = intval($_POST['smtp_port']);
 	
 		$smtp_opts = array();
-		switch (trim($_POST['smtp_options']))
+		switch (trim((string) $_POST['smtp_options']))
 		{
 		  case 'smtp_ssl' :
 		    $smtp_opts[] = 'secure=SSL';
@@ -1571,7 +1571,7 @@ class mailout_admin_form_ui extends e_admin_form_ui
 	
 	public function mail_selectors($curval, $mode)
 	{
-		$val 	= stripslashes($this->getController()->getModel()->get('mail_other'));		
+		$val 	= stripslashes((string) $this->getController()->getModel()->get('mail_other'));		
 		$data 	= e107::unserialize($val);
 		
 		switch($mode)
@@ -1599,7 +1599,7 @@ class mailout_admin_form_ui extends e_admin_form_ui
 	
 	public function mail_send_style($curVal, $mode)
 	{
-		$val 	= stripslashes($this->getController()->getModel()->get('mail_other'));		
+		$val 	= stripslashes((string) $this->getController()->getModel()->get('mail_other'));		
 		$data 	= e107::unserialize($val);
 		
 		switch($mode)
@@ -1629,13 +1629,13 @@ class mailout_admin_form_ui extends e_admin_form_ui
 		switch($mode)
 		{
 			case 'read':
-				$val 	= stripslashes($this->getController()->getListModel()->get('mail_other'));		
+				$val 	= stripslashes((string) $this->getController()->getListModel()->get('mail_other'));		
 				$data 	= e107::unserialize($val);
 				return $data[$field];
 			break;
 
 			case 'write':
-				$val 	= stripslashes($this->getController()->getModel()->get('mail_other'));		
+				$val 	= stripslashes((string) $this->getController()->getModel()->get('mail_other'));		
 				$data 	= e107::unserialize($val);
 				
 				if($field == 'mail_sender_name' && !vartrue($data['mail_sender_name']))
@@ -1685,14 +1685,14 @@ class mailout_admin_form_ui extends e_admin_form_ui
 	{
 		if($mode == 'read')
 		{
-			$val 	= stripslashes($this->getController()->getListModel()->get('mail_other'));		
+			$val 	= stripslashes((string) $this->getController()->getListModel()->get('mail_other'));		
 			$data 	= e107::unserialize($val);
-			return basename($data['mail_attach']);	
+			return basename((string) $data['mail_attach']);	
 		}
 		
 		if($mode == 'write')
 		{
-			$val 	= stripslashes($this->getController()->getModel()->get('mail_other'));		
+			$val 	= stripslashes((string) $this->getController()->getModel()->get('mail_other'));		
 			$data 	= e107::unserialize($val);
 			return $this->filepicker('mail_attach',$data['mail_attach'], $mode);	
 		}

--- a/e107_admin/menus.php
+++ b/e107_admin/menus.php
@@ -11,7 +11,7 @@
 if(isset($_GET['configure']))
 {
 	//Switch to Front-end
-	$_GET['configure'] = preg_replace('[^a-z0-9_-]','',$_GET['configure']);
+	$_GET['configure'] = preg_replace('[^a-z0-9_-]','',(string) $_GET['configure']);
 	
 	define("USER_AREA", true);
 	define('ADMIN_AREA', false);
@@ -692,7 +692,7 @@ if(e_AJAX_REQUEST)
 	
 	if(!empty($_GET['enc']))
 	{
-		$string = base64_decode($_GET['enc']);
+		$string = base64_decode((string) $_GET['enc']);
 		parse_str($string,$_GET);
 
 	}

--- a/e107_admin/meta.php
+++ b/e107_admin/meta.php
@@ -94,7 +94,7 @@ class meta_admin_ui extends e_admin_ui
 		{
 			if(isset($_POST[$key]))
 			{
-				$cfg->setPref($key . '/' . e_LANGUAGE, trim($_POST[$key]));
+				$cfg->setPref($key . '/' . e_LANGUAGE, trim((string) $_POST[$key]));
 			}
 		}
 
@@ -187,7 +187,7 @@ class meta_admin_ui extends e_admin_ui
 
 		$text .= "</td>
 					</tr>
-				
+
 					</tbody>
 				</table>
 				<div class='buttons-bar center'>" .
@@ -214,7 +214,7 @@ class meta_admin_ui extends e_admin_ui
 	function metaLabel($text, $small)
 	{
 
-		$small = htmlentities($small);
+		$small = htmlentities((string) $small);
 
 //	$text = str_replace(['(', ')'], ['<i>', '</i>'], $text);
 		return e107::getParser()->lanVars($text, $small, true);

--- a/e107_admin/newspost.php
+++ b/e107_admin/newspost.php
@@ -338,7 +338,7 @@ class news_sub_form_ui extends e_admin_form_ui
 				
 		if($submitnews_file)
 		{
-			$tmp = explode(',',$submitnews_file);
+			$tmp = explode(',',(string) $submitnews_file);
 			
 			$text .= "<br />";
 			
@@ -550,7 +550,7 @@ class news_admin_ui extends e_admin_ui
 		$this->checkSEFSimilarity($new_data);
 
 
-		$tmp = explode(chr(35), $new_data['news_author']);
+		$tmp = explode(chr(35), (string) $new_data['news_author']);
 		$new_data['news_author'] = intval($tmp[0]);
 
 		if(E107_DBG_SQLQUERIES)
@@ -613,7 +613,7 @@ class news_admin_ui extends e_admin_ui
 
 		if(!empty($new_data['news_author']))
 		{
-			$tmp = explode(chr(35), $new_data['news_author']);
+			$tmp = explode(chr(35), (string) $new_data['news_author']);
 			$new_data['news_author'] = intval($tmp[0]);
 		}
 
@@ -640,7 +640,7 @@ class news_admin_ui extends e_admin_ui
 
 
 		$expectedSEF = eHelper::title2sef($new_data['news_title']);
-		similar_text($expectedSEF,$new_data['news_sef'],$percSimilar);
+		similar_text($expectedSEF,(string) $new_data['news_sef'],$percSimilar);
 
 		if($percSimilar < 60)
 		{
@@ -718,7 +718,7 @@ class news_admin_ui extends e_admin_ui
 	// Trigger the news email notification trigger. (@see admin->notify )
 	private function triggerNotify($new_data)
 	{
-		$visibility = explode(",", $new_data['news_class']);
+		$visibility = explode(",", (string) $new_data['news_class']);
 
 		if(in_array(e_UC_PUBLIC, $visibility))
 		{
@@ -941,8 +941,8 @@ class news_admin_ui extends e_admin_ui
 	//	e107::getMessage()->addInfo($info);
 
 
-		
-		
+
+
 		$sql = e107::getDb();
 		$sql->gen("SELECT category_id,category_name FROM #news_category");
 		while($row = $sql->fetch())
@@ -1028,7 +1028,7 @@ class news_admin_ui extends e_admin_ui
 	function beforePrefsSave($new_data, $old_data)
 	{
 
-		$new_data['news_default_template']	= preg_replace('#[^\w\pL\-]#u', '', $new_data['news_default_template']);
+		$new_data['news_default_template']	= preg_replace('#[^\w\pL\-]#u', '', (string) $new_data['news_default_template']);
 
 		return $new_data;
 	}
@@ -1378,7 +1378,7 @@ class news_admin_ui extends e_admin_ui
 			return false;
 		}
 
-		$row = json_decode($data,true);
+		$row = json_decode((string) $data,true);
 		$text = '';
 		foreach($row as $k)
 		{
@@ -1643,13 +1643,13 @@ class news_form_ui extends e_admin_form_ui
 		  <div class="tab-content">';
 
 
-		$val = strpos($curVal, "[img]http") !== false ? $curVal : str_replace("[img]../", "[img]", $curVal);
+		$val = strpos((string) $curVal, "[img]http") !== false ? $curVal : str_replace("[img]../", "[img]", $curVal);
 		$text .= "<div id='news-body-container' class='tab-pane active'>";
 		$text .= $frm->bbarea('news_body', $val, 'news', 'news');
 		$text .= "</div>";
 		$text .= "<div id='news-extended-container' class='tab-pane'>";
 
-		$val = (strpos($curValExt, "[img]http") !== false ? $curValExt : str_replace("[img]../", "[img]",$curValExt));
+		$val = (strpos((string) $curValExt, "[img]http") !== false ? $curValExt : str_replace("[img]../", "[img]",$curValExt));
 		$text .= $frm->bbarea('news_extended', $val, 'extended', 'news');
 
 		$text .= "</div>
@@ -1668,9 +1668,9 @@ class news_form_ui extends e_admin_form_ui
 
 		if($mode == 'read')
 		{
-			if(strpos($curval, ",")!==false)
+			if(strpos((string) $curval, ",")!==false)
 			{
-				$tmp = explode(",",$curval);
+				$tmp = explode(",",(string) $curval);
 				$curval = $tmp[0];
 			}
 
@@ -1694,7 +1694,7 @@ class news_form_ui extends e_admin_form_ui
 			$url = e107::getParser()->thumbUrl($curval,'aw=80');
 			$link = e107::getParser()->replaceConstants($curval);
 
-			return "<a class='e-modal' href='$link'><img src='$url' alt='".basename($curval)."' /></a>";
+			return "<a class='e-modal' href='$link'><img src='$url' alt='".basename((string) $curval)."' /></a>";
 		}
 
 
@@ -1704,7 +1704,7 @@ class news_form_ui extends e_admin_form_ui
 
 			if(!empty($_GET['sub']))
 			{
-				$thumbTmp = explode(",",$curval);
+				$thumbTmp = explode(",",(string) $curval);
 				foreach($thumbTmp as $key=>$path)
 				{
 					$url = ($path[0] == '{') ? $path : e_TEMP.$path;
@@ -1718,7 +1718,7 @@ class news_form_ui extends e_admin_form_ui
 			$frm = e107::getForm();
 
 			//	$text .= $frm->imagepicker('news_thumbnail[0]', $curval ,'','media=news&video=1');
-			$thumbTmp = explode(",",$curval);
+			$thumbTmp = explode(",",(string) $curval);
 
 
 			$text = "<div class='mediaselector-multi'>";

--- a/e107_admin/notify.php
+++ b/e107_admin/notify.php
@@ -161,7 +161,7 @@ class plugin_notify_admin_ui extends e_admin_ui
 									if($data = e107::callMethod($val."_notify", 'config'))
 									{
 
-										$config_category = str_replace("_menu","",ucfirst($val))." ".LAN_NOTIFY_01;
+										$config_category = str_replace("_menu","",ucfirst((string) $val))." ".LAN_NOTIFY_01;
 
 										foreach($data as $v)
 										{
@@ -271,7 +271,7 @@ class plugin_notify_admin_ui extends e_admin_ui
 			}
 			$text .= "</table>";
 
-			$caption = str_replace("_menu","",ucfirst($k))." ".LAN_NOTIFY_01;
+			$caption = str_replace("_menu","",ucfirst((string) $k))." ".LAN_NOTIFY_01;
 
 			$tab[] = array('caption'=>$caption, 'text' => $text);
 		}

--- a/e107_admin/plugin.php
+++ b/e107_admin/plugin.php
@@ -1178,7 +1178,7 @@ class plugin_online_ui extends e_admin_ui
 			$tp = e107::getParser();
 
 
-			$string =  base64_decode($_GET['src']);
+			$string =  base64_decode((string) $_GET['src']);
 			parse_str($string, $data);
 
 			if(deftrue('e_DEBUG_MARKETPLACE'))
@@ -1309,7 +1309,7 @@ class plugin_online_ui extends e_admin_ui
 					<div><small class="text-muted"><i class="fa fa-user"></i> {AUTHOR} <i>{DATE}</i></small> <span class="pull-right">&nbsp; {OPTIONS}</span></div>
 					</td></tr>
 					</table>
-					
+
 				</div>';
 
 			$this->perPage = 180;
@@ -1403,13 +1403,13 @@ class plugin_online_ui extends e_admin_ui
 
 	private function truncateSentence($string, 	$limit = 120 )
 	{
-		if(strlen($string) <= $limit)
+		if(strlen((string) $string) <= $limit)
 		{
-			$text = nl2br($string);
+			$text = nl2br((string) $string);
 			return $string;
 		}
 
-		$tmp = explode(".", $string);
+		$tmp = explode(".", (string) $string);
 
 		$chars = 0;
 
@@ -1451,7 +1451,7 @@ class plugin_online_ui extends e_admin_ui
 
 		if($filter = $this->getQuery('filter_options'))
 		{
-			list($bla, $cat) = explode("__",$filter);
+			list($bla, $cat) = explode("__",(string) $filter);
 		}
 
 
@@ -1486,13 +1486,13 @@ class plugin_online_ui extends e_admin_ui
 				'plugin_id'          => $row['params']['id'],
 				'plugin_mode'        => $row['params']['mode'],
 				'plugin_icon'        => vartrue($row['icon'], e_IMAGE."logo_template.png"),
-				'plugin_name'        => stripslashes($row['name']),
+				'plugin_name'        => stripslashes((string) $row['name']),
 				'plugin_description' => $this->truncateSentence(vartrue($row['description'])),
 				'plugin_featured'    => $featured,
 				'plugin_sef'         => '',
 				'plugin_folder'      => $row['folder'],
 				'plugin_path'        => $row['folder'],
-				'plugin_date'        => $tp->toDate(strtotime($row['date']), 'relative'),
+				'plugin_date'        => $tp->toDate(strtotime((string) $row['date']), 'relative'),
 				'plugin_category'    => vartrue($row['category'], 'n/a'),
 				'plugin_author'      => vartrue($row['author']),
 				'plugin_version'     => $row['version'],
@@ -1539,7 +1539,7 @@ class plugin_online_ui extends e_admin_ui
 
 		//TODO use admin_ui including filter capabilities by sending search queries back to the xml script.
 		$from = isset($_GET['frm']) ? intval($_GET['frm']) : 0;
-		$srch = preg_replace('/[^\w]/', '', vartrue($_GET['srch']));
+		$srch = preg_replace('/[^\w]/', '', (string) vartrue($_GET['srch']));
 
 
 		$mp = $this->getMarketplace();
@@ -1589,7 +1589,7 @@ class plugin_online_ui extends e_admin_ui
 				'plugin_id'          => $row['params']['id'],
 				'plugin_mode'        => $row['params']['mode'],
 				'plugin_icon'        => vartrue($row['icon'], 'e-plugins-32'),
-				'plugin_name'        => stripslashes($row['name']),
+				'plugin_name'        => stripslashes((string) $row['name']),
 				'plugin_featured'    => $featured,
 				'plugin_sef'         => '',
 				'plugin_folder'      => $row['folder'],
@@ -1598,7 +1598,7 @@ class plugin_online_ui extends e_admin_ui
 				'plugin_category'    => vartrue($row['category'], 'n/a'),
 				'plugin_author'      => vartrue($row['author']),
 				'plugin_version'     => $row['version'],
-				'plugin_description' => nl2br(vartrue($row['description'])),
+				'plugin_description' => nl2br((string) vartrue($row['description'])),
 				'plugin_compatible'  => $badge,
 
 				'plugin_website'     => vartrue($row['authorUrl']),
@@ -1946,7 +1946,7 @@ class pluginLanguage extends e_admin_ui
 
 			foreach($files as $v)
 			{
-				if(strpos($v['path'],'English')!==false OR strpos($v['fname'],'English')!==false)
+				if(strpos((string) $v['path'],'English')!==false OR strpos((string) $v['fname'],'English')!==false)
 				{
 					$path = $v['path'].$v['fname'];
 					$this->lanFiles[] = $path;
@@ -1981,7 +1981,7 @@ class pluginLanguage extends e_admin_ui
 
 				if($this->useSimilar == true)
 				{
-					similar_text($v['value'], $data['value'], $percentSimilar);
+					similar_text((string) $v['value'], (string) $data['value'], $percentSimilar);
 				}
 				else
 				{
@@ -1990,7 +1990,7 @@ class pluginLanguage extends e_admin_ui
 
 				if((($v['value'] == $data['value'] || $percentSimilar > 89) && $data['file'] != $v['file']))
 				{
-					if(strpos($v['lan'],'LAN')===false) // Defined constants that don't contain 'LAN'.
+					if(strpos((string) $v['lan'],'LAN')===false) // Defined constants that don't contain 'LAN'.
 					{
 						$v['status'] = 2;
 					}
@@ -2101,7 +2101,7 @@ class pluginLanguage extends e_admin_ui
 
 				$text = str_replace(e_PLUGIN.$this->plugin.'/languages/','',$path);
 
-				if(strpos($path,'_front.php')===false && strpos($path,'_admin.php')===false && strpos($path,'_global.php')===false && strpos($path,'_menu.php')===false && strpos($path,'_notify.php')===false && strpos($path,'_search.php')===false)
+				if(strpos((string) $path,'_front.php')===false && strpos((string) $path,'_admin.php')===false && strpos((string) $path,'_global.php')===false && strpos((string) $path,'_menu.php')===false && strpos((string) $path,'_notify.php')===false && strpos((string) $path,'_search.php')===false)
 				{
 					return "<span class='text-error e-tip' title='File name should be either English_front.php, English_admin.php or English_global.php'>".$text."</span>";
 				}
@@ -2209,13 +2209,13 @@ class pluginLanguage extends e_admin_ui
 
 			foreach($this->unused as $k=>$v)
 			{
-				if(strpos($v,'LAN')===false)
+				if(strpos((string) $v,'LAN')===false)
 				{
 					unset($this->unused[$k]);
 					$this->unsure[$k] = $v;
 				}
 
-				if(strpos($this->lanDefsData[$k]['file'],$this->plugin) === false || in_array($v,$this->excludeLans))
+				if(strpos((string) $this->lanDefsData[$k]['file'],$this->plugin) === false || in_array($v,$this->excludeLans))
 				{
 					unset($this->unused[$k]);
 					unset($this->unsure[$k]);
@@ -2311,7 +2311,7 @@ class pluginLanguage extends e_admin_ui
 			}
 
 
-			$type = basename($path);
+			$type = basename((string) $path);
 
 			if(preg_match_all('/^\s*?define\s*?\(\s*?(\'|\")([\w]+)(\'|\")\s*?,\s*?(\'|\")([\s\S]*?)\s*?(\'|\")\s*?\)\s*?;/im',$data,$matches))
 			{

--- a/e107_admin/prefs.php
+++ b/e107_admin/prefs.php
@@ -66,8 +66,8 @@ if (isset($_POST['testemail']))
 {
 	sendTest();
 }
-		
-	
+
+
 
 
 
@@ -75,17 +75,17 @@ if (isset($_POST['testemail']))
 /*	UPDATE PREFERENCES */
 if(isset($_POST['updateprefs']))
 {
-	
-	
-	
+
+
+
 	unset($_POST['updateprefs'], $_POST['sitelanguage']);
-	
+
 
 
 	$_POST['cookie_name'] = str_replace(array(" ", "."), "_", $_POST['cookie_name']);
 	$_POST['cookie_name'] = preg_replace("#[^a-zA-Z0-9_]#", "", $_POST['cookie_name']);
 
-	$_POST['siteurl'] = trim($_POST['siteurl']) ? trim($_POST['siteurl']) : SITEURL;
+	$_POST['siteurl'] = trim((string) $_POST['siteurl']) ? trim((string) $_POST['siteurl']) : SITEURL;
 	$_POST['siteurl'] = substr($_POST['siteurl'], - 1) == "/" ? $_POST['siteurl'] : $_POST['siteurl']."/";
 
 	// If email verification or Email/Password Login Method - email address is required!
@@ -120,7 +120,7 @@ if(isset($_POST['updateprefs']))
 	if(!empty($_POST['smtp_options']))
 	{
 
-		switch (trim($_POST['smtp_options']))
+		switch (trim((string) $_POST['smtp_options']))
 		{
 			case 'smtp_ssl' :
 				$smtp_opts[] = 'secure=SSL';
@@ -153,8 +153,8 @@ if(isset($_POST['updateprefs']))
 
 
 
-	
-	$_POST['membersonly_exceptions'] = explode("\n",$_POST['membersonly_exceptions']);
+
+	$_POST['membersonly_exceptions'] = explode("\n",(string) $_POST['membersonly_exceptions']);
 
 	// FIXME - automate - pref model & validation handler
 	$prefChanges = array();
@@ -185,7 +185,7 @@ if(isset($_POST['updateprefs']))
 		elseif('cookie_name' == $key && $core_pref->get($key) != $value)
 		{
 			// special case
-			if(!preg_match('/^[\w\-]+$/', $value))
+			if(!preg_match('/^[\w\-]+$/', (string) $value))
 			{
 				$newValue = e_COOKIE;
 				$mes->addWarning(PRFLAN_219);
@@ -200,7 +200,7 @@ if(isset($_POST['updateprefs']))
 		{
 			$newValue = $tp->toDB($value);
 		}
-		
+
 		$core_pref->update($key, $newValue);
 	}
 
@@ -223,7 +223,7 @@ if(isset($_POST['updateprefs']))
 		// reset cookie
 		cookie($core_pref->get('cookie_name'), $_COOKIE[e_COOKIE], (time() + 3600 * 24 * 30), e_HTTP, e107::getLanguage()->getCookieDomain());
 		cookie(e_COOKIE, null, null);
-		
+
 		// regenerate session
 		$s = $_SESSION;
 		e107::getSession()->destroy();
@@ -267,8 +267,8 @@ function sendTest()
 {
 	$log = e107::getLog();
 	$mes = e107::getMessage();
-	
-	if(trim($_POST['testaddress']) == '')
+
+	if(trim((string) $_POST['testaddress']) == '')
 	{
 		$mes->add(LAN_MAILOUT_19, E_MESSAGE_ERROR);
 		$subAction = 'error';
@@ -278,7 +278,7 @@ function sendTest()
 		$mailheader_e107id = USERID;
 		$pref = e107::pref();
 
-		$add = ($pref['mailer']) ? " (".strtoupper($pref['mailer']).") " : ' (PHP)';
+		$add = ($pref['mailer']) ? " (".strtoupper((string) $pref['mailer']).") " : ' (PHP)';
 
 		if($pref['mailer'] == 'smtp')
 		{
@@ -287,11 +287,11 @@ function sendTest()
 		}
 
 
-		$sendto = trim($_POST['testaddress']);
-		
-		
+		$sendto = trim((string) $_POST['testaddress']);
+
+
 		$eml = array(); 
-		
+
 		$eml['email_subject']		= LAN_MAILOUT_113." ".$add;
 		$eml['email_sender_email']	= null; 
 		$eml['email_sender_name']	= null;
@@ -402,7 +402,7 @@ $text .= "<div class='field-spacer'>".$tp->parseTemplate("{IMAGESELECTOR={$parms
 $sLogo = siteinfo_shortcodes::sc_logo();
 */
 
-if(!empty($pref['sitebutton']) && strpos($pref['sitebutton'],'{')===false && file_exists(e_IMAGE.$pref['sitebutton']))
+if(!empty($pref['sitebutton']) && strpos((string) $pref['sitebutton'],'{')===false && file_exists(e_IMAGE.$pref['sitebutton']))
 {
 	$pref['sitebutton'] = '{e_IMAGE}'.$pref['sitebutton'];
 }
@@ -430,7 +430,7 @@ $text .= "
 							".$frm->textarea('sitedescription', $tp->toForm($pref['sitedescription']), 3, 80, array('size'=>'xxlarge'))."
 						</td>
 					</tr>
-					
+
 					<tr>
 						<td><label for='sitedisclaimer'>".PRFLAN_9."</label>".$frm->help(PRFLAN_229)."</td>
 						<td>
@@ -478,15 +478,15 @@ $text .= "<fieldset class='e-hideme' id='core-prefs-email'>
 							".$frm->text('replyto_email', $pref['replyto_email'], 100, array('size'=>'xlarge'))."
 						</td>
 					</tr>
-							
-							
+
+
 					<tr>
 						<td><label for='testaddress'>".LAN_MAILOUT_110."</label><br /></td>
 						<td class='form-inline'>".$frm->admin_button('testemail', LAN_MAILOUT_112,'other')."&nbsp;
 							<input name='testaddress' id='testaddress' class='tbox form-control input-xxlarge' placeholder='user@yoursite.com' type='text' size='40' maxlength='80' value=\"".(varset($_POST['testaddress']) ? $_POST['testaddress'] : USEREMAIL)."\" />
 						</td>
 					</tr>
-		
+
 					<tr>
 						<td style='vertical-align:top'><label for='mailer'>".PRFLAN_267."</label><br /></td>
 						<td>";
@@ -497,12 +497,12 @@ $text .= "<fieldset class='e-hideme' id='core-prefs-email'>
 
 				$text .="</td>
 				</tr>
-			
-			
+
+
 				<tr>
 					<td><label for='mail-sendstyle'>".LAN_MAILOUT_222."</label></td>
 					<td>";
-					
+
 				$emFormat = array(
 					'textonly' => LAN_MAILOUT_125,
 					'texthtml' => LAN_MAILOUT_126,
@@ -512,7 +512,7 @@ $text .= "<fieldset class='e-hideme' id='core-prefs-email'>
 				$text .= "
 					</td>
 				</tr>
-					
+
 
 					<tr>
 						<td><label for='sitecontactinfo'>".PRFLAN_162."</label>".$frm->help(PRFLAN_163)."</td>
@@ -758,17 +758,17 @@ $text .= "
 						".$frm->radio_switch('admin_helptip', varset($pref['admin_helptip']))."
 						</td>
 					</tr>
-					
+
 					<tr>
 						<td><label for='admin-collapse-sidebar'>".PRFLAN_287."</label></td>
 						<td>
 						".$e_userclass->uc_dropdown('admin_navbar_debug', $pref['admin_navbar_debug'], 'nobody,main,admin,classes,no-excludes', "tabindex='".$frm->getNext()."'")."
-			
+
 						</td>
 					</tr>
-					
-					
-					
+
+
+
 				</tbody>
 			</table>
 			".pref_submit('admindisp')."
@@ -814,9 +814,9 @@ $text .= "
 							".$frm->text('forumdate', $pref['forumdate'], 50)."
 						</td>
 					</tr>";
-					
-					
-					
+
+
+
 					$def = strtotime('December 21, 2012 3:45pm');
 
 					$inputdate = e107::getDate()->dateFormats($def);
@@ -827,9 +827,9 @@ $text .= "
 						<td><label for='inputdate'>".PRFLAN_230."</label></td>
 						<td class='form-inline'>
 							".$frm->select('inputdate',$inputdate, e107::getPref('inputdate'));
-							
+
 					$text .= $frm->select('inputtime',$inputtime, e107::getPref('inputtime'));
-					
+
 					$text .= "
 						</td>
 					</tr>";
@@ -898,7 +898,7 @@ $text .= "
 					$text .= "</select>
 						</td>
 					</tr>
-					
+
 					 <tr>
 						<td><label for='allowemaillogin'>".PRFLAN_184."</label></td>
 						<td>".$frm->select_open('allowEmailLogin', array('size'=>'xlarge'));
@@ -950,7 +950,7 @@ $text .= "
 							</div>
 						</td>
 					</tr>
-              
+
                		<tr>
 						<td><label for='autologinpostsignup'>".PRFLAN_197."</label>".$frm->help(PRFLAN_198)."</td>
 						<td>
@@ -984,21 +984,21 @@ $text .= "
 						</td>
 					</tr>
 
-					
+
 					</tbody>
-					
+
 
 			</table>
 			".pref_submit('registration')."
 		</fieldset>
 
 	";
-	
+
 
 // Key registration 
 
-	
-	
+
+
 
 // Signup options ===========================.
 
@@ -1040,7 +1040,7 @@ $text .= "
 
 
 						";
-				
+
 		$signup_option_names = array(
 		//	"signup_option_loginname" 	=> "Login Name",
 
@@ -1069,8 +1069,8 @@ $text .= "
 						</tr>
 		";
 	}			
-				
-				
+
+
 				$text .= "
 
 
@@ -1223,16 +1223,16 @@ if ($savePrefs) $core_pref->setPref($pref)->save(false, true);
 							".$frm->radio_switch('make_clickable', $pref['make_clickable'])."
 						</td>
 					</tr>";
-					
 
-				
+
+
 				$text .= "
 					<tr>
 						<td><label for='link-replace'>".PRFLAN_102."?:</label>
 						".$frm->help(PRFLAN_103)."
 						</td>
 						<td>
-							
+
 							".$frm->radio_switch('link_replace', $pref['link_replace'])."
 							<div class='e-expandit-container'>
 							<table class='table table-condensed table-bordered' style='margin:0; width:380px'>
@@ -1243,21 +1243,21 @@ if ($savePrefs) $core_pref->setPref($pref)->save(false, true);
 								<td>Emails ".$frm->help(PRFLAN_108)."</td><td>".$frm->text('email_text', $tp->post_toForm($pref['email_text']), 200, 'size=block-level&placeholder='.PRFLAN_107)."</td>
 							</tr>
 							</table>
-														
-							
+
+
 							</div>
 						</td>
 					</tr>
-			
+
 					<tr >
 						<td><label for='links-new-window'>".PRFLAN_145."?:</label>".$frm->help(PRFLAN_146)."</td>
 						<td>
 							".$frm->radio_switch('links_new_window', $pref['links_new_window'])."
-					
+
 						</td>
 					</tr>
-					
-					
+
+
 					<tr>
 						<td><label for='profanity-filter'>".PRFLAN_40."</label>".$frm->help(PRFLAN_41)."</td>
 						<td>
@@ -1277,8 +1277,8 @@ if ($savePrefs) $core_pref->setPref($pref)->save(false, true);
 							".$frm->tags('profanity_words', $pref['profanity_words'], 250, array('maxItems'=>1000))."
 						</td>
 					</tr>
-					
-				
+
+
 					<tr>
 						<td><label for='main-wordwrap'>".PRFLAN_109.":</label>".$frm->help(PRFLAN_110)."</td>
 						<td>
@@ -1329,8 +1329,8 @@ if ($savePrefs) $core_pref->setPref($pref)->save(false, true);
 							".$frm->radio_switch('wysiwyg', $pref['wysiwyg'])."
 						</td>
 					</tr>
-					
-					
+
+
 ";
 
 if(file_exists(e_PLUGIN."geshi/geshi.php"))
@@ -1407,12 +1407,12 @@ $text .= "
 
 	// Secure Image/ Captcha
 	$secureImage = array('signcode'=>PRFLAN_76, 'logcode'=>PRFLAN_81, "fpwcode"=>PRFLAN_138,'admincode'=>PRFLAN_222);
-	
+
 	foreach($secureImage as $key=>$label)
 	{
-		
+
 		$label = str_replace($srch,$repl,$label);
-		
+
 		$text .= "<tr><td><label for='".$key."'>".$label."</label>".$frm->help(PRFLAN_223)."</td><td>";
 		if($hasGD)
 		{
@@ -1422,17 +1422,17 @@ $text .= "
 		{
 			$text .= PRFLAN_133;
 		}
-		
+
 		$text .= "
 		</td></tr>\n";
-		
+
 	}
 
 
 /*
 
 
-					
+
 	$text .= "
 					<tr>
 						<td>".PRFLAN_81.": </td>
@@ -1467,7 +1467,7 @@ $text .= "
 						</td>
 					</tr>";
  * 
- 
+
  */
     $text .= "
 
@@ -1485,8 +1485,8 @@ $text .= "
 							".$frm->radio('user_tracking', array('cookie' => PRFLAN_49, 'session' => PRFLAN_50), varset($pref['user_tracking']))."
 						</div></td>
 					</tr>
-					
-				
+
+
 					<tr>
 						<td><label for='cookie-name'>".PRFLAN_55."</label>".$frm->help(PRFLAN_263)."</td>
 						<td >".$frm->text('cookie_name', varset($pref['cookie_name']), 20)."
@@ -1511,7 +1511,7 @@ $text .= "
 						<td><label for='session-save-method'>".PRFLAN_282."</label></td>
 						<td class='form-inline'>
 							".$frm->select('session_save_method', [ 'db'=>'Database', 'files'=>'Files'], varset($pref['session_save_method']))."
-							
+
 						</td>
 					</tr>
                     ";
@@ -1544,9 +1544,9 @@ $text .= "
 						</td>
 					</tr>
 					<tr>";
-					
+
 					$CHAP_list = array(PRFLAN_180, PRFLAN_181, PRFLAN_182);
-	
+
 					$text .= "
 						<td><label for='password-chap'>".PRFLAN_178."</label>".
 						$frm->help(PRFLAN_183."<br />".PRFLAN_179)."</td>
@@ -1555,12 +1555,12 @@ $text .= "
 						$CHAPopt = !empty($pref['ssl_enabled']) || !empty($pref['passwordEncoding']) ? array('disabled'=>1) : null;
 						$text .=  $frm->select('password_CHAP',$CHAP_list,$pref['password_CHAP'], $CHAPopt );
 						//."	".$frm->select_open('password_CHAP');
-							
+
 						//TODO - user tracking session name - visible only if Cookie is enabled (JS)
 
 						$text .= "</td>
 					</tr>
-					
+
 					<tr>
 						<td><label for='antiflood1'>".PRFLAN_35."</label></td>
 						<td>
@@ -1595,14 +1595,14 @@ foreach($autoban_list as $ab => $ab_title)
 
 $text .= "
 							</select>
-					
+
 						</td>
 					</tr>
 					<tr>
 						<td><label for='failed-login-limit'>".PRFLAN_231."</label>".$frm->help(PRFLAN_232)."</td>
 						<td>
 							".$frm->number('failed_login_limit', varset($pref['failed_login_limit'],10), 3, array('max'=>10, 'min'=>0))."
-				
+
 						</td>
 					</tr>
 					<tr>
@@ -1650,14 +1650,14 @@ $text .= "
 							".$frm->radio_switch('nested_comments', $pref['nested_comments'], LAN_YES, LAN_NO)."
 						</td>
 					</tr>
-					
+
 					<tr>
 						<td>".PRFLAN_90.": </td>
 						<td>
 							".$frm->radio_switch('allowCommentEdit', $pref['allowCommentEdit'], LAN_YES, LAN_NO)."
 						</td>
 					</tr>
-					
+
 					<tr>
 						<td>".PRFLAN_166.": </td>
 						<td>
@@ -1669,7 +1669,7 @@ $text .= "
 						<td><label>".PRFLAN_233."</label>".$frm->help(PRFLAN_234)."</td>
 						<td>
 							".
-							
+
 							$frm->uc_select('comments_moderate', $pref['comments_moderate'],"nobody,guest,new,bots,public,member,admin,main,classes").
 							"
 							</td>
@@ -1677,16 +1677,16 @@ $text .= "
 					<tr>
 						<td>".PRFLAN_235."</td>
 						<td>";
-						
+
 						$comment_sort = array(
 							"desc"	=> PRFLAN_236, //default
 							'asc'	=> PRFLAN_237
 						);
-					
+
 					$text .= $frm->select('comments_sort',$comment_sort, $pref['comments_sort'], array('size'=>'xlarge'))."
 						</td>
 					</tr>
-					
+
 				</tbody>
 			</table>
 
@@ -1710,37 +1710,37 @@ $text .= "
 			".pref_submit('comments')."
 		</fieldset>
 	";
-	
+
 // File Uploads
 
 	e107::includeLan(e_LANGUAGEDIR.e_LANGUAGE."/admin/lan_upload.php");
 	require_once(e_HANDLER."upload_handler.php"); 
-	
-	
-	
-	
-	
-	
+
+
+
+
+
+
 	$text .= "
 	<fieldset class='e-hideme' id='core-prefs-uploads'>
 			<h4 class='caption'>".PRFLAN_53.defset('SEP').PRFLAN_238."</h4>";
-	
-	
+
+
 	$upload_max_filesize = ini_get('upload_max_filesize');
 	$post_max_size = ini_get('post_max_size');
-	
+
 	$maxINI = min($upload_max_filesize,$post_max_size); 
-	
+
 	if($maxINI < $pref['upload_maxfilesize'])
 	{
 		$text .= "<div class='alert-block alert alert-danger'>";
 		$text .= PRFLAN_239." ".$maxINI."</div>";
 		$pref['upload_maxfilesize'] = $maxINI;
 	}
-	
-	
-	
-			
+
+
+
+
 	$text .= "
 			<table class='table adminform'>
 				<colgroup>
@@ -1751,7 +1751,7 @@ $text .= "
 	<tr>
 	<td><label>".UPLLAN_25."</label>".$frm->help(UPLLAN_26)."</td>
 	<td>".
-	
+
 	$frm->radio_switch('upload_enabled', $pref['upload_enabled'])
 	."</td>
 	</tr>
@@ -1831,25 +1831,25 @@ $text .= "
 		<td>".$fl->file_size_encode($v)."</td>
 		</tr>";	
 
-		
+
 	}
 	// $text .= print_a($data,true);
-	
 
-	
+
+
 	$text .= "</table>";
 	*/
 	$text .= "
 	<div style='padding:15px 0'>".PRFLAN_241." <b>".str_replace("../",'',e_SYSTEM).e_READ_FILETYPES."</b></div>
 	</td>
-	
-	
+
+
 	</tbody>
 		</table>
 			".pref_submit('uploads');
-			
-			
-			
+
+
+
 	$text .= "
 		</fieldset>";
 
@@ -2185,7 +2185,7 @@ function prefs_adminmenu()
 
 	$var['core-prefs-signup']['text'] = PRFLAN_19;
 	$var['core-prefs-signup']['image_src'] = 'fas-clipboard-list.glyph';
-	
+
 	$var['core-prefs-comments']['text'] = PRFLAN_210;
 	$var['core-prefs-comments']['image_src'] = 'fa-comments.glyph';
 

--- a/e107_admin/theme.php
+++ b/e107_admin/theme.php
@@ -44,7 +44,7 @@ e107::library('load', 'bootstrap-suggest');
 e107::js('footer-inline', "
 $('textarea').suggest(':', {
   data: function(q, lookup) {
- 
+
       $.getJSON('theme.php', {q : q }, function(data) {
 			console.log(data);
 			console.log(lookup);
@@ -54,7 +54,7 @@ $('textarea').suggest(':', {
       // we aren't returning any
 
   }
-  
+
 });
 
 
@@ -64,9 +64,9 @@ $('textarea').suggest(':', {
 e107::js('footer-inline', "
 
 $('textarea.input-custompages').suggest(':', {
-	
+
   data: function() {
-  
+
   var i = $.ajax({
 		type: 'GET',
 		url: 'theme.php',
@@ -78,7 +78,7 @@ $('textarea.input-custompages').suggest(':', {
 		//	console.log(data);
 			return data; 
 		}).responseText;		
-    	
+
 	try
 	{
 		var d = $.parseJSON(i);
@@ -88,7 +88,7 @@ $('textarea.input-custompages').suggest(':', {
 		// Not JSON.
 		return;
 	}
-	
+
 	return d;   
   },
   filter: {
@@ -203,7 +203,7 @@ class theme_admin extends e_admin_dispatcher
 				case 'info':
 					if(!empty($_GET['src']))
 					{
-						$string =  base64_decode($_GET['src']);
+						$string =  base64_decode((string) $_GET['src']);
 						parse_str($string,$p);
 						$themeInfo = e107::getSession()->get('thememanager/online/'.intval($p['id']));
 						echo $themec->renderThemeInfo($themeInfo);
@@ -488,7 +488,7 @@ class theme_admin_ui extends e_admin_ui
 			$this->perPage = 500;
 
 		}
-		
+
 		public function ChooseAjaxObserver()
 		{
 			$this->ChooseObserver();
@@ -648,7 +648,7 @@ class theme_admin_ui extends e_admin_ui
 
 			if(!empty($_GET['src'])) // online mode.
 			{
-				$string =  base64_decode($_GET['src']);
+				$string =  base64_decode((string) $_GET['src']);
 				parse_str($string,$p);
 				$themeInfo = e107::getSession()->get('thememanager/online/'.intval($p['id']));
 				return $this->themeObj->renderThemeInfo($themeInfo);
@@ -677,7 +677,7 @@ class theme_admin_ui extends e_admin_ui
 
 			$frm = e107::getForm();
 			$mes = e107::getMessage();
-			$string =  base64_decode($_GET['src']);
+			$string =  base64_decode((string) $_GET['src']);
 			parse_str($string, $data);
 
 			if(!empty($data['price']))
@@ -786,7 +786,7 @@ class theme_admin_ui extends e_admin_ui
 
 			foreach($dep as $test)
 			{
-				if(strpos($code, $test) !== false)
+				if(strpos((string) $code, $test) !== false)
 				{
 					e107::getMessage()->addDebug("Incompatible function <b>".rtrim($test,"(")."</b> found in theme.php");
 					return true;
@@ -879,7 +879,7 @@ class theme_admin_ui extends e_admin_ui
 
 		if($filter = $this->getQuery('filter_options'))
 		{
-			list($bla, $cat) = explode("__",$filter);
+			list($bla, $cat) = explode("__",(string) $filter);
 		}
 
 		$limit 	= 96;
@@ -909,7 +909,7 @@ class theme_admin_ui extends e_admin_ui
 						'id'			=> $r['params']['id'],
 						'type'			=> 'theme',
 						'mode'			=> $r['params']['mode'],
-						'name'			=> stripslashes($r['name']),
+						'name'			=> stripslashes((string) $r['name']),
 						'category'		=> $r['category'],
 						'preview' 		=> varset($r['screenshots']['image']),
 						'date'			=> $r['date'],
@@ -1004,7 +1004,7 @@ class theme_admin_tree_model extends e_tree_model
 		foreach($themeList as $k=>$v)
 		{
 
-			if(!empty($parms['searchqry']) && stripos($v['info'],$parms['searchqry']) === false && stripos($v['folder'],$parms['searchqry']) === false && stripos($v['name'],$parms['searchqry']) === false)
+			if(!empty($parms['searchqry']) && stripos((string) $v['info'],(string) $parms['searchqry']) === false && stripos((string) $v['folder'],(string) $parms['searchqry']) === false && stripos((string) $v['name'],(string) $parms['searchqry']) === false)
 			{
 				continue;
 			}
@@ -1228,7 +1228,7 @@ class theme_admin_form_ui extends e_admin_form_ui
 		return $main_icon.$info_icon.$preview_icon;
 
 	}
-	
+
 }
 
 
@@ -1404,7 +1404,7 @@ class theme_builder extends e_admin_ui
 				if($this->themeSrc) // New theme copied from another
 				{
 					$defaults = array(
-						"main-name"				=> ucfirst($this->themeName),
+						"main-name"				=> ucfirst((string) $this->themeName),
 						'category-category'     => vartrue($info['category']),
 					);
 				}
@@ -1489,7 +1489,7 @@ class theme_builder extends e_admin_ui
 			$text .= "
 			<div class='buttons-bar center'>"
 			.$frm->hidden('newtheme', $this->themeName);
-			$text .= $frm->hidden('xml[custompages]', trim(vartrue($leg['CUSTOMPAGES'])))
+			$text .= $frm->hidden('xml[custompages]', trim((string) vartrue($leg['CUSTOMPAGES'])))
 			.$frm->admin_button('step', 3,'other',LAN_GENERATE)."
 			</div>";
 
@@ -1601,7 +1601,7 @@ class theme_builder extends e_admin_ui
 
 			if(!empty($newArray['CUSTOMPAGES']))
 			{
-				$newArray['CUSTOMPAGES'] = trim($newArray['CUSTOMPAGES']);
+				$newArray['CUSTOMPAGES'] = trim((string) $newArray['CUSTOMPAGES']);
 				$LAYOUTS = "\n<layout name='custom' title='Custom'>\n";
 				$LAYOUTS .= "			<custompages>{CUSTOMPAGES}</custompages>\n";
 				$LAYOUTS .= "		</layout>";
@@ -1685,7 +1685,7 @@ TEMPLATE;
 		function xmlInput($name, $info, $default='')
 		{
 			$frm = e107::getForm();
-			list($cat,$type) = explode("-",$info);
+			list($cat,$type) = explode("-",(string) $info);
 
 			$size 		= 30;
 			$help		= '';
@@ -1710,7 +1710,7 @@ TEMPLATE;
 				case 'main-date':
 					$help 		= TPVLAN_CONV_6;
 					$required 	= true;
-					$default = (empty($default)) ? time() : strtotime($default);
+					$default = (empty($default)) ? time() : strtotime((string) $default);
 				break;
 
 				case 'main-version':

--- a/e107_admin/ugflag.php
+++ b/e107_admin/ugflag.php
@@ -39,14 +39,14 @@ if(isset($_POST['updatesettings']))
 		$pref['maintainance_text'] = $temp;
 		$changed = TRUE;
 	}
-	
+
 	$temp = intval($_POST['main_admin_only']);
 	if(getperms('0') && $pref['main_admin_only'] != $temp)
 	{
 		$pref['main_admin_only'] = $temp;
 		$changed = TRUE;
 	}
-	
+
 	if($changed)
 	{
 		e107::getLog()->add(($pref['maintainance_flag'] == 0) ? 'MAINT_02' : 'MAINT_01', $pref['maintainance_text'], E_LOG_INFORMATIVE, '');
@@ -59,7 +59,7 @@ if(isset($_POST['updatesettings']))
 	}
 
 	$pref = e107::getConfig('core', true, true)->getPref();
-		
+
 
 }
 
@@ -75,14 +75,14 @@ $text = "
 					<col class='col-control' />
 				</colgroup>
 				<tbody>";
-				
+
 $elements = array(
 	e_UC_PUBLIC		=> LAN_DISABLED,
 	e_UC_MEMBER		=> ADLAN_110,
 	e_UC_ADMIN		=> UGFLAN_8,
 	e_UC_MAINADMIN	=> UGFLAN_9
 );
-	 
+
 $text .= "
 					<tr>
 						<td>".UGFLAN_2.": </td>
@@ -151,7 +151,7 @@ function headerjs()
 		</script>
 		<script src='".e_JS."core/admin.js'></script>
 	";
-	
+
 	return $ret;
 }
 

--- a/e107_admin/update_routines.php
+++ b/e107_admin/update_routines.php
@@ -87,7 +87,7 @@ if (!$dont_check_update)
 				$fname = e_PLUGIN.$path.'/'.$path.'_update_check.php';  // DEPRECATED - left for BC only. 
 				if (is_readable($fname)) include_once($fname);
 			}
-			
+
 			$fname = e_PLUGIN.$path.'/'.$path.'_setup.php';
 			if (is_readable($fname))
 			{
@@ -103,7 +103,7 @@ if (!$dont_check_update)
 	{
 		$dbupdate['test_code'] = 'Test update routine';
 	}
-	
+
 	// set 'master' to true to prevent other upgrades from running before it is complete.
 
 	$LAN_UPDATE_4 = deftrue('LAN_UPDATE_4',"Update from [x] to [y]"); // in case language-pack hasn't been upgraded.
@@ -115,7 +115,7 @@ if (!$dont_check_update)
 	$dbupdate['706_to_800'] = array('master'=>true, 'title'=> e107::getParser()->lanVars($LAN_UPDATE_4, array('1.x','2.0')), 'message'=> LAN_UPDATE_29, 'hide_when_complete'=>true);
 
 	$dbupdate['20x_to_latest'] = array('master'=>true, 'title'=> e107::getParser()->lanVars($LAN_UPDATE_4, array('2.x', $e107info['e107_version'])), 'message'=> null, 'hide_when_complete'=>false);
-	
+
 
 
 	// always run these last.
@@ -398,7 +398,7 @@ function update_check()
 					$update_needed = true;
 					break;
 				}
-				elseif(strpos($func, 'core_') !==0) // skip the pref and table check.
+				elseif(strpos((string) $func, 'core_') !==0) // skip the pref and table check.
 				{
 					$dbUpdatesPref[$func] = 1;
 
@@ -429,7 +429,7 @@ function update_check()
 		{
 			 $update_needed = TRUE;
 		}
-	
+
 
 	//	$e107cache->set_sys('nq_admin_updatecheck', time().','.($update_needed ? '2,' : '1,').$e107info['e107_version'], TRUE);
 	}
@@ -1254,7 +1254,7 @@ function update_706_to_800($type='')
 	  {		// Check for table - might add some core plugin tables in here
 	    if ($field_info = ($sql->db_Field($t, $f, '', TRUE)))
 	    {
-		  if (strtolower($field_info['Type']) != 'varchar(45)')
+		  if (strtolower((string) $field_info['Type']) != 'varchar(45)')
 		  {
             if ($just_check) return update_needed('Update IP address field '.$f.' in table '.$t);
 			$status = $sql->gen("ALTER TABLE `".MPREFIX.$t."` MODIFY `$f` VARCHAR(45) NOT NULL DEFAULT '';") ? E_MESSAGE_DEBUG : E_MESSAGE_ERROR;
@@ -1548,7 +1548,7 @@ function update_706_to_800($type='')
 		if ($just_check) return update_needed('Avatar paths require updating.');
 		foreach($avatar_images as $av)
 		{
-			$apath = (strpos($av['path'], 'public/') !== false) ? e_AVATAR_UPLOAD : e_AVATAR_DEFAULT;
+			$apath = (strpos((string) $av['path'], 'public/') !== false) ? e_AVATAR_UPLOAD : e_AVATAR_DEFAULT;
 			
 			if(rename($av['path'].$av['fname'], $apath. $av['fname'])===false)
 			{
@@ -1596,7 +1596,7 @@ function update_706_to_800($type='')
 			{
 				$log->addDebug("core-media-cat `media_cat_nick` field removed.");	
 			}
-			
+
 	//		$query = "INSERT INTO `".MPREFIX."core_media_cat` (`media_cat_id`, `media_cat_owner`, `media_cat_category`, `media_cat_title`, `media_cat_diz`, `media_cat_class`, `media_cat_image`, `media_cat_order`) VALUES
 	//		(0, 'gallery', 'gallery_1', 'Gallery 1', 'Visible to the public at /gallery.php', 0, '', 0);
 	///		";
@@ -1723,7 +1723,7 @@ function update_706_to_800($type='')
 			
 			while($row = $sql->fetch())
 			{
-				$ext = strrchr($row['download_url'], "."); 
+				$ext = strrchr((string) $row['download_url'], "."); 
 				$suffix = ltrim($ext,".");
 
 				if(!isset($allowed_types[$suffix]))
@@ -1747,7 +1747,7 @@ function update_706_to_800($type='')
 		// add found Public file-types.
 		foreach($public_files as $v)
 		{
-			$ext = strrchr($v['fname'], ".");
+			$ext = strrchr((string) $v['fname'], ".");
 			$suffix = ltrim($ext,".");
 			if(!isset($allowed_types[$suffix]))
 			{
@@ -1832,7 +1832,7 @@ function update_706_to_800($type='')
 	
 	if (!$just_check)  // Running the Upgrade Process. 
 	{
-			
+
 		if(!is_array($pref['sitetheme_layouts']) || !vartrue($pref['sitetheme_deflayout']))
 		{
 			$th = e107::getSingleton('themeHandler');
@@ -1846,10 +1846,10 @@ function update_706_to_800($type='')
 				$log->addDebug("Couldn't update SiteTheme prefs");	
 			}
 		}
-		
+
 		$log->toFile('upgrade_v1_to_v2'); 
-		
-		
+
+
 		if ($do_save)
 		{
 		//	save_prefs();

--- a/e107_admin/updateadmin.php
+++ b/e107_admin/updateadmin.php
@@ -110,7 +110,7 @@ else
 				</tbody>
 			</table>
 			<div class='buttons-bar center'>
-				<input type='hidden' name='ac' value='".md5(defset('ADMINPWCHANGE'))."' />".
+				<input type='hidden' name='ac' value='".md5((string) defset('ADMINPWCHANGE'))."' />".
 				$frm->admin_button('update_settings','no-value','update',UDALAN_7)."
 				
 			</div>

--- a/e107_admin/upload.php
+++ b/e107_admin/upload.php
@@ -208,7 +208,7 @@ class upload_ui extends e_admin_ui
 
 		// Make sure the upload_category contains only integers
 		// Make sure the owner correspondents to the category id
-		list($catOwner, $catID) = explode("__", $new_data['upload_category'], 2);
+		list($catOwner, $catID) = explode("__", (string) $new_data['upload_category'], 2);
 		$new_data['upload_category'] = intval($catID);
 		$new_data['upload_owner'] = $catOwner;
 

--- a/e107_admin/users.php
+++ b/e107_admin/users.php
@@ -262,34 +262,34 @@ JS;
 
 class users_admin_ui extends e_admin_ui
 {
-		
+
 	protected $pluginTitle = ADLAN_36;
 	protected $pluginName = 'core';
 	protected $eventName = 'user';
 	protected $table = "user";
-		
+
 //	protected $listQry = "SELECT SQL_CALC_FOUND_ROWS * FROM #users"; // without any Order or Limit. 
 	protected $listQry = "SELECT SQL_CALC_FOUND_ROWS u.*,ue.* from #user AS u LEFT JOIN #user_extended AS ue ON u.user_id = ue.user_extended_id  "; // without any Order or Limit.
-			
+
 	protected $editQry = "SELECT u.*,ue.* FROM #user AS u left join #user_extended AS ue ON u.user_id = ue.user_extended_id  WHERE user_id = {ID}";
-	
+
 	protected $pid 			= "user_id";
 	protected $perPage 		= 10;
 	protected $batchDelete 	= true;
 	protected $batchExport	= true; 
 	protected $listOrder 	= 'user_id DESC'; 
-	
+
 	/**
 	 * Show confirm screen before (batch/single) delete
 	 * @var boolean
 	 */
 	public $deleteConfirmScreen = true;
-	
+
 	/**
 	 * @var boolean
 	 */
 	protected $batchCopy = false;
-	
+
 	/**
 	 * List (numerical array) of only disallowed for this controller actions
 	 */
@@ -303,15 +303,15 @@ class users_admin_ui extends e_admin_ui
     	'description' => 'user_name',
     	'vars'=> array('user_id' => true, 'user_name' => true)
 	);
-	
+
 	//TODO - finish 'user' type, set 'data' to all editable fields, set 'noedit' for all non-editable fields
 	protected $fields = array(
 		'checkboxes'		=> array('title'=> '',				'type' => null, 'width' =>'50px', 'forced'=> TRUE, 'thclass'=>'center', 'class'=>'center'),
-	
+
 		'user_id' 			=> array('title' => LAN_ID,			'tab'=>0, 'type' =>'text',	'data'=>'int',	'width' => '3%','forced' => true,'thclass'=>'center', 'class'=>'center', 'readParms'=>'link=sef&target=blank'),
 //		'user_status' 		=> array('title' => LAN_STATUS,		'type' => 'method',	'alias'=>'user_status', 'width' => 'auto','forced' => true, 'nosort'=>TRUE),
 		'user_ban' 			=> array('title' => LAN_STATUS,		'tab'=>0, 'type' => 'method', 'width' => 'auto', 'filter'=>true, 'batch'=>true,'thclass'=>'center', 'class'=>'center'),
-	
+
 		'user_name' 		=> array('title' => LAN_USER_01,	'tab'=>0, 'type' => 'text',	'inline'=>true, 'data'=>'safestr', 'width' => 'auto','thclass' => 'left first'), // Display name
  		'user_loginname' 	=> array('title' => LAN_USER_02,	'tab'=>0, 'type' => 'text',	'data'=>'safestr', 'width' => 'auto'), // User name
  		'user_login' 		=> array('title' => LAN_USER_03,	'tab'=>0, 'type' => 'text',	'inline'=>true, 'data'=>'safestr', 'width' => 'auto'), // Real name (no real vetting)
@@ -336,9 +336,9 @@ class users_admin_ui extends e_admin_ui
 		'user_pwchange'		=> array('title' => LAN_USER_24,	'tab'=>0, 'noedit'=>true, 'type'=>'datestamp' , 'width' => 'auto'),
 		'user_signature'    => array('title' => LAN_USER_09,	'type' => 'textarea', 'data'=>'str',	'width' => 'auto', 'writeParms'=>array('size'=>'xxlarge'))
 	);
-	
+
 	protected $fieldpref = array('user_ban','user_name','user_loginname','user_login','user_email','user_class','user_admin');
-			
+
 	protected $prefs = array(
 	//	'anon_post'				=> array('title'=>PRFLAN_32, 	'type'=>'boolean'),
 		'avatar_upload'				=> array('title' => USRLAN_44,  'type' => 'boolean', 'writeParms' => 'label=yesno', 'data' => 'int',),
@@ -355,7 +355,7 @@ class users_admin_ui extends e_admin_ui
 		'signature_access'			=> array('title' => USRLAN_194, 'type' => 'userclass', 'writeParms' => 'classlist=member,admin,main,classes,nobody', 'data' => 'int',),
 		'user_new_period'			=> array('title' => USRLAN_190,  'type' => 'number',  'writeParms' => array('maxlength' => 3, 'post' => LANDT_04s), 'help' => USRLAN_191, 'data' => 'int',),
 	);
-	
+
 	public $extended = array();
 	public $extendedData = array();
 
@@ -365,7 +365,7 @@ class users_admin_ui extends e_admin_ui
 	{
 		return $this->extendedData;
 	}
-	
+
 	function ListObserver()
 	{
 		parent::ListObserver(); 
@@ -386,7 +386,7 @@ class users_admin_ui extends e_admin_ui
 
 	function init()
 	{
-	
+
 		$sql = e107::getDb();
 		$tp = e107::getParser();
 
@@ -399,7 +399,7 @@ class users_admin_ui extends e_admin_ui
 			$this->resend_to_all($resetPasswords, $age, $class);
 		}
 
-		
+
 		if($this->getAction() == 'edit')
 		{
 			$this->fields['user_class']['noedit'] = true;
@@ -410,9 +410,9 @@ class users_admin_ui extends e_admin_ui
 
 
 
-		
+
 		// Extended fields - FIXME - better field types
-		
+
 		if($rows = $sql->retrieve('user_extended_struct', '*', "user_extended_struct_type > 0 AND user_extended_struct_text != '_system_' ORDER BY user_extended_struct_parent ASC",true))
 		{
 			// TODO FIXME use the handler to build fields and field attributes
@@ -431,13 +431,13 @@ class users_admin_ui extends e_admin_ui
 						continue;
 					}
 				}
-			
-			
+
+
 				$field = "user_".$row['user_extended_struct_name'];
 				// $title = ucfirst(str_replace("user_","",$field));
 				$label = $tp->toHTML($row['user_extended_struct_text'],false,'defs');
 				$this->fields[$field] = array('__tableField'=>'ue.'.$field, 'title' => $label,'width' => 'auto', 'type'=>'method', 'readParms'=>array('ueType'=>$row['user_extended_struct_type']), 'method'=>'user_extended', 'data'=>$dataMode, 'tab'=>1, 'noedit'=>false);
-			
+
 				$this->extended[] = $field;
 				$this->extendedData[$field] = $row;
 			}
@@ -454,7 +454,7 @@ class users_admin_ui extends e_admin_ui
 //		$this->fields['user_signature']['writeParms']['data'] = e107::getUserClass()->uc_required_class_list("classes");
 		$this->fields['options'] = array('title'=> LAN_OPTIONS."&nbsp;",	'type' => 'method',	'forced'=>TRUE, 'width' => '10%', 'thclass' => 'right last', 'class' => 'left');
 
-				
+
 		if(!getperms('4|U0')) // Quick Add User Access Only. 
 		{
 			unset($this->fields['checkboxes']);
@@ -465,7 +465,7 @@ class users_admin_ui extends e_admin_ui
 			}
 
 		}	
-		
+
 		if(!empty($_GET['readonly']))
 		{
 			foreach($this->fields as $key=>$v)
@@ -508,10 +508,10 @@ class users_admin_ui extends e_admin_ui
 			$id = $f['fname'];
 			$sys[$id] = $f['fname'];	
 		}
-		
+
 		$avs['uploaded'] = $upload;
 		$avs['system'] = $sys;	
-		
+
 		return $avs;
 	}
 
@@ -565,21 +565,21 @@ class users_admin_ui extends e_admin_ui
 
 			e107::getMessage()->addDebug("Password Hash: ".$new_data['user_password']);
 		}
-		
+
 		if(!empty($new_data['perms']))
 		{
 			$new_data['user_perms']	= implode(".",$new_data['perms']);
 		}
-		
+
 		// Handle the Extended Fields. 
 		$this->saveExtended($new_data);
 
-		
-	
-		
+
+
+
 		return $new_data;
 	}
-	
+
 
 	function saveExtended($new_data)
 	{
@@ -649,7 +649,7 @@ class users_admin_ui extends e_admin_ui
 		$sql = e107::getDb();
 		$tp = e107::getParser();
 		$sysuser = e107::getSystemUser($userid, false);
-		
+
 		if(!$sysuser->getId())
 		{
 			e107::getMessage()->addError(USRLAN_223);
@@ -661,18 +661,18 @@ class users_admin_ui extends e_admin_ui
 		$sysuser->set('user_ban', 2)
 		->set('user_sess', e_user_model::randomKey())
 		->save();
-		
+
 		$sql->delete("banlist"," banlist_ip='{$row['user_ip']}' ");
 
 		$vars = array('x'=>$sysuser->getId(), 'y'=> $sysuser->getName(), 'z'=> $sysuser->getValue('email'));
 
 		e107::getLog()->add('USET_06', $tp->lanVars( USRLAN_162, $vars), E_LOG_INFORMATIVE);
 		e107::getMessage()->addSuccess("(".$sysuser->getId().".".$sysuser->getName()." - ".$sysuser->getValue('email').") ".USRLAN_9);
-		
+
 		// List data reload
 		$this->getTreeModel()->loadBatch(true);
 	}
-	
+
 	/**
 	 * Ban user trigger
 	 * @param int $userid
@@ -685,7 +685,7 @@ class users_admin_ui extends e_admin_ui
 		$admin_log = e107::getLog();
 		$iph = e107::getIPHandler();
 		$tp = e107::getParser();
-		
+
 		$sysuser = e107::getSystemUser($userid, false);
 		if(!$sysuser->getId())
 		{
@@ -693,7 +693,7 @@ class users_admin_ui extends e_admin_ui
 			return;
 		}
 		$row = $sysuser->getData();
-		
+
 		if (($row['user_perms'] == "0") || ($row['user_perms'] == "0."))
 		{
 			$mes->addWarning(USRLAN_7);
@@ -706,7 +706,7 @@ class users_admin_ui extends e_admin_ui
 				e107::getLog()->add('USET_05',$tp->lanVars(USRLAN_161, $vars), E_LOG_INFORMATIVE);
 				$mes->addSuccess("(".$userid.".".$row['user_name']." - {$row['user_email']}) ".USRLAN_8);
 			}
-			if (trim($row['user_ip']) == "")
+			if (trim((string) $row['user_ip']) == "")
 			{
 				$mes->addInfo(USRLAN_135);
 			}
@@ -732,7 +732,7 @@ class users_admin_ui extends e_admin_ui
 				}
 			}
 		}
-		
+
 		// List data reload
 		$this->getTreeModel()->loadBatch(true);
 	}
@@ -748,15 +748,15 @@ class users_admin_ui extends e_admin_ui
 		$userMethods = e107::getUserSession();
 		$mes = e107::getMessage();
 		$tp = e107::getParser();
-		
+
 		$uid = intval($userid);
 		if ($sysuser->getId())
 		{
 			$sysuser->set('user_ban', '0')
 				->set('user_sess', '');
-				
+
 			$row = $sysuser->getData();
-			
+
 			if ($initUserclasses = $userMethods->userClassUpdate($row, 'userall'))
 			{
 				$row['user_class'] = $initUserclasses;
@@ -779,16 +779,16 @@ class users_admin_ui extends e_admin_ui
 			e107::getLog()->add('USET_10', $tp->lanVars( USRLAN_166, $vars), E_LOG_INFORMATIVE);
 			e107::getEvent()->trigger('userfull', $row); //BC
 			e107::getEvent()->trigger('admin_user_activated', $row);
-			
+
 			$mes->addSuccess(USRLAN_86." (#".$sysuser->getId()." : ".$sysuser->getName().' - '.$sysuser->getValue('email').")");
-			
+
 			$this->getTreeModel()->loadBatch(true);
 
 			if ((int) e107::pref('core', 'user_reg_veri') == 2)
 			{
 				$message = USRLAN_114." ".$row['user_name'].",\n\n".USRLAN_122." ".SITENAME.".\n\n".USRLAN_123."\n\n";
 				$message .= str_replace("{SITEURL}", SITEURL, USRLAN_139);
-				
+
 				$options = array(
 					'mail_subject' => USRLAN_113.' '.SITENAME,
 					'mail_body' => nl2br($message),
@@ -828,23 +828,23 @@ class users_admin_ui extends e_admin_ui
 	  	{ 
 	  		$sysuser = e107::getSystemUser($userid);
 			$user = e107::getUser();
-			
+
 			// TODO - lan
 			$mes->addSuccess('Successfully logged in as '.$sysuser->getName().' <a href="'.e_ADMIN_ABS.'users.php?mode=main&amp;action=logoutas">[logout]</a>')
 				->addSuccess('Please, <a href="'.SITEURL.'" rel="external">Leave Admin</a> to browse the system as this user. Use &quot;Logout&quot; option in Administration to end front-end session');
-			
+
 			$search = array('--UID--', '--NAME--', '--EMAIL--', '--ADMIN_UID--', '--ADMIN_NAME--', '--ADMIN_EMAIL--');
 			$replace = array($sysuser->getId(), $sysuser->getName(), $sysuser->getValue('email'), $user->getId(), $user->getName(), $user->getValue('email'));
-			
+
 			 // TODO - lan
 			$lan = 'Administrator --ADMIN_EMAIL-- (#--ADMIN_UID--, --ADMIN_NAME--) has logged in as the user --EMAIL-- (#--UID--, --NAME--)';
-			
+
 			e107::getLog()->add('USET_100', str_replace($search, $replace, $lan), E_LOG_INFORMATIVE);
-			
+
 			$eventData = array('user_id' => $sysuser->getId(), 'admin_id' => $user->getId());
 			e107::getEvent()->trigger('loginas', $eventData); // BC
 			e107::getEvent()->trigger('admin_user_loginas', $eventData); 
-			
+
 	  	}
 	}
 
@@ -860,21 +860,21 @@ class users_admin_ui extends e_admin_ui
 	  	{
 	  		 // TODO - lan
 			e107::getMessage()->addSuccess('Successfully logged out from '.$sysuser->getName().' ('.$sysuser->getValue('email').') account', 'default', true);
-			
+
 			$search = array('--UID--', '--NAME--', '--EMAIL--', '--ADMIN_UID--', '--ADMIN_NAME--', '--ADMIN_EMAIL--');
 			$replace = array($sysuser->getId(), $sysuser->getName(), $sysuser->getValue('email'), $user->getId(), $user->getName(), $user->getValue('email'));
-			
+
 			 // TODO - lan
 			$lan = 'Administrator --ADMIN_EMAIL-- (#--ADMIN_UID--, --ADMIN_NAME--) has logged out as the user --EMAIL-- (#--UID--, --NAME--)';
-			
+
 			e107::getLog()->add('USET_101', str_replace($search, $replace, $lan), E_LOG_INFORMATIVE);
-			
+
 			$eventData = array('user_id' => $sysuser->getId(), 'admin_id' => $user->getId());
 			e107::getEvent()->trigger('logoutas', $eventData); //BC 
 			e107::getEvent()->trigger('admin_user_logoutas', $eventData); 
 			$this->redirect('list', 'main', true);
 	  	}
-		
+
 
   		 if(!$sysuser->getId()) e107::getMessage()->addError(LAN_USER_NOT_FOUND);
 	}
@@ -949,7 +949,7 @@ class users_admin_ui extends e_admin_ui
 
 	}
 
-	
+
 	/**
 	 * Remove admin status trigger
 	 */
@@ -959,11 +959,11 @@ class users_admin_ui extends e_admin_ui
 		$sysuser = e107::getSystemUser($userid, false);
 		$mes = e107::getMessage();
 		$tp = e107::getParser();
-		
+
 		if(!$user->checkAdminPerms('3'))
 		{
 			$mes->addError(USRLAN_226, 'default', true);
-			
+
 			//$search = array('--UID--', '--NAME--', '--EMAIL--', '--ADMIN_UID--', '--ADMIN_NAME--', '--ADMIN_EMAIL--');
 			$vars = array(
 				'u' => $sysuser->getId(),
@@ -973,7 +973,7 @@ class users_admin_ui extends e_admin_ui
 				'y' => $user->getName(),
 				'z' => $user->getValue('email')
 			);
-			
+
 			e107::getLog()->add('USET_08', $tp->lanVars(USRLAN_244,$vars), E_LOG_INFORMATIVE);
 			$this->redirect('list', 'main', true);
 		}
@@ -1009,7 +1009,7 @@ class users_admin_ui extends e_admin_ui
 		{
 			$this->redirect('list', 'main', true);
 		}
-		
+
 		$userid = $this->getId();
 		$sql = e107::getDb();
 		$user = e107::getUser();
@@ -1017,7 +1017,7 @@ class users_admin_ui extends e_admin_ui
 		$admin_log = e107::getLog();
 		$mes = e107::getMessage();
 		$tp = e107::getParser();
-		
+
 		if(!$user->checkAdminPerms('3'))
 		{
 			$mes->addError(USRLAN_226, 'default', true);
@@ -1033,25 +1033,25 @@ class users_admin_ui extends e_admin_ui
 			);
 
 		//	$replace = array($sysuser->getId(), $sysuser->getName(), $sysuser->getValue('email'), $user->getId(), $user->getName(), $user->getValue('email'));
-			
+
 			e107::getLog()->add('USET_08', $tp->lanVars( USRLAN_245,$vars), E_LOG_INFORMATIVE);
-			
+
 			$this->redirect('list', 'main', true);
 		}
-		
+
 		if(!$sysuser->getId())
 		{
 			$mes->addError(USRLAN_223, 'default', true);
 			$this->redirect('list', 'main', true);
 		}
-		
-	
+
+
 		if($this->getPosted('update_admin'))
 		{
 			 e107::getUserPerms()->updatePerms($userid, $_POST['perms']);
 			 $this->redirect('list', 'main', true);
 		}
-		
+
 		if(!$sysuser->isAdmin()) // Security Check Only. Admin status check is added during 'updatePerms'. 
 		{
 		//	$sysuser->set('user_admin', 1)->save(); //"user","user_admin='1' WHERE user_id={$userid}"
@@ -1065,9 +1065,9 @@ class users_admin_ui extends e_admin_ui
 			$mes->addWarning($message);
 			$mes->addWarning(e107::getParser()->toHTML(USRLAN_229,true));
 		}
-		
+
 	}
-	
+
 	/**
 	 * Admin manage page
 	 */
@@ -1079,16 +1079,16 @@ class users_admin_ui extends e_admin_ui
 		//$sysuser->load($request->getId(), true);
 		$prm = e107::getUserPerms();
 		$frm = e107::getForm();
-		
+
 		$response->appendBody($frm->open('adminperms'))
 			->appendBody($prm->renderPermTable('grouped', $sysuser->getValue('perms')))
 			->appendBody($prm->renderCheckAllButtons())
 			->appendBody($prm->renderSubmitButtons().$frm->token())
 			->appendBody($frm->close());
-		
+
 		$this->addTitle(str_replace(array('[x]', '[y]'), array($sysuser->getName(), $sysuser->getValue('email')), USRLAN_230));
 	}
-	
+
 	protected function checkAllowed($class_id) // check userclass change is permitted.
 	{
 		$e_userclass = e107::getUserClass();
@@ -1102,20 +1102,20 @@ class users_admin_ui extends e_admin_ui
 		}
 		return true;
 	}
-	
+
 	protected function manageUserclass($userid, $uclass, $mode = false)
 	{
 		$request = $this->getRequest();
 		$response = $this->getResponse();
 		$sysuser = e107::getSystemUser($userid, false);
-		
+
 		$admin_log = e107::getLog();
 		$e_userclass = e107::getUserClass();
 		$sql = e107::getDb();
 
 		$remuser = true;
         $mes = e107::getMessage();
-		
+
 		if(!$sysuser->getId())
 		{
 			$mes->addError(USRLAN_223);
@@ -1125,7 +1125,7 @@ class users_admin_ui extends e_admin_ui
 		$curClass = array();
 		if($mode !== 'update')
 		{
-			$curClass = $sysuser->getValue('class') ? explode(',', $sysuser->getValue('class')) : array();
+			$curClass = $sysuser->getValue('class') ? explode(',', (string) $sysuser->getValue('class')) : array();
         }
 
     	foreach ($uclass as $a)
@@ -1136,7 +1136,7 @@ class users_admin_ui extends e_admin_ui
 				$mes->addError(USRLAN_231);
 				return false;
 			}
-			
+
 			if($a != 0) // if 0 - then do not add.
 			{
 				$curClass[] = $a;
@@ -1156,7 +1156,7 @@ class users_admin_ui extends e_admin_ui
 
         $svar = is_array($curClass) ? implode(",", $curClass) : "";
 		$check = $sysuser->set('user_class', $svar)->save();
-		
+
 		if($check)
 		{
 			$message = UCSLAN_9;
@@ -1174,13 +1174,13 @@ class users_admin_ui extends e_admin_ui
 					}
 				}
 				if ($messaccess == '') $messaccess = UCSLAN_12."\n";
-				
+
 				$message = USRLAN_256." ".$sysuser->getName().",\n\n".UCSLAN_4." ".SITENAME."\n( ".SITEURL." )\n\n".UCSLAN_5.": \n\n".$messaccess."\n".UCSLAN_10."\n".SITEADMIN;
 				//    $admin_log->addEvent(4,__FILE__."|".__FUNCTION__."@".__LINE__,"DBG","User class change",str_replace("\n","<br />",$message),FALSE,LOG_TO_ROLLING);
-				
+
 				$options['mail_subject'] = UCSLAN_2;
 				$options['mail_body'] = nl2br($message);
-				
+
 				$sysuser->email('email', $options);
 				//sendemail($send_to,$subject,$message);
 			}
@@ -1209,7 +1209,7 @@ class users_admin_ui extends e_admin_ui
 	{
 		$this->manageUserclass($this->getId(), $this->getPosted('userclass'), 'update');
 	}
-	
+
 	/**
 	 * Back to user list trigger (userclass page)
 	 */
@@ -1217,7 +1217,7 @@ class users_admin_ui extends e_admin_ui
 	{
 		$this->redirect('list', 'main', true);
 	}
-	
+
 	/**
 	 * Manage userclasses page
 	 */
@@ -1229,14 +1229,14 @@ class users_admin_ui extends e_admin_ui
 		$e_userclass = e107::getUserClass();
 		$userid = $this->getId();
 		$frm = e107::getForm();
-		
+
 		$caption = UCSLAN_6." <b>".$sysuser->getName().' - '.$sysuser->getValue('email')."</b> (".$sysuser->getClassList(true).")";
 		$this->addTitle($caption);
-		
+
 		$text = "	<div>
 					<form method='post' action='".e_REQUEST_URI."'>
 					<fieldset id='core-user-userclass'>
-					
+
                     <table class='table adminform'>
 					<colgroup>
 						<col class='col-label' />
@@ -1265,7 +1265,7 @@ class users_admin_ui extends e_admin_ui
 
 		$response->appendBody($text);
 	}
-	
+
 	/**
 	 * Resend user activation email trigger 
 	 */
@@ -1273,7 +1273,7 @@ class users_admin_ui extends e_admin_ui
 	{
 		$this->resendActivation($userid);
 	}
-	
+
 	/**
 	 * Resend user activation email helper
 	 * FIXME - better Subject/Content for the activation email when user is bounced/deactivated.
@@ -1284,7 +1284,7 @@ class users_admin_ui extends e_admin_ui
 		$sysuser = e107::getSystemUser($id, false);
 		$key = $sysuser->getValue('sess');
 		$mes = e107::getMessage();
-		
+
 		if(!$sysuser->getId())
 		{
 			$mes->addError(USRLAN_223);
@@ -1297,7 +1297,7 @@ class users_admin_ui extends e_admin_ui
 			$mes->addDebug("key: ".$key." ban: ".$sysuser->getValue('ban'));
 			return false;
 		}
-		
+
 		// Check for a Language field, and if present, send the email in the user's language.
 		// FIXME - make all system emails to be created from HTML email templates, this should fix the multi-lingual issue when sending multiple emails
 		if ($lfile == "")
@@ -1318,13 +1318,13 @@ class users_admin_ui extends e_admin_ui
 			require_once (e_LANGUAGEDIR.e_LANGUAGE."/lan_signup.php");
 		}
 		if(!$lan) $lan = e_LANGUAGE;
-		
+
 		// FIXME switch to e107::getUrl()->create(), use email content templates
 		//$return_address = (substr(SITEURL,- 1) == "/") ? SITEURL."signup.php?activate.".$sysuser->getId().".".$key : SITEURL."/signup.php?activate.".$sysuser->getId().".".$key;
 		$return_address = SITEURL."signup.php?activate.".$sysuser->getId().".".$key;
 	//	$message = LAN_EMAIL_01." ".$sysuser->getName()."\n\n".LAN_SIGNUP_24." ".SITENAME.".\n".LAN_SIGNUP_21."\n\n";
 	//	$message .= "<a href='".$return_address."'>".$return_address."</a>";
-		
+
 
 		$userInfo = array(
 			'user_id'       =>  $sysuser->getId(),
@@ -1347,13 +1347,13 @@ class users_admin_ui extends e_admin_ui
 		}
 
 		$message = 'null';
-		
+
 		$check = $sysuser->email('signup', array(
 			'mail_subject' => LAN_SIGNUP_98,
 			'mail_body' => nl2br($message),
 			'user_password' => $newPwd
 		), $userInfo);
-		
+
 		if ($check)
 		{
 			$vars = array('x'=> $sysuser->getId(), 'y'=>$sysuser->getName(), 'z'=> $sysuser->getValue('email'));
@@ -1376,13 +1376,13 @@ class users_admin_ui extends e_admin_ui
 		$sysuser = e107::getSystemUser($this->getId(), false);
 		$mes = e107::getMessage();
 		$email = $sysuser->getValue('email');
-		
+
 		if(!$sysuser->getId())
 		{
 			$mes->addError(USRLAN_223, 'default', true);
 			$this->redirect('list', 'main', true);
 		}
-		
+
 		$result = $this->testEmail($email);
 		if($result)
 		{
@@ -1396,12 +1396,12 @@ class users_admin_ui extends e_admin_ui
 		}
 
 	}
-	
+
 	public function TestCancelTrigger()
 	{
 		$this->redirect('list', 'main', true);
 	}
-	
+
 	/**
 	 * Resend activation email page - only if tested email is valid
 	 */
@@ -1412,12 +1412,12 @@ class users_admin_ui extends e_admin_ui
 		$userid = $this->getId();
 		$email = $sysuser->getValue('email');
 		$frm = e107::getForm();
-		
+
 		$caption = str_replace('[x]', $email, USRLAN_119);
 		$this->addTitle($caption);
-		
+
 		$text = "<a href='".e_REQUEST_HTTP."?mode=main&amp;action=list'>".LAN_BACK."</a>";
-		$text .= '<pre>'.htmlspecialchars($this->getParam('testSucces')).'</pre>';
+		$text .= '<pre>'.htmlspecialchars((string) $this->getParam('testSucces')).'</pre>';
 		$text .= "	<div>
 					<form method='post' action='".e_REQUEST_HTTP."?mode=main&amp;action=list'>
 					<fieldset id='core-user-testemail'>
@@ -1439,58 +1439,58 @@ class users_admin_ui extends e_admin_ui
 	 */
 	protected function testEmail($email)
 	{
-		list($adminuser,$adminhost) = explode('@',SITEADMINEMAIL, 2);
-		
+		list($adminuser,$adminhost) = explode('@',(string) SITEADMINEMAIL, 2);
+
 		$validator = new email_validation_class;
 		$validator->localuser = $adminuser;
 		$validator->localhost = $adminhost;
 		$validator->timeout = 5;
 		$validator->debug = 1;
 		$validator->html_debug = 0;
-		
+
 		ob_start();
 		$email_status = $validator->ValidateEmailBox($email);
 		$text = ob_get_contents();
 		ob_end_clean();
-		
+
 		if ($email_status == 1)
 		{
 			return $text;
 		}
-		
+
 		return false;
 	}
-	
+
 	/**
 	 * Set user status to require verification - available for bounced users
 	 */
 	public function ListReqverifyTrigger($userid)
 	{
 		$sysuser = e107::getSystemUser($userid, false);
-		
+
 		if(!$sysuser->getId())
 		{
 			e107::getMessage()->addError(USRLAN_223, 'default', true);
 			return;
 		}
-		
+
 		$sysuser->set('user_ban', 2)
 			->set('user_sess', e_user_model::randomKey());
-		
+
 		if($sysuser->save())
 		{
 			e107::getMessage()->addSuccess(USRLAN_235);
-			
+
 			// TODO - auto-send email or not - discuss
 			$this->resendActivation($userid);
-			
+
 			//FIXME admin log
-			
+
 			// Reload tree
 			$this->getTreeModel()->loadBatch(true);
 			return;
 		}
-		
+
 		e107::getMessage()->addError(USRLAN_236);
 	}
 
@@ -1513,21 +1513,21 @@ class users_admin_ui extends e_admin_ui
 		$e_event 		= e107::getEvent();
 		$admin_log		= e107::getLog();
 		$pref = e107::getPref();
-		
+
 		if (!$_POST['ac'] == md5(ADMINPWCHANGE))
 		{
 			exit;
 		}
-		
+
 		$e107cache->clear('online_menu_member_total');
 		$e107cache->clear('online_menu_member_newest');
 		$error = false;
-		
+
 		if (isset ($_POST['generateloginname']))
 		{
 			$_POST['loginname'] = $userMethods->generateUserLogin($pref['predefinedLoginName']);
 		}
-		
+
 		$_POST['password2'] = $_POST['password1'] = $_POST['password'];
 
 		// #1728 - Default value, because user will always be part of 'Members'
@@ -1548,16 +1548,16 @@ class users_admin_ui extends e_admin_ui
 				//$allData['errors']['user_name'] = ERR_FIELDS_DIFFERENT;
 			}
 		}
-		
+
 		// Do basic validation
 		validatorClass::checkMandatory('user_name, user_loginname', $allData);
-		
+
 		// Check for missing fields (email done in userValidation() )
 		validatorClass::dbValidateArray($allData, $userMethods->userVettingInfo, 'user', 0);
-		
+
 		// Do basic DB-related checks
 		$userMethods->userValidation($allData);
-		
+
 		// Do user-specific DB checks
 		if (!isset($allData['errors']['user_password']))
 		{
@@ -1569,23 +1569,23 @@ class users_admin_ui extends e_admin_ui
 
 		// Restrict the scope of this
 		unset($_POST['password2'], $_POST['password1']);
-		
+
 		if (count($allData['errors']))
 		{
 			$temp = validatorClass::makeErrorList($allData, 'USER_ERR_','%n - %x - %t: %v', '<br />', $userMethods->userVettingInfo);
 			$mes->addError($temp);
 			$error = true;
 		}
-		
+
 		// Always save some of the entered data - then we can redisplay on error
 		$user_data = & $allData['data'];
-		
+
 		if($error)
 		{
 			$this->setParam('user_data', $user_data);
 			return;
 		}
-		
+
 		if(varset($_POST['perms']))
 		{
 			$allData['data']['user_admin'] = 1;
@@ -1598,7 +1598,7 @@ class users_admin_ui extends e_admin_ui
 		$user_data['user_join'] = time();
 
 		e107::getMessage()->addDebug("Password Hash: ".$user_data['user_password']);
-		
+
 		if ($userMethods->needEmailPassword())
 		{
 			// Save separate password encryption for use with email address
@@ -1607,16 +1607,16 @@ class users_admin_ui extends e_admin_ui
 			$user_data['user_prefs'] = e107::getArrayStorage()->serialize($user_prefs);
             unset($user_prefs);
 		}
-		
+
 		$userMethods->userClassUpdate($allData['data'], 'userall');
-		
+
 		//FIXME - (SecretR) there is a better way to fix this (missing default value, sql error in strict mode - user_realm is to be deleted from DB later)
 		$allData['data']['user_realm'] = '';
-		
+
 		// Set any initial classes
 		$userMethods->addNonDefaulted($user_data);
 		validatorClass::addFieldTypes($userMethods->userVettingInfo, $allData);
-		
+
 		$userid = $sql->insert('user', $allData);
 		if ($userid)
 		{
@@ -1626,20 +1626,20 @@ class users_admin_ui extends e_admin_ui
 			$sysuser->setData($allData['data']);
 			$sysuser->setId($userid);
 			$user_data['user_id'] = $userid;
-			
+
 			// Add to admin log
 			e107::getLog()->add('USET_02',"UName: {$user_data['user_name']}; Email: {$user_data['user_email']}", E_LOG_INFORMATIVE);
-			
+
 			// Add to user audit trail
 			e107::getLog()->user_audit(USER_AUDIT_ADD_ADMIN, $user_data, 0, $user_data['user_loginname']);
 			e107::getEvent()->trigger('userfull', $user_data);
 			e107::getEvent()->trigger('admin_user_created', $user_data); 
-			
+
 			// send everything available for user data - bit sparse compared with user-generated signup
 			if(isset($_POST['sendconfemail']))
 			{
 				$check = false;
-				
+
 				// Send confirmation email to user
 				switch ((int) $_POST['sendconfemail']) 
 				{
@@ -1647,7 +1647,7 @@ class users_admin_ui extends e_admin_ui
 						// activate, don't notify
 						$check = -1;
 					break;
-					
+
 					case 1:
 						// activate and send password
 						$check = $sysuser->email('quickadd', array(
@@ -1656,13 +1656,13 @@ class users_admin_ui extends e_admin_ui
 							'activation_url' => USRLAN_246,
 						));
 					break;
-					
+
 					case 2:
 						// require activation and send password and activation link
 						$sysuser->set('user_ban', 2)
 							->set('user_sess', e_user_model::randomKey())
 							->save();
-							
+
 						$check = $sysuser->email('quickadd', array(
 							'user_password' => $savePassword, 
 							'mail_subject' => USRLAN_187,
@@ -1680,20 +1680,20 @@ class users_admin_ui extends e_admin_ui
 					$mes->addError(USRLAN_189);
 				}
 			}
-			
+
 		//	$message = str_replace('--NAME--', htmlspecialchars($user_data['user_name'], ENT_QUOTES, CHARSET), USRLAN_174);
 			$message = USRLAN_172; // "User account has been created with the following:" ie. keep it simple so it can easily be copied and pasted. 
-			
+
 			// Always show Login name and password
 			//if (isset($_POST['generateloginname']))
 			{
 				$mes->addSuccess($message)
-					->addSuccess(USRLAN_128.': <strong>'.htmlspecialchars($user_data['user_loginname'], ENT_QUOTES, CHARSET).'</strong>');	
+					->addSuccess(USRLAN_128.': <strong>'.htmlspecialchars((string) $user_data['user_loginname'], ENT_QUOTES, CHARSET).'</strong>');	
 			}
-				
+
 			//if (isset($_POST['generatepassword']))
 			{
-				$mes->addSuccess(LAN_PASSWORD.': <strong>'.htmlspecialchars($savePassword, ENT_QUOTES, CHARSET).'</strong>');	
+				$mes->addSuccess(LAN_PASSWORD.': <strong>'.htmlspecialchars((string) $savePassword, ENT_QUOTES, CHARSET).'</strong>');	
 			}
 			return;
 		}
@@ -1703,7 +1703,7 @@ class users_admin_ui extends e_admin_ui
 			$mes->addError($sql->getLastErrorText());
 		}
 	}
-	
+
 	/**
 	 * Quick add user page
 	 */
@@ -1715,9 +1715,9 @@ class users_admin_ui extends e_admin_ui
 		$e_userclass = e107::getUserClass();
 		$pref = e107::getPref();
 		$user_data = $this->getParam('user_data');
-		
+
 	// 	$this->addTitle(LAN_USER_QUICKADD);
-		
+
 		$text = "<div>".$frm->open("core-user-adduser-form",null,null,'autocomplete=0')."
 		<div style='display:none'><input type='password' id='_no_autocomplete_' /></div>
 		<fieldset id='core-user-adduser'>
@@ -1753,7 +1753,7 @@ class users_admin_ui extends e_admin_ui
 			<td>".$frm->password('password', '', 128, array('size' => 'xlarge', 'class' => 'tbox e-password', 'generate' => 1, 'strength' => 1, 'autocomplete' => 'new-password'))."
  			</td>
 		</tr>";
-		
+
 
 
 		$text .= "
@@ -1763,7 +1763,7 @@ class users_admin_ui extends e_admin_ui
 				".$frm->text('email', varset($user_data['user_email']), 100, array('size'=>'xlarge'))."
 				</td>
 			</tr>
-	
+
 			<tr>
 				<td>".USRLAN_239."</td>
 				<td>
@@ -1821,8 +1821,8 @@ class users_admin_ui extends e_admin_ui
 		</form>
 		</div>
 		";
-		
-		
+
+
 		return $text;
 		//$ns->tablerender(USRLAN_59,$mes->render().$text);
 	}	
@@ -1846,16 +1846,16 @@ class users_admin_ui extends e_admin_ui
 
 		//Delete existing rank config
 		e107::getDb()->delete('generic', "gen_type = 'user_rank_config'");
-		
+
 		$tmp = array();
 		$tmp['data']['gen_type'] = 'user_rank_config';
 		$tmp['data']['gen_chardata'] = serialize($cfg);
 		$tmp['_FIELD_TYPES']['gen_type'] = 'string';
 		$tmp['_FIELD_TYPES']['gen_chardata'] = 'escape';
-		
+
 		//Add the new rank config
 		e107::getDb()->insert('generic', $tmp);
-		
+
 		// save prefs
 		$config->set('ranks_calc', $ranks_calc);
 		$config->set('ranks_flist', $ranks_flist);
@@ -1864,7 +1864,7 @@ class users_admin_ui extends e_admin_ui
 
 		//Delete existing rank data
 		e107::getDb()->delete('generic',"gen_type = 'user_rank_data'");
-		
+
 		//Add main site admin info
 		$tmp = array();
 		$tmp['_FIELD_TYPES']['gen_datestamp'] = 'int';
@@ -1878,7 +1878,7 @@ class users_admin_ui extends e_admin_ui
 		$tmp['data']['gen_user_id'] = varset($_POST['calc_pfx']['main_admin'],0);
 		$tmp['data']['gen_chardata'] = $_POST['calc_img']['main_admin'];
 		e107::getDb()->insert('generic',$tmp);
-		
+
 		//Add site admin info
 		unset ($tmp['data']);
 		$tmp['data']['gen_type'] = 'user_rank_data';
@@ -1887,7 +1887,7 @@ class users_admin_ui extends e_admin_ui
 		$tmp['data']['gen_user_id'] = varset($_POST['calc_pfx']['admin'],0);
 		$tmp['data']['gen_chardata'] = $_POST['calc_img']['admin'];
 		e107::getDb()->insert('generic', $tmp);
-		
+
 		//Add all current site defined ranks
 		if (isset ($_POST['field_id']))
 		{
@@ -1902,7 +1902,7 @@ class users_admin_ui extends e_admin_ui
 				e107::getDb()->insert('generic', $tmp);
 			}
 		}
-		
+
 		//Add new rank, if posted
 		if (varset($_POST['new_calc_lower']))
 		{
@@ -1915,7 +1915,7 @@ class users_admin_ui extends e_admin_ui
 			$tmp['data']['gen_intdata'] = varset($_POST['new_calc_lower']);
 			e107::getDb()->insert('generic', $tmp);
 		}
-		
+
 		e107::getMessage()->addSuccess(LAN_UPDATED); //XXX maybe not needed see pull/1816
 		e107::getCache()->clear_sys('nomd5_user_ranks');
 	}
@@ -1923,7 +1923,7 @@ class users_admin_ui extends e_admin_ui
 	function RanksDeleteTrigger($posted)
 	{
 		$rankId = (int) key($posted);
-		
+
 		e107::getCache()->clear_sys('nomd5_user_ranks');
 		if (e107::getDb()->delete('generic',"gen_id='{$rankId}'"))
 		{
@@ -1947,19 +1947,19 @@ class users_admin_ui extends e_admin_ui
 
 		$ranks = e107::getRank()->getRankData();
 		$tmp = e107::getFile()->get_files(e_IMAGE.'ranks', '.*?\.(png|gif|jpg)');
-		
+
 	//	$this->addTitle(LAN_USER_RANKS);
-		
+
 		foreach($tmp as $k => $v)
 		{
 			$imageList[] = $v['fname'];
 		}
 		unset($tmp);
 		natsort($imageList);
-	
+
 		$text = $frm->open('core-user-ranks-form');
 
-		
+
 		$fields = array(
 			'type' => array('title' => USRLAN_207, 'type' => 'text', 'width' => 'auto', 'thclass' => 'left', 'class' => 'left'),
 			'rankName' => array('title' => USRLAN_208, 'type' => 'text', 'width' => 'auto', 'thclass' => 'left', 'class' => 'left'),
@@ -1967,13 +1967,13 @@ class users_admin_ui extends e_admin_ui
 			'langPrefix' => array('title' => USRLAN_210, 'type' => 'text', 'width' => 'auto', 'thclass' => 'left', 'class' => 'left'),
 			'rankImage' => array('title' => USRLAN_211, 'type' => 'text', 'width' => 'auto', 'thclass' => 'left', 'class' => 'left'),
 		);
-	
-	
+
+
 		$text .= "
 		<table class='table adminlist'>".
 		$frm->colGroup($fields, array_keys($fields)).
 		$frm->thead($fields, array_keys($fields));
-	
+
 		$info = $ranks['special'][1];
 		$val = $tp->toForm($info['name']);
 		$text .= "
@@ -2003,7 +2003,7 @@ class users_admin_ui extends e_admin_ui
 			<td colspan='5'>&nbsp;</td>
 		</tr>
 		";
-		
+
 		foreach ($ranks['data'] as $k => $r)
 		{
 			$pfx_checked = ($r['lan_pfx'] ? "checked='checked'" : '');
@@ -2022,9 +2022,9 @@ class users_admin_ui extends e_admin_ui
 			</tr>
 			";
 		}
-		
+
 		$text .= "
-	
+
 		<tr>
 			<td colspan='5'>&nbsp;</td>
 		</tr>
@@ -2035,18 +2035,18 @@ class users_admin_ui extends e_admin_ui
 			<td>".$frm->checkbox('new_calc_pfx', 1, false)."</td>
 			<td>".$ui->RankImageDropdown($imageList, 'new_calc_img')."</td>
 		</tr>";
-		
+
 		$text .= '</table>
 		<div class="buttons-bar center">
 		'.$frm->admin_trigger('update', 'no-value', 'update', LAN_UPDATE).'
 		</div>
 		</form>';
-		
+
 		return $text;		
 	}
-	
+
 	// ================== OLD CODE backup =============>
-	
+
 	// It might be rewritten with user info option (ui trigger)
 	// Old trigger code
 	// if ((isset ($_POST['useraction']) && $_POST['useraction'] == "userinfo") || $_GET['userinfo'])
@@ -2080,8 +2080,8 @@ class users_admin_ui extends e_admin_ui
 			while (list($cb_id, $cb_nick, $cb_message, $cb_datestamp, $cb_blocked, $cb_ip ) = $sql->fetch())
 			{
 				$datestamp = $obj->convert_date($cb_datestamp, "short");
-				$post_author_id = substr($cb_nick, 0, strpos($cb_nick, "."));
-				$post_author_name = substr($cb_nick, (strpos($cb_nick, ".")+1));
+				$post_author_id = substr((string) $cb_nick, 0, strpos((string) $cb_nick, "."));
+				$post_author_name = substr((string) $cb_nick, (strpos((string) $cb_nick, ".")+1));
 				$text .= $bullet."
 					<span class=\"defaulttext\"><i>".$post_author_name." (".USFLAN_6.": ".$post_author_id.")</i></span>
 					<div class=\"mediumtext\">
@@ -2098,8 +2098,8 @@ class users_admin_ui extends e_admin_ui
 			while (list($comment_id, $comment_item_id, $comment_author, $comment_author_email, $comment_datestamp, $comment_comment, $comment_blocked, $comment_ip) = $sql->fetch())
 			{
 				$datestamp = $obj->convert_date($comment_datestamp, "short");
-				$post_author_id = substr($comment_author, 0, strpos($comment_author, "."));
-				$post_author_name = substr($comment_author, (strpos($comment_author, ".")+1));
+				$post_author_id = substr((string) $comment_author, 0, strpos((string) $comment_author, "."));
+				$post_author_name = substr((string) $comment_author, (strpos((string) $comment_author, ".")+1));
 				$text .= $bullet."
 					<span class=\"defaulttext\"><i>".$post_author_name." (".USFLAN_6.": ".$post_author_id.")</i></span>
 					<div class=\"mediumtext\">
@@ -2320,7 +2320,7 @@ class users_admin_ui extends e_admin_ui
 			// require_once ("footer.php");
 			// exit;
 		// }
-		
+
 		global $sql,$pref;
 		include (e_HANDLER.'pop3_class.php');
 		if (!trim($bounce_act))
@@ -2394,9 +2394,9 @@ class users_admin_ui extends e_admin_ui
 		$DEL = ($pref['mail_bounce_delete']) ? true : false;
 		$text = "<br /><div><form  method='post' action='".e_REQUEST_URI."'><table>
 		<tr><td style='width:5%'>#</td><td>e107-id</td><td>email</td><td>Subject</td><td>Bounce</td></tr>\n";
-		
+
 		$identifier = deftrue('MAIL_IDENTIFIER', 'X-e107-id');
-		
+
 		for ($i = 1; $i <= $tot; $i++)
 		{
 			$head = $obj->getHeaders($i);
@@ -2666,7 +2666,7 @@ class users_admin_form_ui extends e_admin_form_ui
 			"<span class='label label-info label-status'>".LAN_BOUNCED."</span>",
 			"<span class='label label-important label-danger label-status'>".USRLAN_56."</span>", // Deleted
 		);
-		
+
 		if($mode == 'filter' || $mode == 'batch')
 		{
 			return 	$bo;
@@ -2684,7 +2684,7 @@ class users_admin_form_ui extends e_admin_form_ui
 
 			return $this->select('user_ban',$bo,$curval);
 		}	
-			
+
 		return vartrue($bo[$curval],' '); // ($curval == 1) ? ADMIN_TRUE_ICON : '';	
 	}	
 	
@@ -2771,13 +2771,13 @@ class users_admin_form_ui extends e_admin_form_ui
 	function options($val, $mode) // old drop-down options. 
 	{
 		$controller = $this->getController();
-		
+
 		if($controller->getMode() != 'main' || $controller->getAction() != 'list') return;
 		$row = $controller->getListModel()->getData();
-		
 
-	
-		
+
+
+
 	//	extract($row);
 
 		$user_id = intval($row['user_id']);
@@ -2913,7 +2913,7 @@ class users_admin_form_ui extends e_admin_form_ui
 			$opts['deldiv'] = 'divider';
 			$opts['deluser'] = LAN_DELETE;
 		}
-		
+
 	//	$foot = "</select>";
 	//	$foot = "</div>";
 
@@ -2953,7 +2953,7 @@ class users_admin_form_ui extends e_admin_form_ui
 		{
 			return '';
 		}
-		
+
 		// return ($text) ? $head.$text.$foot . $btn : "";
 	}
 

--- a/e107_admin/users_extended.php
+++ b/e107_admin/users_extended.php
@@ -57,7 +57,7 @@ if(varset($_GET['mode']) == "ajax")
 				}
 
 				$currVal = $current['user_extended_struct_values'];
-				$curVals = explode(",", varset($currVal));
+				$curVals = explode(",", (string) varset($currVal));
 
 				// Ajax URL for "Table" dropdown.
 				$ajaxGetTableSrc = e_SELF . '?mode=ajax&action=changeTable';
@@ -788,7 +788,7 @@ e107::js('footer-inline', js());
 			$txt .= "
 			<tr>
 			<td>{$var['user_extended_struct_name']}</td>
-			<td>".constant(strtoupper($var['user_extended_struct_text'])."_DESC")."</td>
+			<td>".constant(strtoupper((string) $var['user_extended_struct_text'])."_DESC")."</td>
 			<td>".$ue->user_extended_edit($var,'')."</td>
 	        <td>".$tp->toHTML($var['type'], false, 'defs')."</td>
 			<td class='center'>".($active ? ADMIN_TRUE_ICON : "&nbsp;")."</td>
@@ -842,7 +842,7 @@ e107::js('footer-inline', js());
 
 				$name = $this->getController()->getListModel()->get('user_extended_struct_name');
 
-				if(strpos($name, 'plugin_') === 0)
+				if(strpos((string) $name, 'plugin_') === 0)
 				{
 					$attributes['readParms']['deleteClass'] = e_UC_NOBODY;
 				}
@@ -990,7 +990,7 @@ e107::js('footer-inline', js());
 
 			$text = "<div id='values' style='display:$val_hide'>\n";
 			$text .= "<div id='value_container' >\n";
-			$curVals = explode(",",varset($current['user_extended_struct_values']));
+			$curVals = explode(",",(string) varset($current['user_extended_struct_values']));
 			if(count($curVals) == 0)
 			{
 				$curVals[]='';

--- a/e107_admin/wmessage.php
+++ b/e107_admin/wmessage.php
@@ -58,7 +58,7 @@ class wmessage_admin extends e_admin_dispatcher
 				
 class generic_ui extends e_admin_ui
 {
-			
+
 		protected $pluginTitle		= WMLAN_00;
 		protected $pluginName		= 'core';
 		protected $eventName		= 'wmessage';
@@ -71,11 +71,11 @@ class generic_ui extends e_admin_ui
 	//	protected $sortField		= 'somefield_order';
 	//	protected $orderStep		= 10;
 	//	protected $tabs			= array('Tabl 1','Tab 2'); // Use 'tab'=>0  OR 'tab'=>1 in the $fields below to enable. 
-		
+
 		protected $listQry      	= "SELECT * FROM `#generic` WHERE gen_type='wmessage'  "; // Example Custom Query. LEFT JOINS allowed. Should be without any Order or Limit.
-	
+
 		protected $listOrder		= 'gen_id DESC';
-	
+
 		protected $fields		= array (  
 		  'checkboxes'		=>   array ( 'title' => '', 			'type' => null, 'data' => null, 'width' => '5%', 'thclass' => 'center', 'forced' => '1', 'class' => 'center', 'toggle' => 'e-multiselect',  ),
 		  'gen_id'			=>   array ( 'title' => LAN_ID, 		'data' => 'int', 'width' => '5%', 'help' => '', 'readParms' => '', 'writeParms' => '', 'class' => 'left', 'thclass' => 'left',  ),
@@ -87,26 +87,26 @@ class generic_ui extends e_admin_ui
 		  'gen_chardata'	=>   array ( 'title' => LAN_MESSAGE, 	'type' => 'bbarea', 'data' => 'str', 'width' => 'auto', 'help' => '', 'readParms' => '', 'writeParms' => '', 'class' => 'center', 'thclass' => 'center',  ),
 		  'options' 		=>   array ( 'title' => LAN_OPTIONS, 	'type' => null, 'data' => null, 'width' => '10%', 'thclass' => 'center last', 'class' => 'center last', 'forced' => '1',  ),
 		);		
-		
+
 		protected $fieldpref = array('gen_ip', 'gen_intdata');
-		
-		
+
+
 		protected $prefs = array(
 			'wm_enclose'		=> array('title'=> WMLAN_05, 'type'=>'radio', 'data' => 'int','help'=> WMLAN_06, 'writeParms'=>array('optArray'=>array(0=> LAN_DISABLED, 1=> LAN_ENABLED, 2=> WMLAN_11))),
 		);
 
-	
+
 		public function init()
 		{
 
-	
+
 		}
-	
+
 		public function beforeCreate($new_data, $old_data)
 		{
 			return $new_data;
 		}
-	
+
 		public function afterCreate($new_data, $old_data, $id)
 		{
 			// do something
@@ -121,7 +121,7 @@ class generic_ui extends e_admin_ui
 		{
 			e107::getCache()->clear("wmessage");
 		}
-		
+
 		public function onCreateError($new_data, $old_data)
 		{
 			// do something		
@@ -131,8 +131,8 @@ class generic_ui extends e_admin_ui
 		{
 			// do something		
 		}
-		
-		
+
+
 	/*	
 		// optional - override edit page. 
 		public function customPage()
@@ -140,7 +140,7 @@ class generic_ui extends e_admin_ui
 			$ns = e107::getRender();
 			$text = 'Hello World!';
 			$ns->tablerender('Hello',$text);	
-			
+
 		}
 	*/
 			

--- a/e107_core/bbcodes/bb_block.php
+++ b/e107_core/bbcodes/bb_block.php
@@ -27,7 +27,7 @@ class bb_block extends e_bb_base
 		if(!ADMIN) return $code_text; // TODO - pref
 		
 		// transform to class, equal sign at 0 position is not well formed parm string
-		if($parm && !strpos($parm, '=')) $parm = 'class='.$parm;
+		if($parm && !strpos((string) $parm, '=')) $parm = 'class='.$parm;
 		$parms = eHelper::scParams($parm);
 		$safe = array();
 		
@@ -47,7 +47,7 @@ class bb_block extends e_bb_base
 	function toHTML($code_text, $parm)
 	{
 		// transform to class, equal sign at 0 position is not well formed parm string
-		if($parm && !strpos($parm, '=')) $parm = 'class='.$parm;
+		if($parm && !strpos((string) $parm, '=')) $parm = 'class='.$parm;
 		$parms = eHelper::scParams($parm);
 		
 		// add auto-generated class name and parameter class if available

--- a/e107_core/bbcodes/bb_code.php
+++ b/e107_core/bbcodes/bb_code.php
@@ -18,7 +18,7 @@ class bb_code extends e_bb_base
 		$paramet 	= ($parm == 'inline') ? 'inline' : '';
 	//	$code_text 	= htmlspecialchars($code_text, ENT_QUOTES, 'UTF-8');
 	//	$code_text = str_replace('<','&ltr;',$code_text);
-		$code_text = htmlentities($code_text, ENT_QUOTES, 'utf-8');	
+		$code_text = htmlentities((string) $code_text, ENT_QUOTES, 'utf-8');	
 
 	//	$srch = array('{','}');
 	//	$repl = array( '&lbrace;', '&rbrace;'); // avoid code getting parsed as templates or shortcodes. 

--- a/e107_core/bbcodes/bb_h.php
+++ b/e107_core/bbcodes/bb_h.php
@@ -22,7 +22,7 @@ class bb_h extends e_bb_base
 	 */
 	function toDB($code_text, $parm)
 	{
-		$code_text = trim($code_text);
+		$code_text = trim((string) $code_text);
 		if(empty($code_text)) return '';
 
 		$bparms = eHelper::scDualParams($parm);
@@ -57,7 +57,7 @@ class bb_h extends e_bb_base
 	 */
 	function toHTML($code_text, $parm)
 	{
-		$code_text = trim($code_text);
+		$code_text = trim((string) $code_text);
 		if(empty($code_text)) return '';
 		$bparms = eHelper::scDualParams($parm);
 		

--- a/e107_core/bbcodes/bb_img.php
+++ b/e107_core/bbcodes/bb_img.php
@@ -230,7 +230,7 @@
 			$code_text = str_replace($search, $replace, $code_text);
 			$code_text = e107::getParser()->toAttribute($code_text);
 
-			$img_file = pathinfo($code_text);        // 'External' file name. N.B. - might still contain a constant such as e_IMAGE
+			$img_file = pathinfo((string) $code_text);        // 'External' file name. N.B. - might still contain a constant such as e_IMAGE
 
 			$parmStr = $this->processParm($code_text, $parm, 'string');
 

--- a/e107_core/bbcodes/bb_nobr.php
+++ b/e107_core/bbcodes/bb_nobr.php
@@ -30,6 +30,6 @@ class bb_nobr extends e_bb_base
 	 */
 	function toHTML($code_text, $parm)
 	{
-		return str_replace(E_NL, "\n", trim($code_text));
+		return str_replace(E_NL, "\n", trim((string) $code_text));
 	}
 }

--- a/e107_core/bbcodes/bb_p.php
+++ b/e107_core/bbcodes/bb_p.php
@@ -21,10 +21,10 @@ class bb_p extends e_bb_base
 	 */
 	function toDB($code_text, $parm)
 	{
-		$code_text = trim($code_text);
+		$code_text = trim((string) $code_text);
 		if(empty($code_text)) return '';
 		
-		if($parm && !strpos($parm, '=')) $parm = 'class='.$parm;
+		if($parm && !strpos((string) $parm, '=')) $parm = 'class='.$parm;
 		
 		$parms = eHelper::scParams($parm);
 		$safe = array();
@@ -55,8 +55,8 @@ class bb_p extends e_bb_base
 	 */
 	function toHTML($code_text, $parm)
 	{
-		if($parm && !strpos($parm, '=')) $parm = 'class='.$parm;
-		$code_text = trim($code_text);
+		if($parm && !strpos((string) $parm, '=')) $parm = 'class='.$parm;
+		$code_text = trim((string) $code_text);
 
 		$parms = eHelper::scParams($parm);
 				

--- a/e107_core/bbcodes/bb_youtube.php
+++ b/e107_core/bbcodes/bb_youtube.php
@@ -43,10 +43,10 @@ class bb_youtube extends e_bb_base
 	{
 		$bbpars = array();
 		$widthString = '';
-		$parm = trim($parm);
+		$parm = trim((string) $parm);
 		
 		// Convert Simple URLs. 
-		if(strpos($code_text,"youtube.com/watch?v=")!==FALSE || strpos($code_text,"youtube.com/watch#!v=")!==FALSE )
+		if(strpos((string) $code_text,"youtube.com/watch?v=")!==FALSE || strpos((string) $code_text,"youtube.com/watch#!v=")!==FALSE )
 		{
 			$validUrls = array("http://", "https://", "www.","youtube.com/watch?v=","youtube.com/watch#!v=");
 			$tmp = str_replace($validUrls,'',$code_text);
@@ -80,14 +80,14 @@ class bb_youtube extends e_bb_base
 		
 		$params = array();										// Accumulator for parameters from youtube code
 		$ok = 0;
-		if (strpos($code_text, '<') === FALSE)
+		if (strpos((string) $code_text, '<') === FALSE)
 		{	// 'Properly defined' bbcode (we hope)
 			$picRef = $code_text;
 		}
 		else
 		{
 			//libxml_use_internal_errors(TRUE);
-			if (FALSE === ($info = simplexml_load_string($code_text)))
+			if (FALSE === ($info = simplexml_load_string((string) $code_text)))
 			{
 				//print_a($matches);
 				//$xmlErrs = libxml_get_errors();
@@ -113,13 +113,13 @@ class bb_youtube extends e_bb_base
 			if ($ok != 0)
 			{
 				print_a($info);
-				return '[sanitised]'.$ok.'B'.htmlspecialchars($matches[0]).'B[/sanitised]';
+				return '[sanitised]'.$ok.'B'.htmlspecialchars((string) $matches[0]).'B[/sanitised]';
 			}
 			$target =  (array)$info2['@attributes'];
 			unset($info);
 			$ws = varset($target['width'], 0);
 			$hs = varset($target['height'], 0);
-			if (($ws == 0) || ($hs == 0) || !isset($target['src'])) return  '[sanitised]A'.htmlspecialchars($matches[0]).'A[/sanitised]';
+			if (($ws == 0) || ($hs == 0) || !isset($target['src'])) return  '[sanitised]A'.htmlspecialchars((string) $matches[0]).'A[/sanitised]';
 			if (!$widthString)
 			{
 				$widthString = $ws.','.$hs;			// Set size of window
@@ -173,7 +173,7 @@ class bb_youtube extends e_bb_base
 		}
 
 
-		$yID = preg_replace('/[^0-9a-z]/i', '', $picRef);
+		$yID = preg_replace('/[^0-9a-z]/i', '', (string) $picRef);
 		//if (($yID != $picRef) || (strlen($yID) > 20))
 	//	{	// Possible hack attempt
 	//	}
@@ -202,29 +202,29 @@ class bb_youtube extends e_bb_base
 	{
 		if(empty($code_text)) return '';
 
-		$t = explode('|', $parm, 2);
+		$t = explode('|', (string) $parm, 2);
 
 		$dimensions = varset($t[0]);
 		$tmp = varset($t[1]);
 
 		if($tmp)
 		{
-			parse_str(varset($tmp, ''), $bbparm);
+			parse_str((string) varset($tmp, ''), $bbparm);
 		}
 		
-		if(strpos($code_text,"&")!==FALSE && strpos($code_text,"?")===FALSE) // DEPRECATED
+		if(strpos((string) $code_text,"&")!==FALSE && strpos((string) $code_text,"?")===FALSE) // DEPRECATED
 		{
-			$parms = explode('&', $code_text, 2);	
+			$parms = explode('&', (string) $code_text, 2);	
 		}
 		else
 		{
-			$parms = explode('?', $code_text, 2);	// CORRECT SEPARATOR
+			$parms = explode('?', (string) $code_text, 2);	// CORRECT SEPARATOR
 		}
 		
 
 		$code_text = $parms[0];
 			
-		parse_str(varset($parms[1], ''), $params);
+		parse_str((string) varset($parms[1], ''), $params);
 		
 	//	print_a($params);
 
@@ -317,7 +317,7 @@ class bb_youtube extends e_bb_base
 		if(isset($params['color2'])) $color[2] = $params['color2'];
 		foreach ($color as $key => $value)
 		{
-			if (ctype_xdigit($value) && strlen($value) == 6)
+			if (ctype_xdigit($value) && strlen((string) $value) == 6)
 			{
 				$url = $url.'&amp;color'.$key.'='.$value;
 			}

--- a/e107_core/shortcodes/batch/admin_shortcodes.php
+++ b/e107_core/shortcodes/batch/admin_shortcodes.php
@@ -36,7 +36,7 @@ class admin_shortcodes extends e_shortcode
             {	//TODO LANVARS
 				$text = ADLAN_122.'  v'.$cacheData.'</a>.
 					<a class="btn btn-success" href="'.$installUrl.'">'.ADLAN_121.'</a>'; //Install
-				
+
 				$mes->addInfo($text);
 				return null; //  $mes->render();
 			}
@@ -411,7 +411,7 @@ class admin_shortcodes extends e_shortcode
 		{
 			foreach($GLOBALS['mySQLtablelist'] as $tabs)
 			{
-				$clang = strtolower($sql->mySQLlanguage);
+				$clang = strtolower((string) $sql->mySQLlanguage);
 				if($clang !="" && strpos($tabs, 'lan_' .$clang))
 				{
 					$aff[] = str_replace(MPREFIX. 'lan_' .$clang. '_', '',$tabs);
@@ -775,7 +775,7 @@ class admin_shortcodes extends e_shortcode
 		$pref = e107::getPref();
 
 
-		$curScript = basename($_SERVER['SCRIPT_FILENAME']);
+		$curScript = basename((string) $_SERVER['SCRIPT_FILENAME']);
 
 		// Obsolete
 		ob_start();
@@ -860,7 +860,7 @@ class admin_shortcodes extends e_shortcode
 
 		// User Classes as bullets, sorted alphabetically, excluding PUBLIC (0), MAINADMIN (250), READONLY (251), GUEST (252), MEMBER (253), ADMIN (254), NOBODY (255)
 		$text .= "<p><strong>User Classes:</strong><br />";
-		$classIds = array_filter(explode(',', $emulatedUser['user_class']));
+		$classIds = array_filter(explode(',', (string) $emulatedUser['user_class']));
 		$excludedClasses = ['0', '250', '251', '252', '253', '254', '255']; // PUBLIC, MAINADMIN, READONLY, GUEST, MEMBER, ADMIN, NOBODY
 		$classIds = array_diff($classIds, $excludedClasses);
 		if(!empty($classIds))
@@ -889,7 +889,7 @@ class admin_shortcodes extends e_shortcode
 		$text .= "<p><strong>Admin Permissions:</strong><br />";
 		if(!empty($emulatedUser['user_perms']) && $emulatedUser['user_perms'] !== '.')
 		{
-			$permKeys = array_filter(explode('.', $emulatedUser['user_perms']));
+			$permKeys = array_filter(explode('.', (string) $emulatedUser['user_perms']));
 			$permdiz = e107::getUserPerms()->getPermList('all');
 			$permNames = [];
 			foreach($permKeys as $p)
@@ -1050,12 +1050,12 @@ class admin_shortcodes extends e_shortcode
 		{
 			return;
 		}
-        
+
         $sql = e107::getDb();
 		$tp = e107::getParser();
-		
+
         $count =  $sql->count('private_msg','(*)','WHERE pm_read = 0 AND pm_to='.USERID);
-       
+
        	if ($count >0)
        	{
             $countDisp = ' <span class="badge badge-primary">'.$count.'</span> ' ;
@@ -1064,7 +1064,7 @@ class admin_shortcodes extends e_shortcode
       	{
             $countDisp = '';    
       	}
-         
+
 		$inboxUrl 	= e_PLUGIN.'pm/admin_config.php?mode=inbox&amp;action=list&amp;iframe=1';
 		$outboxUrl 	= e_PLUGIN.'pm/admin_config.php?mode=outbox&amp;action=list&amp;iframe=1';
 		$composeUrl = e_PLUGIN.'pm/admin_config.php?mode=outbox&amp;action=create&amp;iframe=1';
@@ -1084,15 +1084,15 @@ class admin_shortcodes extends e_shortcode
         	</li>
         </ul>
         '; 
-        
+
         return $text;
-        
+
       //  e107_plugins/pm/pm.php
-        
-        
-        
+
+
+
        /*
-        
+
 		$text = '
 		<li class="dropdown">
 			<a class="dropdown-toggle" title="Messages" role="button" data-toggle="dropdown" data-bs-toggle="dropdown" href="#" >
@@ -1461,7 +1461,7 @@ class admin_shortcodes extends e_shortcode
 			$text .= '<br />
 			<b>' .FOOTLAN_9. '</b>
 			<br />' .
-			preg_replace('/PHP.*/i', '', varset($_SERVER['SERVER_SOFTWARE'])). '<br />(' .FOOTLAN_10. ': ' .$_SERVER['SERVER_NAME']. ')
+			preg_replace('/PHP.*/i', '', (string) varset($_SERVER['SERVER_SOFTWARE'])). '<br />(' .FOOTLAN_10. ': ' .$_SERVER['SERVER_NAME']. ')
 			<br /><br />
 			<b>' .FOOTLAN_11. '</b>
 			<br />
@@ -1706,7 +1706,7 @@ Inverse 	10 	<span class="badge badge-inverse">10</span>
 	static function legacyToConfig($text)
 	{
 		$var = array();
-		preg_match_all('/(<img[^>]*>)[\s]*<a[^>]href=(\'|")([^\'"]*)(\'|")>([^<]*)<\/a>[: ]*([\d]*)/is',$text, $match);
+		preg_match_all('/(<img[^>]*>)[\s]*<a[^>]href=(\'|")([^\'"]*)(\'|")>([^<]*)<\/a>[: ]*([\d]*)/is',(string) $text, $match);
 		foreach($match[5] as $k=>$m)
 		{
 			$var[$k]['icon'] 	= $match[1][$k];
@@ -2299,7 +2299,7 @@ Inverse 	10 	<span class="badge badge-inverse">10</span>
 			$parms = $parm;
 		}
 
-		$tmpl = strtoupper(varset($parms['tmpl'], 'E_ADMIN_NAVIGATION'));
+		$tmpl = strtoupper((string) varset($parms['tmpl'], 'E_ADMIN_NAVIGATION'));
 	//	global $$tmpl;
 		$template = e107::getCoreTemplate('admin', 'nav', false);
 
@@ -2408,7 +2408,7 @@ Inverse 	10 	<span class="badge badge-inverse">10</span>
 				$tmp['sub_class'] = '';
 				$tmp['sort'] = false;
 
-				if(strpos(e_REQUEST_SELF,$tmp['link'])!==false)
+				if(strpos(e_REQUEST_SELF,(string) $tmp['link'])!==false)
 				{
 					$active = $catid;
 				}
@@ -2480,7 +2480,7 @@ Inverse 	10 	<span class="badge badge-inverse">10</span>
 			 	    $id = $convert[$pg['category']][1];
              	    $menu_vars[$id]['sub'][] = $pg;
 
-				    if(strpos(e_REQUEST_SELF,$pg['link'])!==false)
+				    if(strpos(e_REQUEST_SELF,(string) $pg['link'])!==false)
 					{
 						$active = $id;
 					}
@@ -2790,7 +2790,7 @@ Inverse 	10 	<span class="badge badge-inverse">10</span>
 		$caption .= "<span class='e-help-icon pull-right'><a data-placement=\"bottom\" class='e-tip' title=\"".e107::getParser()->toAttribute($diz). '">' .defset('ADMIN_INFO_ICON'). '</a></span>';
 
 		$var['_extras_']['icon'] = e107::getParser()->toIcon('e-menus-24');
-		
+
 	   return e107::getNav()->admin($caption,$action, $var);
 
 
@@ -2799,7 +2799,7 @@ Inverse 	10 	<span class="badge badge-inverse">10</span>
 
         $var['menumanager']['text'] = LAN_MENULAYOUT;
 		$var['menumanager']['link'] = e_ADMIN_ABS.'menus.php';
-		
+
 		$var['nothing']['divider'] = true;
 
 		if(vartrue($pref['menuconfig_list']))
@@ -2882,7 +2882,7 @@ Inverse 	10 	<span class="badge badge-inverse">10</span>
 		$text .= '<h4>Plugin Menus</h4>';
 		foreach($pluginMenu as $row)
 		{
-			$text .= "<div class='item' data-menu-id='".$row['menu_id']."'>".substr($row['menu_name'],0,-5). '</div>';
+			$text .= "<div class='item' data-menu-id='".$row['menu_id']."'>".substr((string) $row['menu_name'],0,-5). '</div>';
 		}
 
 		$text .= '</div>';

--- a/e107_core/shortcodes/batch/bbcode_shortcodes.php
+++ b/e107_core/shortcodes/batch/bbcode_shortcodes.php
@@ -129,7 +129,7 @@ class bbcode_shortcodes extends e_shortcode
 		}
 		else
 		{
-			list($tag,$tmp) = explode("--",$this->var['tagid']); // works with $frm->bbarea to detect textarea from first half of tag. 
+			list($tag,$tmp) = explode("--",(string) $this->var['tagid']); // works with $frm->bbarea to detect textarea from first half of tag. 
 		}			
 
 		if (ADMIN)
@@ -178,7 +178,7 @@ class bbcode_shortcodes extends e_shortcode
 		}
 		else
 		{
-			list($tag,$tmp) = explode("--",$this->var['tagid']); // works with $frm->bbarea to detect textarea from first half of tag. 
+			list($tag,$tmp) = explode("--",(string) $this->var['tagid']); // works with $frm->bbarea to detect textarea from first half of tag. 
 		}			
 				
 			
@@ -245,7 +245,7 @@ class bbcode_shortcodes extends e_shortcode
 		}
 		else
 		{
-			list($tag,$tmp) = explode("--",$this->var['tagid']); // works with $frm->bbarea to detect textarea from first half of tag. 
+			list($tag,$tmp) = explode("--",(string) $this->var['tagid']); // works with $frm->bbarea to detect textarea from first half of tag. 
 		}
 
 	/*
@@ -275,7 +275,7 @@ class bbcode_shortcodes extends e_shortcode
 		}
 		else
 		{
-			list($tag,$tmp) = explode("--",$this->var['tagid']); // works with $frm->bbarea to detect textarea from first half of tag. 
+			list($tag,$tmp) = explode("--",(string) $this->var['tagid']); // works with $frm->bbarea to detect textarea from first half of tag. 
 		}
 		//$text = "<a class='e-modal btn btn-primary' data-modal-caption='Media Manager' data-target='#uiModal' id='{$id}' title='Insert a file from the Media-Manager' href='".e_HTTP.e_ADMIN."image.php?mode=main&amp;action=dialog&amp;for=_common_file&amp;tagid=".$tag."&amp;iframe=1&amp;bbcode=file'  >";
 		$text = "<a class='e-modal btn btn-primary' data-modal-caption='".LAN_MEDIAMANAGER."' data-target='#uiModal' id='{$id}' title='".LANHELP_64."' href='".e_ADMIN_ABS."image.php?mode=main&amp;action=dialog&amp;for=_common_file&amp;tagid=".$tag."&amp;iframe=1&amp;bbcode=file'  >";
@@ -397,7 +397,7 @@ class bbcode_shortcodes extends e_shortcode
 			$key = str_replace("!", ".", $key);					// Usually '.' was replaced by '!' when saving
 			$key = preg_replace("#_(\w{3})$#", ".\\1", $key);	// '_' followed by exactly 3 chars is file extension
 			$key = e_IMAGE_ABS."emotes/" . $pref['emotepack'] . "/" .$key;		// Add in the file path
-						$value2 = substr($value, 0, strpos($value, " "));
+						$value2 = substr((string) $value, 0, strpos((string) $value, " "));
 			$value = ($value2 ? $value2 : $value);
 			$value = ($value == '&|') ? ':((' : $value;
 			$text .= "<a style='display:inline-block; margin:2px; padding:2px' href=\"javascript:addtext('$value ',true)\"><img src='$key' alt='' /></a>";

--- a/e107_core/shortcodes/batch/comment_shortcodes.php
+++ b/e107_core/shortcodes/batch/comment_shortcodes.php
@@ -71,7 +71,7 @@ class comment_shortcodes extends e_shortcode
 		else
 		{
 			$this->var['user_id'] = 0;
-			$USERNAME = preg_replace("/[0-9]+\./", '', vartrue($this->var['comment_author_name']));
+			$USERNAME = preg_replace("/[0-9]+\./", '', (string) vartrue($this->var['comment_author_name']));
 			$USERNAME = str_replace("Anonymous", LAN_ANONYMOUS, $USERNAME);
 		}
 		return $USERNAME;
@@ -183,7 +183,7 @@ class comment_shortcodes extends e_shortcode
 			$this->var['user_image'] = '';
 		}
 		return $this->var['user_image'];
-		
+
 		 */
 
 	}
@@ -236,12 +236,12 @@ class comment_shortcodes extends e_shortcode
 		return $text;
 		/*
 		$url 		= e_PAGE."?".e_QUERY;
-		
+
 		$unblock 	= "[<a href='".e_ADMIN_ABS."comment.php?unblock-".$comrow['comment_id']."-$url-".$comrow['comment_item_id']."'>".COMLAN_1."</a>] ";
 		$block 		= "[<a href='".e_ADMIN_ABS."comment.php?block-".$comrow['comment_id']."-$url-".$comrow['comment_item_id']."'>".COMLAN_2."</a>] ";
 		$delete 	= "[<a href='".e_ADMIN_ABS."comment.php?delete-".$comrow['comment_id']."-$url-".$comrow['comment_item_id']."'>".LAN_DELETE."</a>] ";
 		$userinfo 	= "[<a href='".e_ADMIN_ABS."userinfo.php?".e107::getIPHandler()->ipDecode($comrow['comment_ip'])."'>".COMLAN_4."</a>]";
-			
+
 		return $unblock.$block.$delete.$userinfo;
 		 * */
 	}

--- a/e107_core/shortcodes/batch/contact_shortcodes.php
+++ b/e107_core/shortcodes/batch/contact_shortcodes.php
@@ -219,7 +219,7 @@ class contact_shortcodes extends e_shortcode
 		$class = (!empty($parm['class'])) ? $parm['class'] : 'tbox '.$size.' form-control';
 
 
-		$value = !empty($_POST['body']) ? stripslashes($_POST['body']) : '';
+		$value = !empty($_POST['body']) ? stripslashes((string) $_POST['body']) : '';
 		
 		return "<textarea cols='{$cols}'  id='contactBody' rows='{$rows}' title='".LAN_CONTACT_20."' aria-label='".LAN_CONTACT_20."' aria-labelledby='contactBody' name='body' ".$placeholder." required='required' class='".$class."'>".$value."</textarea>";
 	}

--- a/e107_core/shortcodes/batch/navigation_shortcodes.php
+++ b/e107_core/shortcodes/batch/navigation_shortcodes.php
@@ -88,9 +88,9 @@ require_once(__DIR__.'/navigation_shortcodes_legacy.php');
 				return null;
 			}
 
-			if(strpos($this->var['link_name'], 'submenu.') === 0) // BC Fix.
+			if(strpos((string) $this->var['link_name'], 'submenu.') === 0) // BC Fix.
 			{
-				list($tmp, $tmp2, $link) = explode('.', $this->var['link_name'], 3);
+				list($tmp, $tmp2, $link) = explode('.', (string) $this->var['link_name'], 3);
 				unset($tmp, $tmp2);
 			}
 			else
@@ -134,11 +134,11 @@ require_once(__DIR__.'/navigation_shortcodes_legacy.php');
 				return e107::url($this->var['link_owner'], $this->var['link_sefurl']);
 			}
 
-			if(strpos($this->var['link_url'], e_HTTP) === 0)
+			if(strpos((string) $this->var['link_url'], e_HTTP) === 0)
 			{
-				$url = "{e_BASE}" . substr($this->var['link_url'], strlen(e_HTTP));
+				$url = "{e_BASE}" . substr((string) $this->var['link_url'], strlen(e_HTTP));
 			}
-			elseif($this->var['link_url'][0] !== "{" && strpos($this->var['link_url'], "://") === false)
+			elseif($this->var['link_url'][0] !== "{" && strpos((string) $this->var['link_url'], "://") === false)
 			{
 				$url = "{e_BASE}" . $this->var['link_url']; // Add e_BASE to links like: 'news.php' or 'contact.php' 	
 			}
@@ -181,9 +181,9 @@ require_once(__DIR__.'/navigation_shortcodes_legacy.php');
 		function sc_nav_link_target($parm = null)
 		{
 
-			if(strpos($this->var['link_url'], '#') !== false)
+			if(strpos((string) $this->var['link_url'], '#') !== false)
 			{
-				list($tmp, $segment) = explode('#', $this->var['link_url'], 2);
+				list($tmp, $segment) = explode('#', (string) $this->var['link_url'], 2);
 
 				return '#' . $segment;
 
@@ -213,7 +213,7 @@ require_once(__DIR__.'/navigation_shortcodes_legacy.php');
 			{
 				case 1:
 					$text = ' target="_blank"';
-					$rel = (strpos($this->var['link_url'], 'http') !== false) ? 'noopener noreferrer'  : '';
+					$rel = (strpos((string) $this->var['link_url'], 'http') !== false) ? 'noopener noreferrer'  : '';
 					break;
 
 				case 4:

--- a/e107_core/shortcodes/batch/news_shortcodes.php
+++ b/e107_core/shortcodes/batch/news_shortcodes.php
@@ -193,7 +193,7 @@ class news_shortcodes extends e_shortcode
 		if(!vartrue($pref['trackbackEnabled'])) { return ''; }
 		$news_item = $this->news_item;
 		$news_item['#'] = 'track';
-		
+
 		return ($this->param['trackbackbeforestring'] ? $this->param['trackbackbeforestring'] : '')."<a href='".e107::getUrl()->create('news/view/item', $this->news_item)."'>".$this->param['trackbackstring'].$this->news_item['tb_count'].'</a>'.($this->param['trackbackafterstring'] ? $this->param['trackbackafterstring'] : '');*/
 	}
 
@@ -269,7 +269,7 @@ class news_shortcodes extends e_shortcode
 			$parm = array('type'=>$parm);
 		}
 		// BC
-		$category_icon = !empty($this->news_item['category_icon']) ? str_replace('../', '', trim($this->news_item['category_icon'])) : '';
+		$category_icon = !empty($this->news_item['category_icon']) ? str_replace('../', '', trim((string) $this->news_item['category_icon'])) : '';
 		if (!$category_icon) { return ''; }
 
 		// We store SC path in DB now + BC
@@ -566,7 +566,7 @@ class news_shortcodes extends e_shortcode
 
 		$tp = e107::getParser();
 
-		$media = explode(",", $this->news_item['news_thumbnail']);
+		$media = explode(",", (string) $this->news_item['news_thumbnail']);
 		$images = array();
 
 		foreach($media as $file)
@@ -978,7 +978,7 @@ class news_shortcodes extends e_shortcode
 	function sc_news_media($parm=array())
 	{
 		
-		$media = explode(",", $this->news_item['news_thumbnail']);
+		$media = explode(",", (string) $this->news_item['news_thumbnail']);
 
 		if(empty($parm['item']))
 		{
@@ -1036,7 +1036,7 @@ class news_shortcodes extends e_shortcode
 		
 		$tp = e107::getParser();
 	
-		$media = explode(",", $this->news_item['news_thumbnail']);
+		$media = explode(",", (string) $this->news_item['news_thumbnail']);
 		$list = array();
 		
 		foreach($media as $file)
@@ -1148,7 +1148,7 @@ class news_shortcodes extends e_shortcode
 		$parm = explode('|', $parm, 2);
 		$parm[1] = 'news_id='.$this->news_item['news_id'].(varset($parm[1]) ? '&'.$parm[1] : '');
 		e107::setRegistry('core/news/schook_data', array('data' => $this->news_item, 'params' => $this->param));
-		return e107::getParser()->parseTemplate('{'.strtoupper($parm[0]).'='.$parm[1].'}');
+		return e107::getParser()->parseTemplate('{'.strtoupper((string) $parm[0]).'='.$parm[1].'}');
 	}
 
 	public function sc_news_info($parm=null)
@@ -1163,14 +1163,14 @@ class news_shortcodes extends e_shortcode
 		$info .= $news_item['news_sticky'] ? '<br />'.LAN_NEWS_31 : '';
 		$info .= '<br />'.($news_item['news_allow_comments'] ? LAN_NEWS_13 : LAN_NEWS_12);
 		$info .= LAN_NEWS_14.$news_item['news_start'].$news_item['news_end'].'<br />';
-		$info .= LAN_NEWS_15.strlen($news_item['news_body']).LAN_NEWS_16.strlen($news_item['news_extended']).LAN_NEWS_17."<br /><br />";
+		$info .= LAN_NEWS_15.strlen((string) $news_item['news_body']).LAN_NEWS_16.strlen((string) $news_item['news_extended']).LAN_NEWS_17."<br /><br />";
 		//return $ns->tablerender(LAN_NEWS_18, $info);
 		return $info;
 	}
 
 	function sc_news_tags($parm=null)
 	{
-		$tmp = explode(",",$this->news_item['news_meta_keywords']);
+		$tmp = explode(",",(string) $this->news_item['news_meta_keywords']);
 		$words = array();
 		$class = (!empty($parm['class'])) ? $parm['class'] : 'news-tag';
 		$separator = (isset($parm['separator'])) ? $parm['separator'] : ', ';

--- a/e107_core/shortcodes/batch/page_shortcodes.php
+++ b/e107_core/shortcodes/batch/page_shortcodes.php
@@ -76,14 +76,14 @@ class cpage_shortcodes extends e_shortcode
 			$pid = $this->var['page_chapter'];
 			$cid = isset($this->chapterData[$pid]['chapter_parent']) ?  $this->chapterData[$pid]['chapter_parent'] : 0;
 		}
-		
+
 		$row = isset($this->chapterData[$cid]) ? $this->chapterData[$cid] : array();
-		
+
 		if(!empty($row['chapter_id']) && $row['chapter_parent'] < 1)
 		{
 			return $row;	
 		}
-		
+
 		return false; // not a book.
 		
 	}
@@ -150,7 +150,7 @@ class cpage_shortcodes extends e_shortcode
 			}
 			elseif(!empty($this->var['user_name']))
 			{
-				$author = preg_replace('/[^\w\pL\s]+/u', ' ', $this->var['user_name']);
+				$author = preg_replace('/[^\w\pL\s]+/u', ' ', (string) $this->var['user_name']);
 			}
 		}
 		
@@ -205,13 +205,13 @@ class cpage_shortcodes extends e_shortcode
 				}
 			}
 		}
-		
+
 		//if($parm && isset($com[$parm])) return $com[$parm];
 		if($comflag)
 		{
 			return e107::getComment()->parseLayout($com['comment'],$com['comment_form'],$com['moderate']);	
 		}
-		
+
 	//	return $com['comment'].$com['moderate'].$com['comment_form'];
 	}
 
@@ -274,7 +274,7 @@ class cpage_shortcodes extends e_shortcode
 		if(empty($parms[1])) return '';
 		
 		$tp = e107::getParser();
-		$path = rawurldecode($parms[1]);
+		$path = rawurldecode((string) $parms[1]);
 		
 		if(substr($path, 0, 2) === 'e_') $path = str_replace($tp->getUrlConstants('raw'), $tp->getUrlConstants('sc'), $path);
 		elseif($path[0] !== '{') $path = '{e_MEDIA}'.$path;
@@ -347,7 +347,7 @@ class cpage_shortcodes extends e_shortcode
 			return $url;
 		}
 		
-		if(trim($this->var['page_text']) == '' && empty($this->var['menu_button_url'])) // Hide the button when there is no page content. (avoids templates with and without buttons)
+		if(trim((string) $this->var['page_text']) == '' && empty($this->var['menu_button_url'])) // Hide the button when there is no page content. (avoids templates with and without buttons)
 		{
 			return "<!-- Button Removed: No page text exists! -->";	
 		}

--- a/e107_core/shortcodes/batch/signup_shortcodes.php
+++ b/e107_core/shortcodes/batch/signup_shortcodes.php
@@ -131,7 +131,7 @@ class signup_shortcodes extends e_shortcode
 		{
 			if ($v['enabled'] == 1)
 			{
-				$ic = strtolower($p);
+				$ic = strtolower((string) $p);
 
 				switch ($ic)
 				{

--- a/e107_core/shortcodes/batch/user_shortcodes.php
+++ b/e107_core/shortcodes/batch/user_shortcodes.php
@@ -298,17 +298,17 @@ class user_shortcodes extends e_shortcode
 	{
 		$boot = deftrue('BOOTSTRAP');
 		$tp = e107::getParser();
-		
+
 		switch ($parm) 
 		{
 			case 'email':
 				return ($boot) ? $tp->toGlyph('fa-envelope') : $this->sc_user_email_icon();
 			break;
-			
+
 			case 'lastvisit':
 				return ($boot) ? $tp->toGlyph('fa fa-clock-o') : '';
 			break;
-			
+
 			case 'birthday':
 				return ($boot) ? $tp->toGlyph('fa-calendar') : $this->sc_user_birthday_icon();
 			break;
@@ -316,11 +316,11 @@ class user_shortcodes extends e_shortcode
 			case 'level':
 				return ($boot) ? $tp->toGlyph('fa-signal') : '';
 			break;
-			
+
 			case 'website':
 				return ($boot) ? $tp->toGlyph('fa-home') : '';
 			break;
-			
+
 			case 'location':
 				return ($boot) ? $tp->toGlyph('fa-map-marker') : '';
 			break;
@@ -337,7 +337,7 @@ class user_shortcodes extends e_shortcode
 			break;
 		}
 
-	
+
 		/*
 		if(defined("USER_ICON"))
 		{
@@ -347,7 +347,7 @@ class user_shortcodes extends e_shortcode
 		{
 			return "<img src='".THEME_ABS."images/user.png' alt='' style='vertical-align:middle;' /> ";
 		}
-		
+
 		return "<img src='".e_IMAGE_ABS."user_icons/user.png' alt='' style='vertical-align:middle;' /> ";
 		*/
 	}
@@ -426,7 +426,7 @@ class user_shortcodes extends e_shortcode
 
 	function sc_user_birthday($parm='')
 	{
-		if(!empty($this->var['user_birthday']) && $this->var['user_birthday'] != "0000-00-00" && preg_match("/([0-9]{4})-([0-9]{1,2})-([0-9]{1,2})/", $this->var['user_birthday'], $regs))
+		if(!empty($this->var['user_birthday']) && $this->var['user_birthday'] != "0000-00-00" && preg_match("/([0-9]{4})-([0-9]{1,2})-([0-9]{1,2})/", (string) $this->var['user_birthday'], $regs))
 		{
 			return "$regs[3].$regs[2].$regs[1]";
 		}
@@ -588,10 +588,10 @@ class user_shortcodes extends e_shortcode
 	
 		if($parms[1] == 'prev')
 		{
-		
+
 			$icon = (deftrue('BOOTSTRAP')) ? $tp->toGlyph('fa-chevron-left') : '&lt;&lt;';
 	    	return isset($userjump['prev']['id']) ? "<a class='".$class."' href='".$url->create('user/profile/view', $userjump['prev']) ."' title=\"".$userjump['prev']['name']."\">".$icon." ".LAN_USER_40."</a>\n" : "&nbsp;";
-		
+
 			// return isset($userjump['prev']['id']) ? "&lt;&lt; ".LAN_USER_40." [ <a href='".$url->create('user/profile/view', $userjump['prev'])."'>".$userjump['prev']['name']."</a> ]" : "&nbsp;";
 		
 		}
@@ -619,7 +619,7 @@ class user_shortcodes extends e_shortcode
 		/*
 
 		return $tp->parseTemplate("{USER_AVATAR=".$this->var['user_sess']."}",true);
-		
+
 		if ($this->var['user_sess'] && file_exists(e_MEDIA."avatars/".$this->var['user_sess']))
 		{
 			//return $tp->parseTemplate("{USER_AVATAR=".$this->var['user_image']."}", true); // this one will resize. 
@@ -675,7 +675,7 @@ class user_shortcodes extends e_shortcode
 		}
 
 		// Get all userclasses that the user belongs to (comma separated)
-		$userclasses = explode(',', $this->var['user_class']);
+		$userclasses = explode(',', (string) $this->var['user_class']);
 		//print_a($userclasses);
  		
  		// Loop through userclasses
@@ -959,8 +959,8 @@ class user_shortcodes extends e_shortcode
 		if($parm){
 			
 			//if the first char of parm is an ! mark, it means it should not render the following parms
-			if(strpos($parm,'!')===0){
-				$tmp = explode(",", substr($parm,1) );
+			if(strpos((string) $parm,'!')===0){
+				$tmp = explode(",", substr((string) $parm,1) );
 				foreach($tmp as $not){
 					$not=trim($not);
 					if(isset($key[$not])){
@@ -968,10 +968,10 @@ class user_shortcodes extends e_shortcode
 						unset($key[$not]);
 					}
 				}
-			
+
 			//else it means we render only the following parms
 			}else{
-				$tmp = explode(",", $parm );
+				$tmp = explode(",", (string) $parm );
 				foreach($tmp as $yes){
 					$yes=trim($yes);
 					if(isset($key[$yes])){

--- a/e107_core/shortcodes/batch/usersettings_shortcodes.php
+++ b/e107_core/shortcodes/batch/usersettings_shortcodes.php
@@ -625,13 +625,13 @@ class usersettings_shortcodes extends e_shortcode
 			$fname = str_replace("{FIELDNAME}", $fname, $REQUIRED_FIELD);
 		}
 
-		$parms = explode("^,^", $fInfo['user_extended_struct_parms']);
+		$parms = explode("^,^", (string) $fInfo['user_extended_struct_parms']);
 
 		$fhide = "";
 
 		if(varset($parms[3]))
 		{
-			$chk = (strpos($this->var['user_hidden_fields'], "^user_" . $parm . "^") === false) ? false : true;
+			$chk = (strpos((string) $this->var['user_hidden_fields'], "^user_" . $parm . "^") === false) ? false : true;
 
 			if(isset($_POST['updatesettings']))
 			{

--- a/e107_core/shortcodes/single/custom.php
+++ b/e107_core/shortcodes/single/custom.php
@@ -5,7 +5,7 @@ function custom_shortcode($parm)
 	$tp = e107::getParser();
 	$e107 = e107::getInstance();
 
-	$custom_query = !empty($parm) ? explode('+', $parm) : array();
+	$custom_query = !empty($parm) ? explode('+', (string) $parm) : array();
 
 	if(empty($custom_query[0]))
 	{

--- a/e107_core/shortcodes/single/iconpicker.php
+++ b/e107_core/shortcodes/single/iconpicker.php
@@ -16,7 +16,7 @@ function iconpicker_shortcode($parm)
 
 		$parms = array();
 
-		parse_str($parm, $parms);
+		parse_str((string) $parm, $parms);
 		$name = varset($parms['id']);
 
 	
@@ -39,7 +39,7 @@ function iconpicker_shortcode($parm)
 		{
 			while($row = $sql->fetch())
 			{
-				list($tmp,$tmp2,$size) = explode("_",$row['media_category']);
+				list($tmp,$tmp2,$size) = explode("_",(string) $row['media_category']);
 				
 								
 				if($str !='' && ($size != $lastsize))

--- a/e107_core/shortcodes/single/imagepreview.php
+++ b/e107_core/shortcodes/single/imagepreview.php
@@ -8,9 +8,9 @@ function imagepreview_shortcode($parm)
 		return null;
 	}
 
-	list($name, $width, $height, $nothumb) = explode("|",$parm, 4);
+	list($name, $width, $height, $nothumb) = explode("|",(string) $parm, 4);
 
-	$name = rawurldecode(varset($name));//avoid warnings
+	$name = rawurldecode((string) varset($name));//avoid warnings
 	if(varset($width))
 	{
 		$width = intval($width);

--- a/e107_core/shortcodes/single/imageselector.php
+++ b/e107_core/shortcodes/single/imageselector.php
@@ -13,14 +13,14 @@ function imageselector_shortcode($parm = '', $mod = '')
 		return null;
 	}
 
-	if (strpos($parm, "=") !== false)
+	if (strpos((string) $parm, "=") !== false)
 	{ // query style parms.
-		parse_str($parm, $parms);
+		parse_str((string) $parm, $parms);
 		extract($parms);
 	}
 	else
 	{ // comma separated parms.
-		list($name, $path, $default, $width, $height, $multiple, $label, $subdirs, $filter, $fullpath, $click_target, $click_prefix, $click_postfix, $tabindex, $class) = explode(",", $parm);
+		list($name, $path, $default, $width, $height, $multiple, $label, $subdirs, $filter, $fullpath, $click_target, $click_prefix, $click_postfix, $tabindex, $class) = explode(",", (string) $parm);
 	}
 
 	
@@ -136,7 +136,7 @@ function imageselector_shortcode($parm = '', $mod = '')
 			$text .= "</optgroup>\n";
 		}
 		$text .= "</select>";
-		$text .= "<a href='#'  onclick=\"replaceSC('imageselector=".rawurlencode($parm)."&amp;saction=select',\$('{$name_id}').up('form'),'{$name_id}_cont'); return false;\">refresh</a>";
+		$text .= "<a href='#'  onclick=\"replaceSC('imageselector=".rawurlencode((string) $parm)."&amp;saction=select',\$('{$name_id}').up('form'),'{$name_id}_cont'); return false;\">refresh</a>";
 		if(!e_AJAX_REQUEST) $text .= '</div>';
 
 		if ($scaction == 'select') return $text;

--- a/e107_core/shortcodes/single/lan.php
+++ b/e107_core/shortcodes/single/lan.php
@@ -8,7 +8,7 @@ function lan_shortcode($parm = '')
 		return null;
 	}
 
-	$lan = trim($parm);
+	$lan = trim((string) $parm);
 
 	if(defined('LAN_'.$lan))
 	{

--- a/e107_core/shortcodes/single/menu.php
+++ b/e107_core/shortcodes/single/menu.php
@@ -14,7 +14,7 @@ function menu_shortcode($parm, $mode='')
 
 	if(is_array($parm)) //v2.x format allowing for parms. {MENU: path=y&count=x}
 	{
-		list($plugin,$menu) = explode("/",$parm['path'],2); 		
+		list($plugin,$menu) = explode("/",(string) $parm['path'],2); 		
 		if($menu == '')
 		{
 			$menu = $plugin;	
@@ -35,7 +35,7 @@ function menu_shortcode($parm, $mode='')
 		}
 		else // eg. {MENU=contact} for e107_plugins/contact/contact_menu.php OR {MENU=contact/other} for e107_plugins/contact/other_menu.php 
 		{
-			list($plugin,$menu) = explode("/",$path,2); 
+			list($plugin,$menu) = explode("/",(string) $path,2); 
 			
 			if($menu == '')
 			{

--- a/e107_core/shortcodes/single/nextprev.php
+++ b/e107_core/shortcodes/single/nextprev.php
@@ -68,7 +68,7 @@ function nextprev_shortcode($parm = null)
 	 * New parameter requirements formatted as a GET string.
 	 * Template support.
 	 */
-	if(is_array($parm) || strpos($parm, 'total=') !== false)
+	if(is_array($parm) || strpos((string) $parm, 'total=') !== false)
 	{
 		if(is_string($parm))
 		{
@@ -186,7 +186,7 @@ function nextprev_shortcode($parm = null)
 		if($total_pages <= 1) {	return ''; }
 
 		// urldecoded once by parse_str()
-		if(substr($parm['url'], 0, 7) == 'route::')
+		if(substr((string) $parm['url'], 0, 7) == 'route::')
 		{
 			// New - use URL assembling engine
 			// Format is: route::module/controller/action::urlParams::urlOptions
@@ -195,7 +195,7 @@ function nextprev_shortcode($parm = null)
 			$urlParms = explode('::', str_replace('--AMP--', '&', $parm['url']));
 			$url = str_replace('--FROM--', '[FROM]', $e107->url->create($urlParms[1], $urlParms[2], varset($urlParms[3])));
 		}
-		elseif(substr($parm['url'], 0, 5) == 'url::')
+		elseif(substr((string) $parm['url'], 0, 5) == 'url::')
 		{
 			// New - use URL assembling engine
 			// Format is: url::module/controller/action?id=xxx--AMP--name=yyy--AMP--page=--FROM--::full=1
@@ -223,7 +223,7 @@ function nextprev_shortcode($parm = null)
 		// sprintXX(defset($e_vars->caption, $e_vars->caption), $current_page, $total_pages);
 
 		// urldecoded by parse_str()
-		$pagetitle = explode('|', vartrue($parm['pagetitle']));
+		$pagetitle = explode('|', (string) vartrue($parm['pagetitle']));
 		
 		// new - bullet support
 		$bullet = vartrue($parm['bullet'], '');
@@ -342,7 +342,7 @@ function nextprev_shortcode($parm = null)
 
 
 		$e_vars_loop = new e_vars();
-		$e_vars_loop->bullet = stripslashes($bullet); // fix magicquotes 
+		$e_vars_loop->bullet = stripslashes((string) $bullet); // fix magicquotes 
 		$ret_items = array();
 		for($c = $loop_start; $c < $loop_end; $c++)
 		{
@@ -352,7 +352,7 @@ function nextprev_shortcode($parm = null)
 				$label = defset($pagetitle[$c], $pagetitle[$c]);
 			}
 			$e_vars_loop->url = str_replace('[FROM]', ($perpage * ($c + $index_add)), $url);
-			$e_vars_loop->label = $label ? $tp->toHTML(stripslashes($label), false, 'TITLE') : $c + 1; //quick fix servers with magicquotes - stripslashes()
+			$e_vars_loop->label = $label ? $tp->toHTML(stripslashes((string) $label), false, 'TITLE') : $c + 1; //quick fix servers with magicquotes - stripslashes()
 
 			if($c + 1 == $current_page)
 			{
@@ -417,14 +417,14 @@ function nextprev_shortcode($parm = null)
 	 */
 	else
 	{
-		$parm_count = substr_count($parm, ',');
+		$parm_count = substr_count((string) $parm, ',');
 		while($parm_count < 5)
 		{
 			$parm .= ',';
 			$parm_count++;
 		}
 
-		$p = explode(',', $parm, 6);
+		$p = explode(',', (string) $parm, 6);
 
 		$total_items = intval($p[0]);
 		$perpage = intval($p[1]);

--- a/e107_core/shortcodes/single/sitelinks_alt.php
+++ b/e107_core/shortcodes/single/sitelinks_alt.php
@@ -21,7 +21,7 @@ class sitelinks_alt
 			return null;
 		}
 
-		$params = explode('+', $parm);
+		$params = explode('+', (string) $parm);
 		
 		if (vartrue($params[0]) && ($params[0] != 'no_icons') && ($params[0] != 'default'))
 		{
@@ -60,7 +60,7 @@ class sitelinks_alt
 		foreach ($linklist['head_menu'] as $lk)
 		{
 
-			if(substr($lk['link_url'],0,3) != '{e_' && strpos($lk['link_url'], '://') === false)
+			if(substr((string) $lk['link_url'],0,3) != '{e_' && strpos((string) $lk['link_url'], '://') === false)
 			{
 				$lk['link_url'] = '{e_BASE}'.$lk['link_url'];
 			}
@@ -197,9 +197,9 @@ class sitelinks_alt
 			{
 				// Filter title for backwards compatibility ---->
 				
-				if (substr($sub['link_name'], 0, 8) == "submenu.")
+				if (substr((string) $sub['link_name'], 0, 8) == "submenu.")
 				{
-					$tmp = explode(".", $sub['link_name']);
+					$tmp = explode(".", (string) $sub['link_name']);
 					$subname = $tmp[2];
 				}
 				else

--- a/e107_core/shortcodes/single/sublinks.php
+++ b/e107_core/shortcodes/single/sublinks.php
@@ -10,7 +10,7 @@ function sublinks_shortcode($parm)
 
 	if($parm)
 	{
-		list($page, $cat) = explode(":", $parm);
+		list($page, $cat) = explode(":", (string) $parm);
 	}
 
 	$page = isset($page) ? $page : defset('e_PAGE');

--- a/e107_core/shortcodes/single/uploadfile.php
+++ b/e107_core/shortcodes/single/uploadfile.php
@@ -94,7 +94,7 @@ function uploadfile_shortcode($parm)
 	}
 
 	$parms = array();
-	parse_str(varset($parm[1], ''), $parms);
+	parse_str((string) varset($parm[1], ''), $parms);
 
 	$parms = array_merge(array(
 		'trigger'		=> 'uploadfiles',

--- a/e107_core/shortcodes/single/user_avatar.php
+++ b/e107_core/shortcodes/single/user_avatar.php
@@ -38,12 +38,12 @@ function user_avatar_shortcode($parm=null)
 	$tp 		= e107::getParser();
 	$width 		= $tp->thumbWidth;
 	$height 	= ($tp->thumbHeight !== 0) ? $tp->thumbHeight : "";
-	
+
 	if(intval($loop_uid) > 0 && trim($parm) == "")
 	{
 		$parm = $loop_uid;
 	}
-	
+
 	if(is_numeric($parm))
 	{
 		if($parm == USERID)
@@ -68,24 +68,24 @@ function user_avatar_shortcode($parm=null)
 	{
 		$image = "";	
 	}
-	
+
 
 	$genericImg = $tp->thumbUrl(e_IMAGE."generic/blank_avatar.jpg","w=".$width."&h=".$height,true);	
-	
+
 	if (vartrue($image)) 
 	{
-		
+
 		if(strpos($image,"://")!==false) // Remove Image
 		{
 			$img = $image;	
 
-			
+
 			//$height 	= e107::getPref("im_height",100); // these prefs are too limiting for local images.  
 			//$width 		= e107::getPref("im_width",100);
 		}
 		elseif(substr($image,0,8) == "-upload-")
 		{
-			
+
 			$image = substr($image,8); // strip the -upload- from the beginning. 
 			if(file_exists(e_AVATAR_UPLOAD.$image)) // Local Default Image
 			{
@@ -93,7 +93,7 @@ function user_avatar_shortcode($parm=null)
 			}	
 			else 
 			{
-				
+
 				$img = $genericImg;
 			}	
 		}
@@ -103,7 +103,7 @@ function user_avatar_shortcode($parm=null)
 		}
 		else // Image Missing. 
 		{
-			
+
 			$img = $genericImg;
 		}
 	}
@@ -111,9 +111,9 @@ function user_avatar_shortcode($parm=null)
 	{
 		$img = $genericImg;
 	}
-	
+
 	$title = (ADMIN) ? $image : "";
-	
+
 	$text = "<img class='img-rounded user-avatar e-tip' title='".$title."' src='".$img."' alt='' style='width:".$width."px; height:".$height."px' />";
 //	return $img;
 	return $text;

--- a/e107_core/shortcodes/single/user_extended.php
+++ b/e107_core/shortcodes/single/user_extended.php
@@ -26,7 +26,7 @@
 			return null;
 		}
 
-		$tmp = explode('.', $parm);
+		$tmp = explode('.', (string) $parm);
 
 		$fieldname = trim($tmp[0]);
 		$type = trim($tmp[1]);
@@ -98,7 +98,7 @@
 				$ret_cause = 3;
 			}
 
-			if((!ADMIN && substr($fkeyStruct, -1) == 1	&& strpos($udata['user_hidden_fields'], '^user_' . $fieldname . '^') !== false && $uid != USERID))
+			if((!ADMIN && substr($fkeyStruct, -1) == 1	&& strpos((string) $udata['user_hidden_fields'], '^user_' . $fieldname . '^') !== false && $uid != USERID))
 			{
 				$ret_cause = 4;
 			}

--- a/e107_core/templates/email_template.php
+++ b/e107_core/templates/email_template.php
@@ -170,7 +170,7 @@ $EMAIL_TEMPLATE['default']['header']		= "<!DOCTYPE html PUBLIC \"-//W3C//DTD XHT
 													.btn-sm 		{ padding: 5px 10px; font-size: 12px; line-height: 1.5; border-radius: 3px; }
 												</style>
 												</head>
-												
+
 												<body>
 												<div id='body'>
 												";
@@ -221,14 +221,14 @@ $EMAIL_TEMPLATE['signup']['body'] 			= "
 												".LAN_EMAIL_06."<br />
 												<br />
 
-											
+
 												<br /><table cellspacing='4'>
 												<tr><td>{SITEBUTTON: type=email&h=60}</td>
 												<td><h4 class='sitename'>{SITENAME=link}</h4>
 												{SITEURL}</td></tr>
 												</table>
 												</div>
-												
+
 												";
 $EMAIL_TEMPLATE['signup']['footer']			= "</div>
 												</body>
@@ -241,7 +241,7 @@ $EMAIL_TEMPLATE['signup']['attachments']	= "";
 
 // -----------------------------
 
-												
+
 /*
  * QUICK ADD USER EMAIL TEMPLATE - BODY. 	
  * This is the email that is sent when an admin creates a user account in admin. "Quick Add User"
@@ -359,7 +359,7 @@ $EMAIL_TEMPLATE['example']['subject']			= '{SITENAME}: {SUBJECT} ';
 $EMAIL_TEMPLATE['example']['header']			= $EMAIL_TEMPLATE['default']['header']; // will use default header above. 	
 $EMAIL_TEMPLATE['example']['body']				= $EMAIL_TEMPLATE['default']['body']; // will use default header above. 	
 $EMAIL_TEMPLATE['example']['footer']			= "<br /><br />
-												
+
 												<a href='{SITEURL}'><img src='{THEME}images/my-signature.png' alt='{SITENAME}' /></a>
 												</div>
 												</body>

--- a/e107_core/templates/footer_default.php
+++ b/e107_core/templates/footer_default.php
@@ -63,7 +63,7 @@ if (varset($e107_popup) != 1)
 	//
 	// B.1 Clear cache (admin-only)
 	//
-	
+
 	//
 	// B.2 Send footer template, stop timing, send simple page stats
 	//
@@ -84,7 +84,7 @@ if (varset($e107_popup) != 1)
 
 	   e107::renderLayout($FOOTER, array('magicSC'=>$psc));
     }
-    
+
 	$eTimingStop = microtime();
 	global $eTimingStart;
 	$clockTime = e107::getSingleton('e107_traffic')->TimeDelta($eTimingStart, $eTimingStop);
@@ -101,7 +101,7 @@ if (varset($e107_popup) != 1)
 	{ // Collect the first batch of data to log
 		$logLine .= "'".($now = time())."','".gmstrftime('%y-%m-%d %H:%M:%S', $now)."','".e107::getIPHandler()->getIP(FALSE)."','".e_PAGE.'?'.e_QUERY."','".$rendertime."','".$db_time."','".$queryCount."','".$memuse."','".$_SERVER['HTTP_USER_AGENT']."','{$_SERVER["REQUEST_METHOD"]}'";
 	}
-	
+
 	if (function_exists('getrusage') && !empty($eTimingStartCPU))
 	{
 		$ru = getrusage();
@@ -127,7 +127,7 @@ if (varset($e107_popup) != 1)
 	//
 	//	$logname = "/home/mysite/public_html/queryspeed.log";
 	//	$logfp = fopen($logname, 'a+'); fwrite($logfp, "$cpuTot,$cpuPct,$cpuStart,$rendertime,$db_time\n"); fclose($logfp);
-	
+
 	if ($pref['displayrendertime'])
 	{
 		$rinfo .= CORE_LAN11;
@@ -157,18 +157,18 @@ if (varset($e107_popup) != 1)
 
 		$logname = e_LOG."logd_".date("Y-m-d", time()).".csv";
 		$logHeader = "Unix time,Date/Time,IP,URL,RenderTime,DbTime,Qrys,Memory-Usage,User-Agent,Request-Method";
-			
+
 		$logfp = fopen($logname, 'a+');
-		
+
 		if(filesize($logname) == 0 || !is_file($logname))
 		{
 			fwrite($logfp, $logHeader."\n");	
 		}	
-		
+
 		fwrite($logfp, $logLine."\n");
 		fclose($logfp);
 	}
-	
+
 	if (function_exists('theme_renderinfo')) 
 	{
 		theme_renderinfo($rinfo);
@@ -177,7 +177,7 @@ if (varset($e107_popup) != 1)
 	{
 		echo($rinfo ? "\n<div class='e-footer-info muted smalltext hidden-print'><small>{$rinfo}</small></div>\n" : "");
 	}
-	
+
 } // End of regular-page footer (the above NOT done for popups)
 
 //
@@ -322,7 +322,7 @@ if (!empty($pref['e_footer_list']) && is_array($pref['e_footer_list']))
 	foreach($pref['e_footer_list'] as $val)
 	{		
 		$fname = e_PLUGIN.$val."/e_footer.php"; // Do not place inside a function - BC $pref required. . 
-		
+
 		if(is_readable($fname))
 		{
 			$ret = (deftrue('e_DEBUG') || isset($_E107['debug'])) ? include_once($fname) : @include_once($fname);
@@ -341,7 +341,7 @@ if(deftrue('e_DEVELOPER'))
 {
 	echo "\n\n<!-- ======= [JSManager] FOOTER: Remaining CSS ======= -->";
 }
-$CSSORDER = defined('CSSORDER') && deftrue('CSSORDER') ? explode(",",CSSORDER) : array('library','other','core','plugin','theme');  // INLINE CSS in Body not supported by HTML5. .
+$CSSORDER = defined('CSSORDER') && deftrue('CSSORDER') ? explode(",",(string) CSSORDER) : array('library','other','core','plugin','theme');  // INLINE CSS in Body not supported by HTML5. .
 
 foreach($CSSORDER as $val)
 {
@@ -389,7 +389,7 @@ if (abs($_serverTime - $lastSet) > 120)
 	echo "<script>\n";
 	echo "var nowLocal = new Date();		/* time at very beginning of js execution */
 var localTime = Math.floor(nowLocal.getTime()/1000);	/* time, in ms -- recorded at top of jscript */
-	
+
 function SyncWithServerTime(serverTime, path, domain)
 {
 	if (serverTime) 
@@ -449,7 +449,7 @@ if (!empty($pref['e_output_list']) && is_array($pref['e_output_list']))
 	foreach($pref['e_output_list'] as $val)
 	{
 		$fname = e_PLUGIN.$val."/e_output.php"; // Do not place inside a function - BC $pref required. . 
-		
+
 		if(is_readable($fname))
 		{
 			$ret = (deftrue('e_DEBUG') || isset($_E107['debug'])) ? include_once($fname) : @include_once($fname);

--- a/e107_core/templates/header_default.php
+++ b/e107_core/templates/header_default.php
@@ -236,11 +236,11 @@ if (is_array($pref['e_meta_list']))
 {	
 	// $pref = e107::getPref();
 	ob_start();
-	
+
 	foreach($pref['e_meta_list'] as $val)
 	{		
 		$fname = e_PLUGIN.$val."/e_meta.php"; // Do not place inside a function - BC $pref required. . 
-		
+
 		if(is_readable($fname))
 		{
 			$ret = (deftrue('e_DEBUG') || isset($_E107['debug'])) ? include_once($fname) : @include_once($fname);
@@ -298,7 +298,7 @@ else
 	else 
 	{
 		// Theme default
-		
+
 		$e_js->themeCSS(THEME_STYLE, $css_default);
 
 		// Support for style.css - override theme default CSS
@@ -318,11 +318,11 @@ else
 			$e_js->themeCSS('style_print.css', 'print');
 		}
 	}
-	
+
 	// possibility to overwrite some CSS definition according to TEXTDIRECTION
 	// especially usefull for rtl.css
 	// see _blank theme for examples
-	if(defined('TEXTDIRECTION') && file_exists(THEME.'/'.strtolower(TEXTDIRECTION).'.css'))
+	if(defined('TEXTDIRECTION') && file_exists(THEME.'/'.strtolower((string) TEXTDIRECTION).'.css'))
 	{
 		//echo '
 		//<link rel="stylesheet" href="'.THEME_ABS.strtolower(TEXTDIRECTION).'.css" type="text/css" media="all" />';
@@ -617,10 +617,10 @@ echo "</head>\n";
 			{
 				continue;	
 			}
-			
-			if(strpos($template,'{---}') !==false)
+
+			if(strpos((string) $template,'{---}') !==false)
 			{
-				list($hd,$ft) = explode("{---}",$template);
+				list($hd,$ft) = explode("{---}",(string) $template);
 				$HEADER[$key] = isset($LAYOUT['_header_']) ? $LAYOUT['_header_'] . $hd : $hd;
 				$FOOTER[$key] = isset($LAYOUT['_footer_']) ? $ft . $LAYOUT['_footer_'] : $ft ;	
 			}
@@ -664,7 +664,7 @@ echo "</head>\n";
 	        echo e107::getMessage()->addError("There is no layout in theme.php with the key: <b>".$def."</b> or your layout is missing {---}. ")->render();
 	    }
     }
-    
+
     if(deftrue('e_IFRAME'))
     {
         $HEADER = deftrue('e_IFRAME_HEADER');
@@ -728,7 +728,7 @@ if(deftrue('BOOTSTRAP'))
 				            <div class="modal-header">
 				            	<h4 class="modal-caption modal-title col-sm-11">&nbsp;</h4>
 				                <button type="button" class="close" data-dismiss="modal" data-bs-dismiss="modal" aria-hidden="true">&times;</button>
-				                
+
 				             </div>
 				             <div class="modal-body">
 				             <p>Loading…</p>
@@ -790,7 +790,7 @@ e107::getDebug()->logTime('Render Layout');
 		if(deftrue('DEMO_CONTENT')) // embedded content relative to THEME directory - update paths. 
 		{
 			$HEADER = preg_replace('#(src|href)=("|\')([^:\'"]*)("|\')#','$1=$2'.THEME.'$3$4', $HEADER);	
-			$FOOTER = preg_replace('#(src|href)=("|\')([^:\'"]*)("|\')#','$1=$2'.THEME.'$3$4', $FOOTER);	
+			$FOOTER = preg_replace('#(src|href)=("|\')([^:\'"]*)("|\')#','$1=$2'.THEME.'$3$4', (string) $FOOTER);	
 		}
 
 
@@ -833,7 +833,7 @@ e107::getDebug()->logTime('Render Other');
 		// echo "<div class='installer alert alert-danger alert-block alert-dismissible text-center'>".e107::getParser()->toHTML(LAN_DEVELOPERMODE_CHECK, true)."<button type='button' class='close btn-close' data-bs-dismiss='alert' data-dismiss='alert' aria-label='".LAN_CLOSE."'></button></div>";
 	}
 
-	
+
 	//XXX TODO LAN in English.php 
 	echo "<noscript><div class='alert alert-block alert-error alert-danger'><strong>This web site requires that javascript be enabled. <a rel='external' href='https://enablejavascript.io'>Click here for instructions.</a>.</strong></div></noscript>";
 
@@ -847,12 +847,12 @@ e107::getDebug()->logTime('Render Other');
      * fix - only when e_FRONTPAGE set to true
      * @see core_index_index_controller/actionIndex
      */
-    if(deftrue('e_FRONTPAGE') && ($noBody !== true) && strpos($HEADER, "{WMESSAGE") === false && strpos($FOOTER, "{WMESSAGE") === false) // Auto-detection to override old pref.
+    if(deftrue('e_FRONTPAGE') && ($noBody !== true) && strpos($HEADER, "{WMESSAGE") === false && strpos((string) $FOOTER, "{WMESSAGE") === false) // Auto-detection to override old pref.
 	{
 		echo e107::getParser()->parseTemplate("{WMESSAGE}");
 	}
 
-	if(!deftrue('e_IFRAME') && (strpos($HEADER, "{ALERTS}") === false && strpos($FOOTER, "{ALERTS}") === false)) // Old theme, missing {ALERTS}
+	if(!deftrue('e_IFRAME') && (strpos($HEADER, "{ALERTS}") === false && strpos((string) $FOOTER, "{ALERTS}") === false)) // Old theme, missing {ALERTS}
 	{
 		if(deftrue('e_DEBUG'))
 		{

--- a/e107_core/url/news/sef_noid_url.php
+++ b/e107_core/url/news/sef_noid_url.php
@@ -150,7 +150,7 @@ class core_news_sef_noid_url extends eUrlConfig
 
 		if($urlFormat == 'dashl' || $urlFormat == 'underscorel' || $urlFormat == 'plusl') // convert template to lowercase when using lowercase SEF URL format.  
 		{
-			$r[0] = strtolower($r[0]);	
+			$r[0] = strtolower((string) $r[0]);	
 		}	
 			
 			

--- a/e107_core/url/news/sef_url.php
+++ b/e107_core/url/news/sef_url.php
@@ -22,28 +22,28 @@ class core_news_sef_url extends eUrlConfig
 				'defaultRoute'	=> 'list/items', 		// [optional] default empty; route (no leading module) used when module is found with no additional controller/action information e.g. /news/
 				'urlSuffix' 	=> '',
 				'allowMain' 	=> true,
-				
+
 				### default vars mapping (create URL), override per rule is allowed
 				'mapVars' 		=> array(  
 					'news_id' => 'id', 
 					'news_sef' => 'name', 
 				),
-				
+
 				### match will only check if parameter is empty to invalidate the assembling vs current rule
 				'matchValue' => 'empty',	 
-				
+
 				### Numerical array containing allowed vars by default (create URL, used for legacyQuery parsing in parse routine as well), 
 				### false means - disallow all vars beside those required by the rules
 				### Override per rule is allowed
 				'allowVars' 	=> false, 
-				
+
 				### Best news - you don't need to write one and the same
 				### regex over and over again. Even better news - you might avoid
 				### writing regex at all! Just use the core regex templates, they 
 				### should fit almost every case. 
 				### Here is a test custom regex template:
 				'varTemplates' => array('testIt' => '[\d]+'),
-				
+
 				/*	Predefined Core regex templates, see usage below
 				 	'az'					=> '[A-Za-z]+', // NOTE - it won't match non-latin word characters!
 					'alphanum'  			=> '[\w\pL]+',
@@ -59,19 +59,19 @@ class core_news_sef_url extends eUrlConfig
 					'usernameOptional' 		=> '[\w\pL.\-\s!,]{0,}', 
 				 */
 			),
-			
+
 			'rules' => array(
 				### simple matches first - PERFORMANCE
 				'' 							=> array('list/items', 'allowVars' => array('page'), 'legacyQuery' => 'default.0.{page}', ),
 				'Category' 					=> array('list/items', 'allowVars' => array('page'), 'legacyQuery' => 'default.0.{page}', ),
-				
+
 				## URL with ID and Title - no DB call, balanced performance, name optional
 				## Demonstrating the usage of custom user defined regex template defined above - 'testIt' 
 				'Category/<id:{testIt}>/<name:{sefsecure}>' => array('list/category', 'allowVars' => array('page'), 'mapVars' => array('category_id' => 'id', 'category_sef' => 'name'), 'legacyQuery' => 'list.{id}.{page}'),
-				
+
 				## URL with Title only - prettiest and slowest! Example with direct regex - no templates
 				//'Category/<name:{sefsecure}>' => array('list/category', 'allowVars' => array('page'), 'mapVars' => array('category_sef' => 'name'), 'legacyQuery' => 'list.{name}.{page}', 'parseCallback' => 'categoryIdByTitle'),
-				
+
 				## URL with ID only - best performance, fallback when no sef name provided
 				'Category/<id:{number}>' 		=> array('list/category', 'allowVars' => array('page'), 'legacyQuery' => 'list.{id}.{page}', 'mapVars' => array('category_id' => 'id')),
 
@@ -84,18 +84,18 @@ class core_news_sef_url extends eUrlConfig
 
 				## All news
 				'All' => array('list/all', 'allowVars' => array('page'), 'legacyQuery' => 'all.0.{page}'),
-				
+
 				## URL with ID and Title - no DB call, balanced performance!
 				'Short/<id:{number}>/<name:{sefsecure}>' => array('list/short', 'allowVars' => array('page'), 'mapVars' => array('category_id' => 'id', 'category_sef' => 'name'), 'legacyQuery' => 'cat.{id}.{page}'),
 				## fallback when name is not provided	
 				'Short/<id:{number}>' => array('list/short', 'allowVars' => array('page'), 'mapVars' => array('category_id' => 'id'), 'legacyQuery' => 'cat.{id}.{page}'),				
-				
+
 				// less used after
 				//'Brief/<id:[\d]+>' 			=> array('list/short', 'allowVars' => array('page'), 'legacyQuery' => 'cat.{id}.{page}', 'mapVars' => array('category_id' => 'id')),
 				'Day/<id:{number}>' 			=> array('list/day', 'allowVars' => array('page'), 'legacyQuery' => 'day.{id}.{page}'),
 				'Month/<id:{number}>' 			=> array('list/month', 'allowVars' => array('page'), 'legacyQuery' => 'month.{id}.{page}'),
 				//'Year/<id:[\d]+>' 			=> array('list/year', 'allowVars' => array('page'), 'legacyQuery' => 'year.{id}.{page}'), not supported yet
-				
+
 				### View news item - kinda catch all - very bad performance when News is chosen as default namespace - two additional DB queries on every site call!
 				## Leading category name - uncomment to enable
 				//'<category:{sefsecure}>/<name:{sefsecure}>' => array('view/item', 'mapVars' => array('category_sef' => 'category', 'news_sef' => 'name', 'news_id' => 'id'), 'legacyQuery' => 'extend.{name}', 'parseCallback' => 'itemIdByTitle'),
@@ -104,16 +104,16 @@ class core_news_sef_url extends eUrlConfig
 				//'<name:{sefsecure}>' 						=> array('view/item', 'mapVars' => array('news_id' => 'id', 'news_sef' => 'name'), 'legacyQuery' => 'extend.{name}', 'parseCallback' => 'itemIdByTitle'),
 				// fallback if news sef is missing
 				'View/<id:{number}>/<name:{sefsecure}>' 		=> array('view/item', 'mapVars' => array('news_id' => 'id', 'news_sef' => 'name'), 'legacyQuery' => 'extend.{id}'),
-				
+
 				'View/<id:{number}>' 		=> array('view/item', 'mapVars' => array('news_id' => 'id'), 'legacyQuery' => 'extend.{id}'),
-				
+
 				'Tag/<tag:{secure}>' 	=> array('list/tag', 'allowVars' => array('page'), 'legacyQuery' => 'tag={tag}&page={page}'),
-			
+
 				'Author/<author:{secure}>' 	=> array('list/author', 'allowVars' => array('page'), 'legacyQuery' => 'author={author}&page={page}'),
 			) 
 		);
 	}
-	
+
 	/**
 	 * Query mapping in format route?params:
 	 * - item/view?id=xxx -> ?extend.id
@@ -126,8 +126,8 @@ class core_news_sef_url extends eUrlConfig
 	 * - list/year?id=xxx -> ?year-id
 	 * - list/nextprev?route=xxx -> PARSED_ROUTE.[FROM] (recursive parse() call)
 	 */
-	
-	
+
+
 	/**
 	 * Admin callback
 	 * Language file not loaded as all language data is inside the lan_eurl.php (loaded by default on administration URL page)
@@ -146,12 +146,12 @@ class core_news_sef_url extends eUrlConfig
 			'form' => array(), // Under construction - additional configuration options
 			'callbacks' => array(), // Under construction - could be used for e.g. URL generator functionallity
 		);
-		
+
 		return $admin;
 	}
-	
+
 	### CUSTOM METHODS ###
-	
+
 	/**
 	 * view/item by name callback
 	 * @param eRequest $request
@@ -169,7 +169,7 @@ class core_news_sef_url extends eUrlConfig
 		{
 			return;
 		}
-		
+
 		$sql = e107::getDb('url');
 		$name = e107::getParser()->toDB($name);
 		if($sql->select('news', 'news_id', "news_sef='{$name}'")) // TODO - it'll be news_sef (new) field
@@ -179,7 +179,7 @@ class core_news_sef_url extends eUrlConfig
 		}
 		else $request->setRequestParam('name', 0);
 	}*/
-	
+
 	/**
 	 * list/items by name callback
 	 * @param eRequest $request
@@ -197,7 +197,7 @@ class core_news_sef_url extends eUrlConfig
 		{
 			return;
 		}
-		
+
 		$sql = e107::getDb('url');
 		$id = e107::getParser()->toDB($name);
 		if($sql->select('news_category', 'category_id', "category_sef='{$name}'")) // TODO - it'll be category_sef (new) field

--- a/e107_handlers/admin_log_class.php
+++ b/e107_handlers/admin_log_class.php
@@ -987,7 +987,7 @@ class e_admin_log
 
 		foreach($this->_allMessages as $m)
 		{
-			$text .= date('Y-m-d H:i:s', $m['time']) . "  \t" . str_pad($m['loglevel'], 10, ' ', STR_PAD_RIGHT) . "\t" . strip_tags($m['message']) . "\n";
+			$text .= date('Y-m-d H:i:s', $m['time']) . "  \t" . str_pad((string) $m['loglevel'], 10, ' ', STR_PAD_RIGHT) . "\t" . strip_tags((string) $m['message']) . "\n";
 		}
 
 		$date = ($append == true) ? date('Y-m-d') : date('Y-m-d_H-i-s') . '_' . crc32($text);
@@ -1017,7 +1017,7 @@ class e_admin_log
 
 		if(!empty($opts['filename']))
 		{
-			$fileName = $dir . basename($opts['filename']);
+			$fileName = $dir . basename((string) $opts['filename']);
 		}
 
 		if($append == true)

--- a/e107_handlers/admin_ui.php
+++ b/e107_handlers/admin_ui.php
@@ -693,7 +693,7 @@ class e_admin_response
 	public function getTitle($namespace = 'default', $reset = false, $glue = '  ')
 	{
 		$content = array();
-				
+
 		if(isset($this->_title[$namespace]) && is_array($this->_title[$namespace]))
 		{
 			$content = $this->_title[$namespace];
@@ -989,7 +989,7 @@ class e_admin_dispatcher
 	 * @var array
 	 */
 	protected $modes = array();
-	
+
 	/**
 	 * Optional - access restrictions per action 
 	 * Access array in format (similar to adminMenu)
@@ -998,7 +998,7 @@ class e_admin_dispatcher
 	 * @var array
 	 */
 	protected $access = array();
-	
+
 	/**
 	 * Optional - generic entry point access restriction (via getperms()) 
 	 * Value of this for plugins would be always 'P'.
@@ -1035,7 +1035,7 @@ class e_admin_dispatcher
 	 * @var array
 	 */
 	protected $adminMenu = array();
-	
+
 
 	protected $adminMenuIcon;
 	/**
@@ -1079,7 +1079,7 @@ class e_admin_dispatcher
 		}
 
 		require_once(e_ADMIN.'boot.php');
-		
+
 		if($request === null || !is_object($request))
 		{
 			$request = new e_admin_request($request);
@@ -1113,7 +1113,7 @@ class e_admin_dispatcher
 
 		// register itself
 		e107::setRegistry('admin/ui/dispatcher', $this);
-		
+
 		// permissions and restrictions
 		$this->checkAccess();
 
@@ -1147,7 +1147,7 @@ class e_admin_dispatcher
 				->addDebug('Mode access restriction triggered.');
 			return false;
 		}
-		
+
 		// access based on $access settings - access per action
 		$currentAction = $request->getAction();
 		$route = $currentMode.'/'.$currentAction;
@@ -1161,7 +1161,7 @@ class e_admin_dispatcher
 				->addDebug('Route access restriction triggered:'.$route);
 			return false;
 		}
-		
+
 		return true;
 	}
 
@@ -1181,7 +1181,7 @@ class e_admin_dispatcher
 		{
 			return false;
 		}
-		
+
 		// generic dispatcher admin permission  (former getperms())
 		if($this->perm !== null && is_string($this->perm) && !e107::getUser()->checkAdminPerms($this->perm))
 		{
@@ -1227,7 +1227,7 @@ class e_admin_dispatcher
 		if($this->adminMenu)
 		{
 			reset($this->adminMenu);
-			list($mode, $action) = explode('/', key($this->adminMenu), 3);
+			list($mode, $action) = explode('/', (string) key($this->adminMenu), 3);
 		}
 		else
 		{
@@ -1295,7 +1295,7 @@ class e_admin_dispatcher
 		$this->adminMenu = $menu;
 		return $this;
 	}
-	
+
 	/**
 	 * Get admin menu array
 	 * @return array
@@ -1633,7 +1633,7 @@ class e_admin_dispatcher
 
 		//	$parentKey = '';
 
-			$tmp = explode('/', trim($key, '/'), 2); // mode/action
+			$tmp = explode('/', trim((string) $key, '/'), 2); // mode/action
 
 
 			$isSubItem = !empty($val['group']);
@@ -1741,7 +1741,7 @@ class e_admin_dispatcher
 			}
 			elseif(!isset($item['link']))
 			{
-				$tmp = explode('/', trim($key, '/'), 2);
+				$tmp = explode('/', trim((string) $key, '/'), 2);
 				$item['link'] = e_REQUEST_SELF . '?mode=' . $tmp[0] . '&action=' . ($tmp[1] ?? 'main');
 			}
 		}
@@ -1794,7 +1794,7 @@ class e_admin_dispatcher
 			$val = $adminMenu[$key] ?? [];
 
 			// Handle single-segment keys (e.g., 'treatment') by using the key as the mode
-			$mode = strpos($key, '/') !== false ? explode('/', trim($key, '/'), 2)[0] : $key;
+			$mode = strpos((string) $key, '/') !== false ? explode('/', trim((string) $key, '/'), 2)[0] : $key;
 
 			// Default to true for hasPerms if perm is unset or empty
 			$hasPerms = isset($val['perm']) && $val['perm'] !== '' ? $this->hasPerms($val['perm']) : true;
@@ -1818,7 +1818,7 @@ class e_admin_dispatcher
 					//	fwrite(STDOUT, "B. restrictMenuAccess: removing subKey=$subKey, parent=$parentKey, group=" . ($subVal['group'] ?? 'none') . ", perm=" . ($subVal['perm'] ?? 'none') . ", hasPerms=" . var_export(isset($subVal['perm']) && $subVal['perm'] !== '' ? $this->hasPerms($subVal['perm']) : true, true) . ", hasModeAccess=" . var_export($this->hasModeAccess($subMode ?? $subKey), true) . ", hasRouteAccess=" . var_export($this->hasRouteAccess($subKey), true) . ", parentRouteAccess=" . var_export($this->hasRouteAccess($parentKey), true) . "\n");
 						continue;
 					}
-					$subMode = strpos($subKey, '/') !== false ? explode('/', trim($subKey, '/'), 2)[0] : $subKey;
+					$subMode = strpos((string) $subKey, '/') !== false ? explode('/', trim((string) $subKey, '/'), 2)[0] : $subKey;
 					// Default to true for hasPerms if perm is unset or empty
 					$hasPerms = isset($subVal['perm']) && $subVal['perm'] !== '' ? $this->hasPerms($subVal['perm']) : true;
 					if($hasPerms && $this->hasModeAccess($subMode) && $this->hasRouteAccess($subKey) && $this->hasRouteAccess($parentKey))
@@ -1992,19 +1992,19 @@ class e_admin_dispatcher
 
 	}
 
-	
+
 	/** 
 	 * Check for table issues and warn the user. XXX TODO 
 	 * ie. user is using French interface but no french tables found for the current DB tables. 
 	 */
 	public function renderWarnings()
 	{
-		
-		
-		
-		
+
+
+
+
 	}
-	
+
 
 }
 
@@ -2039,7 +2039,7 @@ class e_admin_controller
 	 * @var string default trigger action.
 	 */
 	protected $_default_trigger = 'auto';
-	
+
 	/**
 	 * List (numerical array) of only allowed for this controller actions
 	 * Useful to grant access for certain pre-defined actions only
@@ -2047,7 +2047,7 @@ class e_admin_controller
 	 * @var array
 	 */
 	protected $allow = array();
-	
+
 	/**
 	 * List (numerical array) of only disallowed for this controller actions
 	 * Useful to restrict access for certain pre-defined actions only
@@ -2068,7 +2068,7 @@ class e_admin_controller
 		$this->setRequest($request)
 			->setResponse($response)
 			->setParams($params);
-			
+
 		$this->checkAccess();
 
 		$this->_log(); // clear the log (when debug is enabled)
@@ -2092,7 +2092,7 @@ class e_admin_controller
 				->addDebug('Controller action disallowed restriction triggered.');
 			return false;
 		}
-		
+
 		// access based on $access settings - access per action
 		if(!empty($this->allow) && !in_array($currentAction, $this->allow))
 		{
@@ -2211,7 +2211,7 @@ class e_admin_controller
 		$this->_response = $response;
 		return $this;
 	}
-	
+
 	/**
 	 * Get current dispatcher object
 	 * @return e_admin_dispatcher
@@ -2276,7 +2276,7 @@ class e_admin_controller
 	 */
 	public function addTitle($title = true, $meta = true)
 	{
-		
+
 		$response = $this->getResponse();
 
 		if($title === true)
@@ -2334,9 +2334,9 @@ class e_admin_controller
 
 
 		}
-		
+
 		//	echo "<h3>".__METHOD__." - ".$title."</h3>";
-	
+
 	//	print_a($title);
 		$response->appendTitle($title);
 
@@ -2525,9 +2525,9 @@ class e_admin_controller
 			{
 				foreach ($posted as $key => $value)
 				{
-					if(strpos($key, 'etrigger_') === 0)
+					if(strpos((string) $key, 'etrigger_') === 0)
 					{
-						$actionTriggerName = $this->toMethodName($action.$request->camelize(substr($key, 9)), 'trigger', false);
+						$actionTriggerName = $this->toMethodName($action.$request->camelize(substr((string) $key, 9)), 'trigger', false);
 						if(method_exists($this, $actionTriggerName))
 						{
 							$this->$actionTriggerName($value);
@@ -2629,8 +2629,8 @@ class e_admin_controller
 
 
 
-		
-		
+
+
 		ob_start(); //catch any output
 		$ret = $this->{$actionName}();
 
@@ -2660,7 +2660,7 @@ class e_admin_controller
 		{
 			$response->appendBody($ret);
 		}
-	
+
 		return $response;
 	}
 
@@ -2743,7 +2743,7 @@ class e_admin_controller
 		{
 			$path = e_REQUEST_SELF;
 		}
-		
+
 		//prevent cache
 		header('Cache-Control: private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0');
 	//	header('Pragma: no-cache');
@@ -2824,7 +2824,7 @@ class e_admin_controller
 		$posted = array_keys($this->getPosted());
 		foreach ($posted as $key)
 		{
-			if(!in_array($key, $exclude) && strpos($key, 'etrigger_') === 0)
+			if(!in_array($key, $exclude) && strpos((string) $key, 'etrigger_') === 0)
 			{
 				return true;
 			}
@@ -2964,7 +2964,7 @@ class e_admin_controller_ui extends e_admin_controller
 	 * @var string plugin name
 	 */
 	protected $pluginName;
-	
+
 
 	/**
 	 * @var string event name
@@ -2991,7 +2991,7 @@ class e_admin_controller_ui extends e_admin_controller
 	 * @var string SQL group-by field name (optional)
 	 */
 	protected $listGroup;
-	
+
 	/**
 	 * @var string field containing the order number
 	 */
@@ -3006,26 +3006,26 @@ class e_admin_controller_ui extends e_admin_controller
 	 * @var string field containing the parent field
 	 */
 	protected $sortParent;
-	
+
 	/**
 	 * @var int reorder step
 	 */
 	protected $orderStep = 1;
-	
+
 	/**
 	 * Example: array('0' => 'Tab label', '1' => 'Another label');
 	 * Referenced from $field property per field - 'tab => xxx' where xxx is the tab key (identifier)
 	 * @var array edit/create form tabs
 	 */
 	protected $tabs = array();
-	
+
 	/**
 	 * Example: array('0' => 'Tab label', '1' => 'Another label');
 	 * Referenced from $prefs property per field - 'tab => xxx' where xxx is the tab key (identifier)
 	 * @var array edit/create form tabs
 	 */
 	protected $preftabs = array();
-	
+
 	/**
 	 * TODO Example: 
 	 * Contains required data for auto-assembling URL from every record
@@ -3033,7 +3033,7 @@ class e_admin_controller_ui extends e_admin_controller
 	 * @var array
 	 */
 	protected $url = array();
-	
+
 	/**
 	 * TODO Example: 
 	 * Contains required data for mapping featurebox fields
@@ -3046,7 +3046,7 @@ class e_admin_controller_ui extends e_admin_controller
 	 * @var additional SQL to be applied when auto-building the list query
 	 */
 	protected $listQrySql = array();
-	
+
 	/**
 	 * @var Custom Filter SQL Query override.
 	 */
@@ -3069,17 +3069,17 @@ class e_admin_controller_ui extends e_admin_controller
 	 * @var boolean
 	 */
 	protected $batchDelete = true;
-	
+
 	/**
 	 * @var boolean
 	 */
 	protected $batchCopy = false;
-	
+
     /**
      * @var boolean
      */
     protected $batchLink = false;
-	
+
     /**
      * @var boolean
      */
@@ -3094,7 +3094,7 @@ class e_admin_controller_ui extends e_admin_controller
 	 * @var array
 	 */
 	protected $batchOptions = array();
-	
+
 	/**
 	 * Could be LAN constant (mulit-language support)
 	 *
@@ -3114,7 +3114,7 @@ class e_admin_controller_ui extends e_admin_controller
 	 * @var array
 	 */
 	protected $grid = array();
-	
+
 		/**
 	 * @var e_admin_model
 	 */
@@ -3139,7 +3139,7 @@ class e_admin_controller_ui extends e_admin_controller
 	 * @var e_plugin_pref|e_core_pref
 	 */
 	protected $_pref;
-	
+
 	/**
 	 * Prevent parsing table aliases more than once
 	 * @var boolean
@@ -3233,7 +3233,7 @@ class e_admin_controller_ui extends e_admin_controller
 	{
 		return  $this->batchSort;
 	}
-	
+
 	/**
 	 * @return string
 	 */
@@ -3278,7 +3278,7 @@ class e_admin_controller_ui extends e_admin_controller
 	{
 		return $this->treePrefix;
 	}
-	
+
 	/**
 	 * Get Tab data
 	 * @return array
@@ -3315,7 +3315,7 @@ class e_admin_controller_ui extends e_admin_controller
     {
         return $this->url;
     }
-	
+
 
       /**
      * Get Featurebox Copy 
@@ -3959,7 +3959,7 @@ class e_admin_controller_ui extends e_admin_controller
 		{
 			foreach ($selected as $i => $_sel) 
 			{
-				$selected[$i] = preg_replace('/[^\w\-:.]/', '', $_sel);
+				$selected[$i] = preg_replace('/[^\w\-:.]/', '', (string) $_sel);
 			}
 		}
 
@@ -4030,7 +4030,7 @@ class e_admin_controller_ui extends e_admin_controller
 					$params = $this->getFieldAttr($trigger[1], 'writeParms', array());
 					if(!is_array($params))
 					{
-						parse_str($params, $params);
+						parse_str((string) $params, $params);
 					}
 					if(!vartrue($params['batchNoCheck']))
 					{
@@ -4073,7 +4073,7 @@ class e_admin_controller_ui extends e_admin_controller
 					$this->$method($selected, $field);
 				}
 			break;
-			
+
 			// see commma, userclasses batch options
 			case 'attach':
 			case 'deattach':
@@ -4085,13 +4085,13 @@ class e_admin_controller_ui extends e_admin_controller
 				}
 				$field = $trigger[1];
 				$value = $trigger[2];
-				
+
 				if($trigger[0] === 'addAll')
 				{
 					$parms = $this->getFieldAttr($field, 'writeParms', array());
 					if(!is_array($parms))
 					{
-						parse_str($parms, $parms);
+						parse_str((string) $parms, $parms);
 					}
 					unset($parms['__options']);
 					$value = $parms;
@@ -4104,13 +4104,13 @@ class e_admin_controller_ui extends e_admin_controller
 						$value = array_map('trim', explode(',', $value));
 					}
 				}
-				
+
 				if(method_exists($this, 'handleCommaBatch')) 
 				{
 					$this->handleCommaBatch($selected, $field, $value, $trigger[0]);
 				}
 			break;
-			
+
 			// append to userclass list
 			case 'ucadd':
 			case 'ucremove':
@@ -4122,7 +4122,7 @@ class e_admin_controller_ui extends e_admin_controller
 				$class = $trigger[2];
 				$user = e107::getUser();
 				$e_userclass = e107::getUserClass(); 
-				
+
 				// check userclass manager class
 				if (!isset($e_userclass->class_tree[$class]) || !$user->checkClass($e_userclass->class_tree[$class]))
 				{
@@ -4135,7 +4135,7 @@ class e_admin_controller_ui extends e_admin_controller
 					$this->handleCommaBatch($selected, $field, $class, $trigger[0]);
 				}
 			break;
-			
+
 			// add all to userclass list
 			// clear userclass list
 			case 'ucaddall':
@@ -4150,13 +4150,13 @@ class e_admin_controller_ui extends e_admin_controller
 				$parms = $this->getFieldAttr($field, 'writeParms', array());
 				if(!is_array($parms))
 				{
-					parse_str($parms, $parms);
+					parse_str((string) $parms, $parms);
 				}
 				if(!vartrue($parms['classlist']))
 				{
 					return $this;
 				}
-				
+
 				$classes = $e_userclass->uc_required_class_list($parms['classlist']);
 				foreach ($classes as $id => $label) 
 				{
@@ -4227,9 +4227,9 @@ class e_admin_controller_ui extends e_admin_controller
 				$res = array($filter[1], $filter[2]);
 				$this->_log('listQry Filtered by ' .$filter[1]. ' (' .($filter[2] ? 'true': 'false'). ')');
 			break;
-			
+
 			case 'datestamp':
-							
+
 				//XXX DO NOT TRANSLATE THESE VALUES!
 				$dateConvert = array(
 					'hour'    => '1 hour ago',
@@ -4253,15 +4253,15 @@ class e_admin_controller_ui extends e_admin_controller
 					'nmonth9' => 'now + 9 months',
 					'nyear'   => 'now + 1 year',
 				);
-				
+
 				$ky = $filter[2];
 				$time = vartrue($dateConvert[$ky]);
-				$timeStamp = strtotime($time);
+				$timeStamp = strtotime((string) $time);
 
 				$res = array($filter[1], $timeStamp);
 			//	e107::getMessage()->addDebug('Date: '.date('c', $timeStamp));
 				$this->_log('listQry Filtered by ' .$filter[1]. ' (' .$time. ')');
-				
+
 			break;
 
 			default:
@@ -4314,7 +4314,7 @@ class e_admin_controller_ui extends e_admin_controller
 	protected function convertToData(&$data)
 	{
 		$model = new e_model($data);
-	
+
 		foreach ($this->getFields() as $key => $attributes)
 		{
 			$value = vartrue($attributes['dataPath']) ? $model->getData($attributes['dataPath'])  : $model->get($key);
@@ -4325,16 +4325,16 @@ class e_admin_controller_ui extends e_admin_controller
 			}
 			switch($attributes['type'])
 			{
-			
+
 				case 'password': //TODO more encryption options. 
 					if(strlen($value) < 30) // expect a non-md5 value if less than 32 chars. 
 					{
 						$value = md5($value);
 					}
-					
+
 				break;	
-			
-			
+
+
 				case 'datestamp':
 					$opt = array();
 					if(!is_numeric($value))
@@ -4351,12 +4351,12 @@ class e_admin_controller_ui extends e_admin_controller
 							}
 						}
 
-						
+
 						$format = !empty($opt['type']) ? ('input'.$opt['type']) : 'inputdate';
 
 						if($attributes['data'] !== false)
 						{
-							$value = trim($value) ? e107::getDate()->toTime($value, $format) : 0;
+							$value = trim((string) $value) ? e107::getDate()->toTime($value, $format) : 0;
 						}
 					}
 				break;
@@ -4381,18 +4381,18 @@ class e_admin_controller_ui extends e_admin_controller
 						$value = implode(',', $value);
 					}
 				break;
-				
+
 				case 'images':
 				case 'files':
-		
+
 				//	XXX Cam @ SecretR: didn't work here. See model_class.php line 2046. 
 				// if(!is_array($value))
 			//		{
 				//		$value = e107::unserialize($value);	
 				//	}
 				break;
-				
-	
+
+
 			}
 /*
 			if($attributes['serialize'] == true)
@@ -4405,7 +4405,7 @@ class e_admin_controller_ui extends e_admin_controller
 				$value = e107::unserialize($value);	
 			}
 */
-	
+
 			if(!empty($attributes['dataPath']))
 			{
 				$model->setData($attributes['dataPath'], $value);
@@ -4445,7 +4445,7 @@ class e_admin_controller_ui extends e_admin_controller
 		{
 			return;
 		}
-		
+
 		if($noredirect_for && $noredirect_for == $this->getPosted('__after_submit_action') && $noredirect_for == $this->getAction())
 		{
 			return;
@@ -4487,7 +4487,7 @@ class e_admin_controller_ui extends e_admin_controller
 		$ret .= '<li>'.$srch.'<span class="informal warning"> '.LAN_FILTER_LABEL_TYPED.'</span></li>'; // fix Enter - search for typed word only
 
 		$reswords = array();
-		if(trim($srch) !== '')
+		if(trim((string) $srch) !== '')
 		{
 			// Build query
 			$qry = $this->_modifyListQry(false, true, 0, 20, $listQry);
@@ -4509,7 +4509,7 @@ class e_admin_controller_ui extends e_admin_controller
 							array_unshift($reswords, $w); //exact match
 							continue;
 						}
-						preg_match('#[\S]*('.$srch.')[\S]*#i', $w, $tmp1);
+						preg_match('#[\S]*('.$srch.')[\S]*#i', (string) $w, $tmp1);
 						if($tmp1[0])
 						{
 							$reswords[] = $tmp1[0];
@@ -4540,7 +4540,7 @@ class e_admin_controller_ui extends e_admin_controller
 		{
 			list($alias,$tmp) = explode('.',$alias,2);
 		}
-				
+
 		$tmp = array_flip($this->joinAlias);
 		return vartrue($tmp[$alias]);			
 	}
@@ -4579,14 +4579,14 @@ class e_admin_controller_ui extends e_admin_controller
 		} // already parsed!!!
 
 		$this->joinAlias($this->listQry); // generate Table Aliases from listQry
-		
+
 		if($this->getJoinData())
 		{
 			foreach ($this->getJoinData() as $table => $att)
 			{
-				if(strpos($table, '.') !== false)
+				if(strpos((string) $table, '.') !== false)
 				{
-					$tmp = explode('.', $table, 2);
+					$tmp = explode('.', (string) $table, 2);
 					$this->setJoinData($table, null);
 					$att['alias'] = $tmp[0];
 					$att['table'] = $tmp[1];
@@ -4603,7 +4603,7 @@ class e_admin_controller_ui extends e_admin_controller
 				$this->setJoinData($table, $att);
 			}
 		}
-		
+
 
 		if(empty($this->fields))
 		{
@@ -4617,9 +4617,9 @@ class e_admin_controller_ui extends e_admin_controller
 		foreach ($this->fields as $field => $att)
 		{
 			// fieldAlias.fieldName // table name no longer required as it's included in listQry. (see joinAlias() )
-			if(strpos($field, '.') !== false) // manually entered alias.
+			if(strpos((string) $field, '.') !== false) // manually entered alias.
 			{
-				$tmp = explode('.', $field, 2);
+				$tmp = explode('.', (string) $field, 2);
 				$table = $this->getTableFromAlias($tmp[0]);
 				$att['table'] = $table;
 				$att['alias'] = $tmp[0];
@@ -4636,7 +4636,7 @@ class e_admin_controller_ui extends e_admin_controller
 			{
 
 				$att['table'] = $this->getIfTableAlias();
-				
+
 				if($newField = $this->getJoinField($field)) // Auto-Detect. 
 				{
 					$table = $this->getTableFromAlias($newField); // Auto-Detect. 
@@ -4687,7 +4687,7 @@ class e_admin_controller_ui extends e_admin_controller
 			*/
 		}
 
-	
+
 		$this->fields = $fields;
 
 		$this->_alias_parsed = true;
@@ -4703,7 +4703,7 @@ class e_admin_controller_ui extends e_admin_controller
 	{
 		if(!empty($listQry))
 		{
-			preg_match_all("/`?#([\w-]+)`?\s*(as|AS)\s*([\w-]+)/im",$listQry,$matches);
+			preg_match_all("/`?#([\w-]+)`?\s*(as|AS)\s*([\w-]+)/im",(string) $listQry,$matches);
 			$keys = array();
 			foreach($matches[1] AS $k=>$v)
 			{
@@ -4711,13 +4711,13 @@ class e_admin_controller_ui extends e_admin_controller
 				{
 					$this->joinAlias[$v] = $matches[3][$k]; // array. eg $this->joinAlias['core_media'] = 'm';
 				}
-				
+
 				$keys[] = $matches[3][$k];
 			}
 
 			foreach($keys as $alias)
 			{
-				preg_match_all('/' .$alias."\.([\w]*)/i",$listQry,$match);
+				preg_match_all('/' .$alias."\.([\w]*)/i",(string) $listQry,$match);
 				foreach($match[1] as $k=>$m)
 				{
 					if(empty($m))
@@ -4733,12 +4733,12 @@ class e_admin_controller_ui extends e_admin_controller
 		{
 			foreach ($this->tableJoin as $tbl => $data) 
 			{
-				$matches = explode('.', $tbl, 2);
+				$matches = explode('.', (string) $tbl, 2);
 				$this->joinAlias[$matches[1]] = $matches[0]; // array. eg $this->joinAlias['core_media'] = 'm';
 				//'user_name'=>'u.user_name'
 				if(isset($data['fields']) && $data['fields'] !== '*')
 				{
-					$tmp = explode(',', $data['fields']);
+					$tmp = explode(',', (string) $data['fields']);
 					foreach ($tmp as $field) 
 					{
 						$this->joinField[$field] = $matches[0].'.'.$field;
@@ -4759,18 +4759,18 @@ class e_admin_controller_ui extends e_admin_controller
 		{
 			e107::getMessage()->addDebug('Using Custom listQry ');	
 		}
-			
-		if(strpos($qry,'`')===false && strpos($qry, 'JOIN')===false) 
+
+		if(strpos((string) $qry,'`')===false && strpos((string) $qry, 'JOIN')===false) 
 		{
-			$ret = preg_replace("/FROM\s*(#[\w]*)/", 'FROM `$1`', $qry);  // backticks missing, so add them.
-						
+			$ret = preg_replace("/FROM\s*(#[\w]*)/", 'FROM `$1`', (string) $qry);  // backticks missing, so add them.
+
 			if($ret)
 			{
 				e107::getMessage()->addDebug('Your $listQry is missing `backticks` around the table name! It should look like this'. print_a($ret,true)); 
 				return $ret; 	
 			}
 		}
-		
+
 		return $qry; 
 	}
 
@@ -4826,15 +4826,15 @@ class e_admin_controller_ui extends e_admin_controller
 	 */
 	protected function _modifyListQry($raw = false, $isfilter = false, $forceFrom = false, $forceTo = false, $listQry = '')
 	{
-		
+
 		$request    = $this->getRequest();
 
-		
+
 		$tablePath  = $this->getIfTableAlias(true, true).'.';
 		$tableFrom  = '`'.$this->getTableName(false, true).'`'.($this->getTableName(true) ? ' AS '.$this->getTableName(true) : '');
 		$primaryName = $this->getPrimaryName();
 		$perPage    = (int) $this->getPerPage();
-				
+
 		$qryField   = $request->getQuery('field');
 		$qryAsc     = $request->getQuery('asc');
 		$qryFrom    = (int) $request->getQuery('from', 0);
@@ -5021,7 +5021,7 @@ class e_admin_controller_ui extends e_admin_controller
 		{
 
 		}
-			
+
 		// Scenario II - inner model sanitize
 		//$this->getModel()->setPosted($this->convertToData($_POST, null, false, true);
 
@@ -5146,8 +5146,8 @@ class e_admin_controller_ui extends e_admin_controller
 		{
 			$type .= 'd'; // ie. 'created' or 'updated'.
 		}
-		
-		return 'admin_'.strtolower($name).'_'.strtolower($type);
+
+		return 'admin_'.strtolower((string) $name).'_'.strtolower($type);
 
 	}
 
@@ -5625,7 +5625,7 @@ class e_admin_controller_ui extends e_admin_controller
 		if(count($searchQry) > 0)
 		{
 			// add more where details on the fly via $this->listQrySql['db_where'];
-			$qry .= (strripos($qry, 'where') === false) ? ' WHERE ' : ' AND '; // Allow 'where' in custom listqry
+			$qry .= (strripos((string) $qry, 'where') === false) ? ' WHERE ' : ' AND '; // Allow 'where' in custom listqry
 			$qry .= implode(' AND ', $searchQry);
 
 			// Disable tree (use flat list instead) when filters are applied
@@ -5653,10 +5653,10 @@ class e_admin_controller_ui extends e_admin_controller
 		{
 			$orderField = !empty($qryField) ? $qryField : $this->getDefaultOrderField();
 			$orderDef   = ($qryAsc === null ? $this->getDefaultOrder() : $qryAsc);
-			if(isset($fields[$orderField]) && strpos($this->listQry, 'ORDER BY') == false) //override ORDER using listQry (admin->sitelinks)
+			if(isset($fields[$orderField]) && strpos((string) $this->listQry, 'ORDER BY') == false) //override ORDER using listQry (admin->sitelinks)
 			{
 				// no need of sanitize - it's found in field array
-				$qry .= ' ORDER BY ' . $fields[$orderField]['__tableField'] . ' ' . (strtolower($orderDef) === 'desc' ? 'DESC' : 'ASC');
+				$qry .= ' ORDER BY ' . $fields[$orderField]['__tableField'] . ' ' . (strtolower((string) $orderDef) === 'desc' ? 'DESC' : 'ASC');
 			}
 		}
 
@@ -5795,7 +5795,7 @@ class e_admin_ui extends e_admin_controller_ui
 	 * @var boolean
 	 */
 	public $deleteConfirmScreen = false;
-	
+
 	/**
 	 * Confirm screen custom message
 	 * @var string
@@ -5909,7 +5909,7 @@ class e_admin_ui extends e_admin_controller_ui
 
 				}
 
-				$batchCat = deftrue('LAN_PLUGIN_'.strtoupper($plug).'_NAME', $plug);
+				$batchCat = deftrue('LAN_PLUGIN_'.strtoupper((string) $plug).'_NAME', $plug);
 				$this->batchOptions[$batchCat] = $opts;
 
 			}
@@ -6008,9 +6008,9 @@ class e_admin_ui extends e_admin_controller_ui
 	 */
 	protected function handleListDeleteBatch($selected)
 	{
-		
+
 		$tp = e107::getParser();
-		
+
 		if(!$this->getBatchDelete())
 		{
 			e107::getMessage()->add(LAN_UI_BATCHDEL_ERROR, E_MESSAGE_WARNING);
@@ -6027,7 +6027,7 @@ class e_admin_ui extends e_admin_controller_ui
 			else
 			{
 				// already confirmed, resurrect selected values
-				$selected = explode(',', $this->getPosted('delete_confirm_value'));
+				$selected = explode(',', (string) $this->getPosted('delete_confirm_value'));
 				foreach ($selected as $i => $_sel) 
 				{
 					$selected[$i] = preg_replace('/[^\w\-:.]/', '', $_sel);
@@ -6146,7 +6146,7 @@ class e_admin_ui extends e_admin_controller_ui
         {
         	if(!$tree->hasNode($id))
         	{
-        		e107::getMessage()->addError('Item #ID '.htmlspecialchars($id).' not found.');
+        		e107::getMessage()->addError('Item #ID '.htmlspecialchars((string) $id).' not found.');
         		continue;
         	}
 
@@ -6225,7 +6225,7 @@ class e_admin_ui extends e_admin_controller_ui
 		{
 			return false;
 		}// TODO warning message
-		
+
 		if(!is_array($selected))
 		{
 			$selected = array($selected);
@@ -6236,17 +6236,17 @@ class e_admin_ui extends e_admin_controller_ui
 		$allData 	= $this->getTreeModel()->url($selected, array('sc' => true), true);
 
         e107::getMessage()->addDebug('Using Url Route:'.$urlData['route']);   
-        
+
 		$scount = 0;
         foreach($allData as $id => $data)
         {
             $name = $data['name'];
             $desc = $data['description'];
-            
+
             $link = $data['url'];
-            
+
             $link = str_replace('{e_BASE}', '', $link); // TODO temporary here, discuss
-            
+
             // _FIELD_TYPES auto created inside mysql handler now
             $linkArray = array(
                 'link_name'         => $name, 
@@ -6260,9 +6260,9 @@ class e_admin_ui extends e_admin_controller_ui
                 'link_class'        => 0,
                 'link_sefurl'		=> e107::getParser()->toDB($urlData['route'].'?'.$id),
             );
-            
+
             $res = $sql->insert('links', $linkArray);
-            
+
             if($res !== FALSE)
             {
 				e107::getMessage()->addSuccess(LAN_CREATED. ': ' .LAN_NAVIGATION. ': ' .($name ? $name : 'n/a'));
@@ -6282,16 +6282,16 @@ class e_admin_ui extends e_admin_controller_ui
             }
 
         }
-        
+
 		if($scount > 0)
 		{
 			e107::getMessage()->addSuccess(LAN_CREATED. ' (' .$scount. ') ' .LAN_NAVIGATION_LINKS);
 			e107::getMessage()->addSuccess("<a class='btn btn-small btn-primary' href='".e_ADMIN_ABS."links.php?searchquery=&filter_options=link_category__255'>".LAN_CONFIGURE. ' ' .LAN_NAVIGATION. '</a>');
 			return $scount;        
 		}
-        
+
         return false; 
- 
+
 	}
 
 	/**
@@ -6305,12 +6305,12 @@ class e_admin_ui extends e_admin_controller_ui
 		{
 			return false;
 		}
-		
+
 		if(empty($selected))
 		{
 			return false;
 		}// TODO warning message
-		
+
 		if(!is_array($selected))
 		{
 			$selected = array($selected);
@@ -6320,7 +6320,7 @@ class e_admin_ui extends e_admin_controller_ui
 		$tree = $this->getTreeModel();
 		$urlData = $this->getTreeModel()->url($selected, array('sc' => true));
 		$data = $this->featurebox;
-		
+
 		$scount = 0;
 		$category = 0;
 
@@ -6328,10 +6328,10 @@ class e_admin_ui extends e_admin_controller_ui
         {
         	if(!$tree->hasNode($id)) 
         	{
-        		e107::getMessage()->addError('Item #ID '.htmlspecialchars($id).' not found.');
+        		e107::getMessage()->addError('Item #ID '.htmlspecialchars((string) $id).' not found.');
         		continue; // TODO message
         	} 
-        	
+
         	$model = $tree->getNode($id);
             if($data['url'] === true)
 			{
@@ -6342,9 +6342,9 @@ class e_admin_ui extends e_admin_controller_ui
 				$url = $model->get($data['url']);
 			}
 			$name = $model->get($data['name']);
-			
+
 			$category = e107::getDb()->retrieve('featurebox_category', 'fb_category_id', "fb_category_template='unassigned'");
-			
+
             $fbArray = array (
                 	'fb_title' 		=> $name, 
      				'fb_text' 		=> $model->get($data['description']), 
@@ -6376,16 +6376,16 @@ class e_admin_ui extends e_admin_controller_ui
 				}
             }
         }
-        
+
         if($scount > 0)
         {
 			e107::getMessage()->addSuccess(LAN_CREATED. ' (' .$scount. ') ' .defset('LAN_PLUGIN_FEATUREBOX_NAME'));
 			e107::getMessage()->addSuccess("<a class='btn btn-small btn-primary' href='".e_PLUGIN_ABS."featurebox/admin_config.php?searchquery=&filter_options=fb_category__{$category}' ".LAN_CONFIGURE. ' ' .LAN_PLUGIN_FEATUREBOX_NAME. '</a>');
 			return $scount;        
         }
-        
+
         return false; 
- 
+
 	}
 
 
@@ -6400,7 +6400,7 @@ class e_admin_ui extends e_admin_controller_ui
 
 
 
-	
+
 	/**
 	 * Batch boolean trigger
 	 * @param array $selected
@@ -6449,7 +6449,7 @@ class e_admin_ui extends e_admin_controller_ui
 		$rcnt = 0;
 		$cnt = $rcnt;
 		$value = e107::getParser()->toDB($value);
-		
+
 		switch ($type) 
 		{
 			case 'attach':
@@ -6463,16 +6463,16 @@ class e_admin_ui extends e_admin_controller_ui
 						continue;
 					}
 					$val = $node->get($field);
-					
+
 					if(empty($val))
 					{
 						$val = array();
 					}
 					elseif(!is_array($val))
 					{
-						$val = explode(',', $val);
+						$val = explode(',', (string) $val);
 					}
-					
+
 					if($type === 'deattach')
 					{
 						$search = array_search($value, $val);
@@ -6485,7 +6485,7 @@ class e_admin_ui extends e_admin_controller_ui
 						$val = implode(',', $val);
 						$node->set($field, $val);
 						$check = $this->getModel()->setData($node->getData())->save(false, true);
-						
+
 						if($check === false)
 						{
 							$this->getModel()->setMessages();
@@ -6496,7 +6496,7 @@ class e_admin_ui extends e_admin_controller_ui
 						}
 						continue;
 					}
-					
+
 					// attach it
 					if(in_array($value, $val) === false)
 					{
@@ -6517,7 +6517,7 @@ class e_admin_ui extends e_admin_controller_ui
 				}
 				$this->_model = null;
 			break;
-				
+
 			case 'addAll':
 				if(!empty($value))
 				{
@@ -6526,7 +6526,7 @@ class e_admin_ui extends e_admin_controller_ui
 						sort($value);	
 						$value = implode(',', array_map('trim', $value));
 					}
-					
+
 					$cnt = $this->getTreeModel()->batchUpdate($field, $value, $selected, true);
 				}
 				else
@@ -6535,9 +6535,9 @@ class e_admin_ui extends e_admin_controller_ui
 					$this->getTreeModel()->addMessageDebug(LAN_UPDATED_FAILED. ': Comma list is empty, aborting.')->setMessages();
 				}
 			break;
-				
+
 			case 'clearAll':
-				$allowed = !is_array($value) ? explode(',', $value) : $value;
+				$allowed = !is_array($value) ? explode(',', (string) $value) : $value;
 				if(!$allowed)
 				{
 					$rcnt = $this->getTreeModel()->batchUpdate($field, '', $selected, '');
@@ -6552,9 +6552,9 @@ class e_admin_ui extends e_admin_controller_ui
 						{
 							continue;
 						}
-						
+
 						$val = $node->get($field);
-						
+
 						// nothing to do
 						if(empty($val))
 						{
@@ -6562,9 +6562,9 @@ class e_admin_ui extends e_admin_controller_ui
 						}
 						elseif(!is_array($val))
 						{
-							$val = explode(',', $val);
+							$val = explode(',', (string) $val);
 						}
-						
+
 						// remove only allowed, see userclass
 						foreach ($val as $_k => $_v) 
 						{
@@ -6573,12 +6573,12 @@ class e_admin_ui extends e_admin_controller_ui
 								unset($val[$_k]);
 							}
 						}
-						
+
 						sort($val);
 						$val = !empty($val) ? implode(',', $val) : '';
 						$node->set($field, $val);
 						$check = $this->getModel()->setData($node->getData())->save(false, true);
-						
+
 						if($check === false)
 						{
 							$this->getModel()->setMessages();
@@ -6649,7 +6649,7 @@ class e_admin_ui extends e_admin_controller_ui
 	protected function handleListBatch($selected, $field, $value)
 	{
 		// special exceptions
-		
+
 		if($value === '#delete') // see admin->users
 		{
 			$val = "''";
@@ -6664,7 +6664,7 @@ class e_admin_ui extends e_admin_controller_ui
 		{
 			$val = "'".$value."'";	
 		}
-		
+
 		if($field === 'options') // reserved field type. see: admin -> media-manager - batch rotate image.
 		{
 			return null;
@@ -6737,16 +6737,16 @@ class e_admin_ui extends e_admin_controller_ui
 						return null;
 					} 	
 				}
-				
+
 				$check = $this->getTreeModel()->delete($id);
-				 		 
+
 				if($this->afterDelete($data, $id, $check))
 				{
 					if($triggerName = $this->getEventTriggerName($this->getEventName(), 'deleted')) // trigger for after.
 					{
 						$this->triggerEvent($triggerName, null, $data, $id);
 					}
-					
+
 					$this->getTreeModel()->setMessages();
 				}
 			}
@@ -6812,7 +6812,7 @@ class e_admin_ui extends e_admin_controller_ui
 
 		$this->addTitle();
 
-		
+
 	}
 
 	/**
@@ -6837,7 +6837,7 @@ class e_admin_ui extends e_admin_controller_ui
 	{
 		return $this->renderAjaxFilterResponse($this->listQry); //listQry will be used only if available
 	}
-	
+
 	/**
 	 * Inline edit action
 	 * @return void
@@ -6855,7 +6855,7 @@ class e_admin_ui extends e_admin_controller_ui
 			$this->logajax('Field not found');
 			return;
 		}
-		
+
 		$_name = $_POST['name'];
 		$_value = $_POST['value'];
 		$_token = $_POST['token'];
@@ -6869,8 +6869,8 @@ class e_admin_ui extends e_admin_controller_ui
 		{
 			$this->fields[$_name]['inline'] = true;
 		}
-		
-		if(!empty($this->fields[$_name]['noedit']) || !empty($this->fields[$_name]['nolist']) || empty($this->fields[$_name]['inline']) || empty($_token) || !password_verify(session_id(),$_token))
+
+		if(!empty($this->fields[$_name]['noedit']) || !empty($this->fields[$_name]['nolist']) || empty($this->fields[$_name]['inline']) || empty($_token) || !password_verify(session_id(),(string) $_token))
 		{
 			header($protocol.': 403 Forbidden', true, 403);
 			header('Status: 403 Forbidden', true, 403);
@@ -6883,7 +6883,7 @@ class e_admin_ui extends e_admin_controller_ui
 			$problem['nolist'] = !empty($this->fields[$_name]['nolist']) ? 'yes' : 'no';
 			$problem['inline'] = empty($this->fields[$_name]['inline']) ? 'yes' : 'no';
 			$problem['token'] = empty($_token) ? 'yes' : 'no';
-			$problem['password'] = !password_verify(session_id(),$_token) ? 'yes' : 'no';
+			$problem['password'] = !password_verify(session_id(),(string) $_token) ? 'yes' : 'no';
 
 			$result .= "\nForbidden Caused by: ".print_r($problem,true);
 			$this->logajax("Forbidden\nAction:".$this->getAction()."\nField (".$_name."):\n".$result);
@@ -6893,14 +6893,14 @@ class e_admin_ui extends e_admin_controller_ui
 
 
 
-		
+
 		$model = $this->getModel()->load($this->getId());
 		$_POST = array(); //reset post
 		$_POST[$_name] = $_value; // set current field only
 		$_POST['etrigger_submit'] = 'update'; // needed for event trigger
 
 	//	print_r($_POST);
-		
+
 		// generic handler - same as regular edit form submit
 
 		$this->convertToData($_POST);
@@ -6928,7 +6928,7 @@ class e_admin_ui extends e_admin_controller_ui
 			{
 				$message = e107::getMessage()->get('error', $model->getMessageStackName(), true);
 			}
-			
+
 			if(!empty($message))
 			{
 				echo implode(' ', $message);
@@ -6961,11 +6961,11 @@ class e_admin_ui extends e_admin_controller_ui
 		$message .= print_r($_GET,true);
 
 		$message .= '---------------';
-		
+
 		file_put_contents(e_LOG.'uiAjaxResponseInline.log', $message."\n\n", FILE_APPEND);
 	}
-	
-	
+
+
 	/**
 	 * Drag-n-Drop sort action
 	 * @return void
@@ -7006,7 +7006,7 @@ class e_admin_ui extends e_admin_controller_ui
 		foreach($_POST['all'] as $row)
 		{
 
-			list($tmp,$id) = explode('-', $row, 2);
+			list($tmp,$id) = explode('-', (string) $row, 2);
 			$id = preg_replace('/[^\w\-:.]/', '', $id);
 			if(!is_numeric($id))
 			{
@@ -7962,12 +7962,12 @@ class e_admin_form_ui extends e_form
 			foreach($fields as $fld)
 			{
 
-				if(strpos($fld,'x_') !== 0)
+				if(strpos((string) $fld,'x_') !== 0)
 				{
 					continue;
 				}
 
-				list($prefix,$plug,$field) = explode('_',$fld,3);
+				list($prefix,$plug,$field) = explode('_',(string) $fld,3);
 
 				if($prefix !== 'x' || empty($field) || empty($plug))
 				{
@@ -8151,9 +8151,9 @@ class e_admin_form_ui extends e_form
 		$request = $controller->getRequest();
 		$fieldsets = array();
 		$forms = array();
-		$id_array = explode(',', $ids);
+		$id_array = explode(',', (string) $ids);
 		$delcount = count($id_array);
-		
+
 		if(!empty($controller->deleteConfirmMessage))
         { 
 			e107::getMessage()->addWarning(str_replace('[x]', '<b>' .$delcount. '</b>', $controller->deleteConfirmMessage));
@@ -8162,7 +8162,7 @@ class e_admin_form_ui extends e_form
         {
 			e107::getMessage()->addWarning(str_replace('[x]', '<b>' .$delcount. '</b>',LAN_UI_DELETE_WARNING));
         }
-    
+
 		$fieldsets['confirm'] = array(
 			'fieldset_pre' => '', // markup to be added before opening fieldset element
 			'fieldset_post' => '', // markup to be added after closing fieldset element
@@ -8226,7 +8226,7 @@ class e_admin_form_ui extends e_form
 				\$('#admin-ui-list-filter a.nextprev-item').on('click', function() {
 					\$('#admin-ui-list-filter .indicator').show();
 			});
-		
+
 		");
 
 		return $this->pagination(e_REQUEST_SELF.'?'.$paginate,$totalRecords,$fromPage,$perPage,array('template'=>'basic'));
@@ -8250,7 +8250,7 @@ class e_admin_form_ui extends e_form
 		{
 			$location = 'main/list'; //default location
 		}
-		$l = e107::getParser()->post_toForm(explode('/', $location));
+		$l = e107::getParser()->post_toForm(explode('/', (string) $location));
 		if(!is_array($input_options))
 		{
 			parse_str($input_options, $input_options);
@@ -8277,9 +8277,9 @@ class e_admin_form_ui extends e_form
 				{
 					continue;
 				}
-				
-				$key = preg_replace('/[\W]/', '', $key);
-				$filter_preserve_var[] = $this->hidden($key, rawurlencode($value));
+
+				$key = preg_replace('/[\W]/', '', (string) $key);
+				$filter_preserve_var[] = $this->hidden($key, rawurlencode((string) $value));
 			}
 		}
 		else
@@ -8327,7 +8327,7 @@ class e_admin_form_ui extends e_form
 							<div class='e-autocomplete'></div>
 							".implode("\n", $filter_preserve_var). '
 							' .$this->admin_button('etrigger_filter', 'etrigger_filter', 'filter e-hide-if-js', defset('ADMIN_FILTER_ICON'), array('id' => false, 'title' =>LAN_FILTER, 'loading' => false)). '
-							
+
 							' .$this->renderPagination()."	
 							".$gridToggle."
 							<span class='indicator' style='display: none;'>
@@ -8352,11 +8352,11 @@ class e_admin_form_ui extends e_form
 			</form>
 		';
 
-	
+
 		e107::js('core','scriptaculous/controls.js','prototype', 2);
 		//TODO - external JS
 		e107::js('footer-inline',"
-	
+
 	            //autocomplete fields
 	             \$\$('input[name=searchquery]').each(function(el, cnt) {
 				 	if(!cnt) el.activate();
@@ -8389,7 +8389,7 @@ class e_admin_form_ui extends e_form
 					}
 				});
 		",'prototype');
-		
+
 		// TODO implement ajax queue
 		// FIXME
 		// dirty way to register events after ajax update - DO IT RIGHT - see all.jquery, create object and use handler,
@@ -8418,7 +8418,7 @@ class e_admin_form_ui extends e_form
 					if(\$(this).val().startsWith('jstarget:')) {
 						selector = 'input[type=\"checkbox\"][name^=\"' + \$(this).val().split(/jstarget\:/)[1] + '\"]';
 					}
-					
+
 					if(\$(this).is(':checked')){
 						\$(selector).attr('checked', 'checked');
 					}
@@ -8428,16 +8428,16 @@ class e_admin_form_ui extends e_form
 				});
 			};
 			var searchQueryHandler = function (e) {
-				
+
 				var el = \$(this), frm = el.parents('form'), cont = frm.nextAll('.e-container');
 				if(cont.length < 1 || frm.length < 1 || (el.val().length > 0 && el.val().length < 3)) return;
 				e.preventDefault();
-				
+
 				if(filterRunning && request) request.abort();
 				filterRunning = true;
 				\$('#admin-ui-list-filter .indicator').show();
 				cont.css({ opacity: 0.5 });
-				
+
 				request = \$.get(frm.attr('action'), frm.serialize(), function(data){
 					filterRunning = false;
 					setTimeout(function() {
@@ -8459,16 +8459,16 @@ class e_admin_form_ui extends e_form
 				});
 			};
 			\$('#searchquery').on('keyup', searchQueryHandler);
-			
+
 			\$('#filter-options').on('change', function() {
 					\$('#admin-ui-list-filter .indicator').show();
 			});
-			
+
 			\$('#etrigger-filter').on('click', function() {
 					\$('#admin-ui-list-filter .indicator').show();
 			});
-			
-			
+
+
 		", 'jquery');
 
 		return $text;
@@ -8546,13 +8546,13 @@ class e_admin_form_ui extends e_form
 			$mes->add("Cannot display Batch drop-down as 'checkboxes' was not found in \$fields array.", E_MESSAGE_DEBUG);
 			return '';
 		}
-		
+
 		// FIX - don't show FB option if plugin not installed
 		if(!e107::isInstalled('featurebox'))
 		{
 			$options['featurebox'] = false;
 		}
-		
+
 		// TODO - core ui-batch-option class!!! REMOVE INLINE STYLE!
 		// XXX Quick Fix for styling - correct. 
 		$text = "
@@ -8566,7 +8566,7 @@ class e_admin_form_ui extends e_form
 						' .$this->option(defset('LAN_BATCH_LABEL_SELECTED'), '');
 
 		$selectOpt = '';
-				
+
 		if(!$this->getController()->getTreeModel()->isEmpty())
 		{		
 			$selectOpt .= !empty($options['copy']) ? $this->option(defset('LAN_COPY'),
@@ -8641,7 +8641,7 @@ class e_admin_form_ui extends e_form
 
 		}
 
-		
+
 		$text .= "
 
 				<div id='admin-ui-list-total-records' class='span6 col-md-6 right'><span>".e107::getParser()->lanVars(LAN_UI_TOTAL_RECORDS,number_format($this->getController()->getTreeModel()->getTotal())). '</span></div>
@@ -8685,7 +8685,7 @@ class e_admin_form_ui extends e_form
 		$table = $obj->getTableName();
 		$text = '';
 		$textsingle = '';
-				
+
 
 		$searchFieldOpts = array();
 
@@ -8768,7 +8768,7 @@ class e_admin_form_ui extends e_form
 							$LAN_TRUE = LAN_YES;
 							$LAN_FALSE = LAN_NO;
 						}
-						
+
 						if(!empty($parms['enabled']))
 						{
 							$LAN_TRUE = $parms['enabled'];
@@ -8797,13 +8797,13 @@ class e_admin_form_ui extends e_form
 							$option['bool__'.$key.'__1'] = $LAN_TRUE;
 							$option['bool__'.$key.'__0'] = $LAN_FALSE;
 						}
-							
+
 						if($type === 'batch')
 						{
 							$option['boolreverse__'.$key] = LAN_BOOL_REVERSE;
 						}
 					break;
-					
+
 					case 'checkboxes':
 					case 'comma':
 
@@ -8814,7 +8814,7 @@ class e_admin_form_ui extends e_form
 							unset($fopts['optArray']);
 							$parms['__options'] = $fopts;
 						}
-				
+
 						// TODO lan
 						if(!isset($parms['__options']))
 						{
@@ -8822,18 +8822,18 @@ class e_admin_form_ui extends e_form
 						}
 						if(!is_array($parms['__options']))
 						{
-							parse_str($parms['__options'], $parms['__options']);
+							parse_str((string) $parms['__options'], $parms['__options']);
 						}
 						$opts = $parms['__options'];
 						unset($parms['__options']); //remove element options if any
-						
+
 						$options = $parms ? $parms : array();
 						if(empty($options))
 						{
 							continue 2;
 						}
-						
-						
+
+
 						if($type === 'batch')
 						{
 							$_option = array(); 
@@ -8848,7 +8848,7 @@ class e_admin_form_ui extends e_form
 								$_option['deattach_all__'.$key] = vartrue($options['clearAll'], '(' .LAN_CLEAR_ALL. ')');
 								unset($options['clearAll']);
 							}
-							
+
 							if(!empty($opts['simple']))
 							{
 								foreach ($options as $value) 
@@ -8888,7 +8888,7 @@ class e_admin_form_ui extends e_form
 
 						}						
 					break;
-						
+
 					case 'templates':
 					case 'layouts':
 						$parms['raw'] = true;
@@ -8942,7 +8942,7 @@ class e_admin_form_ui extends e_form
 					case 'lanlist': // use the array $parm;
 						if(!is_array(varset($parms['__options'])))
 						{
-							parse_str($parms['__options'], $parms['__options']);
+							parse_str((string) $parms['__options'], $parms['__options']);
 						}
 						$opts = $parms['__options'];
 						if(!empty($opts['multiple']))
@@ -9007,7 +9007,7 @@ class e_admin_form_ui extends e_form
 							$time = time();
 							$option[$key.'__'.$time] = LAN_UI_BATCH_NOW;
 						}
-					    
+
 
 					break;
 
@@ -9021,7 +9021,7 @@ class e_admin_form_ui extends e_form
 					case 'userclasses':
 						$classes = e107::getUserClass()->uc_required_class_list(vartrue($parms['classlist'], 'public,nobody,guest,member,admin,main,classes'));
 						$_option = array();
-						
+
 						if($type === 'batch')
 						{
 							foreach ($classes as $k => $v) 
@@ -9040,7 +9040,7 @@ class e_admin_form_ui extends e_form
 								$option[$key.'__'.$k] = $v;	
 							}
 						}
-						
+
 						unset($_option);
 					break;
 
@@ -9048,9 +9048,9 @@ class e_admin_form_ui extends e_form
 
 						$method = !empty($val['method']) ? $val['method'] : $key; // Use the method attribute if specified, otherwise fall back to the field key
 
-						if(strpos($method, '::') !== false)
+						if(strpos((string) $method, '::') !== false)
 						{
-							list($className, $methodName) = explode('::', $method);
+							list($className, $methodName) = explode('::', (string) $method);
 							$cls = new $className();
 						}
 						else
@@ -9089,10 +9089,10 @@ class e_admin_form_ui extends e_form
 						break;
 
 					case 'user': // TODO - User Filter
-					
+
 						$sql = e107::getDb();
 						$field = $val['field'];
-						
+
 						$query = 'SELECT d.' .$field. ', u.user_name FROM #' .$val['table']. ' AS d LEFT JOIN #user AS u ON d.' .$field. ' = u.user_id  GROUP BY d.' .$field. ' ORDER BY u.user_name';
 						$row = $sql->retrieve($query,true);
 						foreach($row as $data)
@@ -9106,8 +9106,8 @@ class e_admin_form_ui extends e_form
 							{
 								$option[$key.'__'.$k] = vartrue($data['user_name'],LAN_UNKNOWN);
 							}
-							
-							
+
+
 						}
 					break;
 			}

--- a/e107_handlers/application.php
+++ b/e107_handlers/application.php
@@ -170,7 +170,7 @@ class e_url
 				}
 
 
-				$newLocation = preg_replace($regex, $v['redirect'], $this->_request);
+				$newLocation = preg_replace($regex, (string) $v['redirect'], $this->_request);
 
 				if($newLocation != $this->_request)
 				{
@@ -957,9 +957,9 @@ class eDispatcher
 		$location = self::getModuleConfigLocation($module);
 		if(!$location) return null;
 		
-		if(($pos = strpos($location, '/'))) //can't be 0
+		if(($pos = strpos((string) $location, '/'))) //can't be 0
 		{
-			return substr($location, 0, $pos);
+			return substr((string) $location, 0, $pos);
 		}
 		return $location;
 	}
@@ -1408,7 +1408,7 @@ class eRouter
 					$ret[$module] = $current[$module];
 					continue;
 				}
-				
+
 				// in all other cases additional re-check will be made - see below
 			}
 			
@@ -1882,7 +1882,7 @@ class eRouter
 		}
 
 		// max number of parts is actually 4 - module/controller/action/[additional/pathinfo/vars], here for reference only
-		$parts = $rawPathInfo ? explode('/', $rawPathInfo, 4) : array();
+		$parts = $rawPathInfo ? explode('/', (string) $rawPathInfo, 4) : array();
 
 		$this->_debug('parts',$parts,  __LINE__);
 
@@ -2000,7 +2000,7 @@ class eRouter
 									if(isset($_GET[$key]) && !$request->isRequestParam($key))
 									{
 										// sanitize
-										$vars->$key = preg_replace('/[^\w\-]/', '', $_GET[$key]);
+										$vars->$key = preg_replace('/[^\w\-]/', '', (string) $_GET[$key]);
 									}
 								}
 							}
@@ -2234,7 +2234,7 @@ class eRouter
 
 		$alias = $this->hasAlias($module, vartrue($options['lan'], null)) ? $this->getAliasFromModule($module, vartrue($options['lan'], null)) : $module;
 		$route[0] = $alias;
-		if($options['encode']) $alias = rawurlencode($alias);
+		if($options['encode']) $alias = rawurlencode((string) $alias);
 		
 		$format = isset($config['format']) && $config['format'] ? $config['format'] : self::FORMAT_GET;
 		
@@ -2411,7 +2411,7 @@ class eRouter
 		$ampersand = !$encode && $options['amp'] == '&amp;' ? '&' : $options['amp'];
 		foreach ($params as $k => $v)
 		{
-			if (null !== $key) $k = $key.'['.rawurlencode($k).']';
+			if (null !== $key) $k = $key.'['.rawurlencode((string) $k).']';
 
 			if (is_array($v)) $pairs[] = $this->createPathInfo($v, $options, $k);
 			else 
@@ -2420,15 +2420,15 @@ class eRouter
 				{
 					if($encode)
 					{
-						$k = null !== $key ? $k : rawurlencode($k);
+						$k = null !== $key ? $k : rawurlencode((string) $k);
 					}
 					$pairs[] = $k;
 					continue;
 				}
 				if($encode)
 				{
-					$k =  null !== $key ? $k : rawurlencode($k);
-					$v = rawurlencode($v);
+					$k =  null !== $key ? $k : rawurlencode((string) $k);
+					$v = rawurlencode((string) $v);
 				}
 				$pairs[] = $k.$equal.$v;
 			}
@@ -2805,7 +2805,7 @@ class eUrlRule
 			{
 				foreach($this->params as $key=>$value)
 				{
-					if(!preg_match('/'.$value.'/'.$case,$params[$key]))
+					if(!preg_match('/'.$value.'/'.$case,(string) $params[$key]))
 						return false;
 				}
 			}
@@ -2825,7 +2825,7 @@ class eUrlRule
 		foreach ($this->params as $key => $value)
 		{
 			// FIX - non-latin URLs proper encoded
-			$tr["<$key>"] = rawurlencode($params[$key]); //todo transliterate non-latin
+			$tr["<$key>"] = rawurlencode((string) $params[$key]); //todo transliterate non-latin
 		//	$tr["<$key>"] = eHelper::title2sef($tp->toASCII($params[$key]), $urlFormat); // enabled to test.
 			unset($params[$key]);
 		}
@@ -3179,7 +3179,7 @@ class eController
 			else 
 			{
 				//TODO not found method by controller or default one
-				$action = substr($actionMethodName, 6);
+				$action = substr((string) $actionMethodName, 6);
 				throw new eException('Action "'.$action.'" does not exist');
 			}
 		}
@@ -3221,7 +3221,7 @@ class eController
 		{
 			$url = eFront::instance()->getRouter()->assemble($url, '', 'encode=0');
 		}
-		if(strpos($url, 'http://') !== 0 && strpos($url, 'https://') !== 0)
+		if(strpos((string) $url, 'http://') !== 0 && strpos((string) $url, 'https://') !== 0)
 		{
 			$url = $url[0] == '/' ? SITEURLBASE.$url : SITEURL.$url;
 		}
@@ -3910,7 +3910,7 @@ class eRequest
 		$this->setModule($parts[0])
 			->setController(vartrue($parts[1], 'index'))
 			->setAction(vartrue($parts[2], 'index'));
-			
+
 		return $this;//->getRoute(true);
 	}
 
@@ -4049,7 +4049,7 @@ class eRequest
 		$qstring = '';
 		if($_SERVER['QUERY_STRING'])
 		{
-			$qstring = str_replace(array('{', '}', '%7B', '%7b', '%7D', '%7d'), '', rawurldecode($_SERVER['QUERY_STRING']));
+			$qstring = str_replace(array('{', '}', '%7B', '%7b', '%7D', '%7d'), '', rawurldecode((string) $_SERVER['QUERY_STRING']));
 		}
 
 		return str_replace('&', '&amp;', e107::getParser()->post_toForm($qstring));
@@ -4568,7 +4568,7 @@ class eResponse
 		if(!empty($pref['meta_keywords'][e_LANGUAGE])) // Always append (global) meta keywords to the end.
 		{
 			$tmp1 = (array) explode(",", $this->getMetaKeywords());
-			$tmp2 = (array) explode(",", $pref['meta_keywords'][e_LANGUAGE]);
+			$tmp2 = (array) explode(",", (string) $pref['meta_keywords'][e_LANGUAGE]);
 
 			$tmp3 = array_unique(array_merge($tmp1,$tmp2));
 
@@ -4585,7 +4585,7 @@ class eResponse
 			$attrData .= '<meta';
 			foreach ($attr as $p => $v) 
 			{
-				$attrData .= ' '.preg_replace('/[^\w\-]/', '', $p).'="'.str_replace(array('"', '<'), '', $v).'"';
+				$attrData .= ' '.preg_replace('/[^\w\-]/', '', (string) $p).'="'.str_replace(array('"', '<'), '', $v).'"';
 			}
 			$attrData .= ' />'."\n";
 		}
@@ -4878,7 +4878,7 @@ class eHelper
 	 */
 	public static function secureClassAttr($string)
 	{
-		return preg_replace(self::$_classRegEx, '', $string);
+		return preg_replace(self::$_classRegEx, '', (string) $string);
 	}
 
 
@@ -4930,7 +4930,7 @@ class eHelper
 	 */
 	public static function secureStyleAttr($string)
 	{
-		return preg_replace(self::$_styleRegEx, '', $string);
+		return preg_replace(self::$_styleRegEx, '', (string) $string);
 	}
 
 	/**
@@ -4949,7 +4949,7 @@ class eHelper
 	public static function formatMetaTitle($title)
 	{
 		$title = trim(str_replace(array('"', "'"), '', strip_tags(e107::getParser()->toHTML($title, TRUE))));
-		return trim(preg_replace('/[\s,]+/', ' ', str_replace('_', ' ', $title)));
+		return trim((string) preg_replace('/[\s,]+/', ' ', str_replace('_', ' ', $title)));
 	}
 
 	/**
@@ -4958,7 +4958,7 @@ class eHelper
 	 */
 	public static function secureSef($sef)
 	{
-		return trim(preg_replace('/[^\w\pL\s\-+.,]+/u', '', strip_tags(e107::getParser()->toHTML($sef, TRUE))));
+		return trim((string) preg_replace('/[^\w\pL\s\-+.,]+/u', '', strip_tags(e107::getParser()->toHTML($sef, TRUE))));
 	}
 
 	/**
@@ -4968,7 +4968,7 @@ class eHelper
 	public static function formatMetaKeys($keywordString)
 	{
 		$keywordString = preg_replace('/[^\w\pL\s\-.,+]/u', '', strip_tags(e107::getParser()->toHTML($keywordString, TRUE)));
-		return trim(preg_replace('/[\s]?,[\s]?/', ',', str_replace('_', ' ', $keywordString)));
+		return trim((string) preg_replace('/[\s]?,[\s]?/', ',', str_replace('_', ' ', $keywordString)));
 	}
 
 	/**
@@ -4978,7 +4978,7 @@ class eHelper
 	public static function formatMetaDescription($descrString)
 	{
 		$descrString = preg_replace('/[\r]*\n[\r]*/', ' ', trim(str_replace(array('"', "'"), '', strip_tags(e107::getParser()->toHTML($descrString, TRUE)))));
-		return trim(preg_replace('/[\s]+/', ' ', str_replace('_', ' ', $descrString)));
+		return trim((string) preg_replace('/[\s]+/', ' ', str_replace('_', ' ', $descrString)));
 	}
 
 	/**
@@ -5059,7 +5059,7 @@ class eHelper
 		$title = str_replace(array('/',' ',","),' ',$title);
 		$title = str_replace(array("&","(",")"),'',$title);
 		$title = preg_replace('/[^\w\pL\s.-]/u', '', strip_tags(e107::getParser()->toHTML($title, TRUE)));
-		$title = trim(preg_replace('/[\s]+/', ' ', str_replace('_', ' ', $title)));
+		$title = trim((string) preg_replace('/[\s]+/', ' ', str_replace('_', ' ', $title)));
 		$title = str_replace(array(' - ',' -','- ','--'),'-',$title); // cleanup to avoid ---
 
 		$words = str_word_count($title,1, '1234567890');

--- a/e107_handlers/bbcode_handler.php
+++ b/e107_handlers/bbcode_handler.php
@@ -104,7 +104,7 @@ class e_bbcode
 		$postID = $p_ID;
 
 
-		if (strlen($value) <= 6) return $value;     		// Don't waste time on trivia!
+		if (strlen((string) $value) <= 6) return $value;     		// Don't waste time on trivia!
 		if ($force_lower == 'default') $force_lower = TRUE;	// Set the default behaviour if not overridden
 		$code_stack = array();								// Stack for unprocessed bbcodes and text
 		$unmatch_stack = array();							// Stack for unmatched bbcodes
@@ -116,7 +116,7 @@ class e_bbcode
 		$strip_array = array();
 		if (!is_bool($bbStrip))
 		{
-			$strip_array = explode(',',$bbStrip);
+			$strip_array = explode(',',(string) $bbStrip);
 			if ($strip_array[0] == 'PRE')
 			{
 				$this->preProcess = "toDB";
@@ -143,7 +143,7 @@ class e_bbcode
 		// $matches[4] - '=' or ':' according to the separator used
 		// $matches[5] - any parameter
 
-		$content = preg_split('#(\[(?:\w|/\w).*?\])#ms', $value, -1, PREG_SPLIT_NO_EMPTY | PREG_SPLIT_DELIM_CAPTURE );
+		$content = preg_split('#(\[(?:\w|/\w).*?\])#ms', (string) $value, -1, PREG_SPLIT_NO_EMPTY | PREG_SPLIT_DELIM_CAPTURE );
 
 		foreach ($content as $cont)
 		{  // Each chunk is either a bbcode or a piece of text
@@ -336,7 +336,7 @@ class e_bbcode
 			else
 			{	// Add code to check for plugin bbcode addition
 				$bbPath = e_PLUGIN.$this->bbLocation[$code].'/';
-				$bbFile = strtolower($code);
+				$bbFile = strtolower((string) $code);
 				$debugFile = $bbFile;
 			}
 			if (file_exists($bbPath.'bb_'.$bbFile.'.php'))
@@ -434,7 +434,7 @@ class e_bbcode
 			return null;
 		}
 
-		if(strpos(ltrim($text), '[html]') === 0 && $type == 'img') // support for html img tags inside [html] bbcode.
+		if(strpos(ltrim((string) $text), '[html]') === 0 && $type == 'img') // support for html img tags inside [html] bbcode.
 		{
 
 			$tmp = e107::getParser()->getTags($text,'img');
@@ -444,7 +444,7 @@ class e_bbcode
 				$mtch = array();
 				foreach($tmp['img'] as $k)
 				{
-					$mtch[1][] = str_replace('"','',trim($k['src']));
+					$mtch[1][] = str_replace('"','',trim((string) $k['src']));
 					// echo $k['src']."<br />";
 				}
 
@@ -453,7 +453,7 @@ class e_bbcode
 		}
 		else // regular bbcode;
 		{
-			preg_match_all("/\[".$type."(?:[^\]]*)?]([^\[]*)(?:\[\/".$type."])/im",$text,$mtch);
+			preg_match_all("/\[".$type."(?:[^\]]*)?]([^\[]*)(?:\[\/".$type."])/im",(string) $text,$mtch);
 		}
 
 
@@ -743,7 +743,7 @@ class e_bbcode
                 break;
             }
            
-           $html = preg_replace($search,$replace,$html);  
+           $html = preg_replace($search,$replace,(string) $html);  
         }
   
         return str_replace(array("<html><body>","</body></html>"),"",$html); 
@@ -783,7 +783,7 @@ class e_bbcode
 		$arr['img'] = isset($arr['img']) && is_array($arr['img']) ? $arr['img'] : [];
 		foreach($arr['img'] as $img)
 		{
-			if(/*substr($img['src'],0,4) == 'http' ||*/ strpos($img['src'], e_IMAGE_ABS.'emotes/')!==false) // dont resize external images or emoticons.
+			if(/*substr($img['src'],0,4) == 'http' ||*/ strpos((string) $img['src'], e_IMAGE_ABS.'emotes/')!==false) // dont resize external images or emoticons.
 			{
 				continue;
 			}
@@ -792,7 +792,7 @@ class e_bbcode
 
 			$qr = $tp->thumbUrlDecode($img['src']); // extract width/height and src from thumb URLs.
 
-			if(strpos($qr['src'],'http')!==0 && empty($qr['w']) && empty($qr['aw']))
+			if(strpos((string) $qr['src'],'http')!==0 && empty($qr['w']) && empty($qr['aw']))
 			{
 				$qr['w'] = varset($img['width']);
 				$qr['h'] = varset($img['height']);
@@ -803,7 +803,7 @@ class e_bbcode
 
 			if(!empty($img['class']))
 			{
-				$tmp = explode(" ",$img['class']);
+				$tmp = explode(" ",(string) $img['class']);
 				$cls = array();
 				foreach($tmp as $v)
 				{
@@ -833,14 +833,14 @@ class e_bbcode
 			}
 
 
-			$code_text = (strpos($img['src'],'http') === 0) ? $img['src'] : str_replace($tp->getUrlConstants('raw'), $tp->getUrlConstants('sc'), $qr['src']);
+			$code_text = (strpos((string) $img['src'],'http') === 0) ? $img['src'] : str_replace($tp->getUrlConstants('raw'), $tp->getUrlConstants('sc'), $qr['src']);
 
 			unset($img['src'],$img['srcset'],$img['@value'], $img['caption'], $img['alt']);
 			$parms = !empty($img) ? ' '.str_replace('+', ' ', http_build_query($img)) : "";
 
 			$replacement = '[img'.$parms.']'.$code_text.'[/img]';
 
-			$html = preg_replace($regexp, $replacement, $html);
+			$html = preg_replace($regexp, $replacement, (string) $html);
 
 		}
 

--- a/e107_handlers/bounce_handler.php
+++ b/e107_handlers/bounce_handler.php
@@ -117,7 +117,7 @@ class e107Bounce
 				//	$message .= "<h4>Emails Found</h4><pre>".print_r($multiArray,TRUE). "</pre>";
 
 				$message .= "<pre>" . $strEmail . "</pre>";
-				
+
 			}
 
 
@@ -211,7 +211,7 @@ class e107Bounce
 		function getHeader($message, $id = 'X-e107-id')
 		{
 
-			$tmp = explode("\n", $message);
+			$tmp = explode("\n", (string) $message);
 			foreach($tmp as $val)
 			{
 				if(strpos($val, $id . ":") !== false)
@@ -380,7 +380,7 @@ class BounceHandler
 			$arrBody = explode("\r\n", $body);
 
 			// now we try all our weird text parsing methods
-			if(preg_match("/auto.{0,20}reply|vacation|(out|away|on holiday).*office/i", $head_hash['Subject']))
+			if(preg_match("/auto.{0,20}reply|vacation|(out|away|on holiday).*office/i", (string) $head_hash['Subject']))
 			{
 				// looks like a vacation autoreply, ignoring
 
@@ -415,7 +415,7 @@ class BounceHandler
 				$arrFailed = self::find_email_addresses($mime_sections['first_body_part']);
 				for($j = 0, $jMax = count($arrFailed); $j < $jMax; $j++)
 				{
-					$output[$j]['recipient'] = trim($arrFailed[$j]);
+					$output[$j]['recipient'] = trim((string) $arrFailed[$j]);
 					$output[$j]['status'] = self::get_status_code_from_text($output[$j]['recipient'], $arrBody, 0);
 					$output[$j]['action'] = self::get_action_from_status_code($output[$j]['status']);
 				}
@@ -430,7 +430,7 @@ class BounceHandler
 				$arrFailed = self::find_email_addresses($body);
 				for($j = 0, $jMax = count($arrFailed); $j < $jMax; $j++)
 				{
-					$output[$j]['recipient'] = trim($arrFailed[$j]);
+					$output[$j]['recipient'] = trim((string) $arrFailed[$j]);
 					$output[$j]['status'] = self::get_status_code_from_text($output[$j]['recipient'], $arrBody, 0);
 					$output[$j]['action'] = self::get_action_from_status_code($output[$j]['status']);
 				}
@@ -453,10 +453,10 @@ class BounceHandler
 
 			for($i = $index, $iMax = count($arrBody); $i < $iMax; $i++)
 			{
-				$line = trim($arrBody[$i]);
+				$line = trim((string) $arrBody[$i]);
 
 				/******** recurse into the email if you find the recipient ********/
-				if(stripos($line, $recipient) !== false)
+				if(stripos($line, (string) $recipient) !== false)
 				{
 					// the status code MIGHT be in the next few lines after the recipient line,
 					// depending on the message from the foreign host... What a laugh riot!
@@ -476,7 +476,7 @@ class BounceHandler
 				}
 				//if we see an email address other than our current recipient's,
 				if(count(self::find_email_addresses($line)) >= 1
-					&& stripos($line, $recipient) === false
+					&& stripos($line, (string) $recipient) === false
 					&& strpos($line, 'FROM:<') === false)
 				{ // Kanon added this line because Hotmail puts the e-mail address too soon and there actually is error message stuff after it.
 					return '';
@@ -609,7 +609,7 @@ class BounceHandler
 				//$out = "";
 				for($i = 0; $i < $blob; $i++)
 				{
-					$out = preg_replace("/<HEADER>/i", "", $blob[$i]);
+					$out = preg_replace("/<HEADER>/i", "", (string) $blob[$i]);
 					$out = preg_replace("/</HEADER>/i", "", $out);
 					$out = preg_replace("/<MESSAGE>/i", "", $out);
 					$out = preg_replace("/</MESSAGE>/i", "", $out);
@@ -627,7 +627,7 @@ class BounceHandler
 				$strEmail = "";
 				for($i = 0; $i < $blob; $i++)
 				{
-					$strEmail .= rtrim($blob[$i]) . "\r\n";
+					$strEmail .= rtrim((string) $blob[$i]) . "\r\n";
 				}
 			}
 
@@ -655,15 +655,15 @@ class BounceHandler
 
 			if(!is_array($headers))
 			{
-				$headers = explode("\r\n", $headers);
+				$headers = explode("\r\n", (string) $headers);
 			}
 			$hash = self::standard_parser($headers);
 			// get a little more complex
-			$arrRec = explode('|', $hash['Received']);
+			$arrRec = explode('|', (string) $hash['Received']);
 			$hash['Received'] = $arrRec;
 			if($hash['Content-type'])
 			{//preg_match('/Multipart\/Report/i', $hash['Content-type'])){
-				$multipart_report = explode(';', $hash['Content-type']);
+				$multipart_report = explode(';', (string) $hash['Content-type']);
 				$hash['Content-type'] = array();
 				$hash['Content-type']['type'] = strtolower($multipart_report[0]);
 				foreach($multipart_report as $mr)
@@ -697,7 +697,7 @@ class BounceHandler
 			{
 				$body = implode("\r\n", $body);
 			}
-			$body = explode($boundary, $body);
+			$body = explode($boundary, (string) $body);
 			$mime_sections['first_body_part'] = $body[1];
 			$mime_sections['machine_parsable_body_part'] = $body[2];
 			$mime_sections['returned_message_body_part'] = $body[3];
@@ -720,11 +720,11 @@ class BounceHandler
 
 			if(!is_array($content))
 			{
-				$content = explode("\r\n", $content);
+				$content = explode("\r\n", (string) $content);
 			}
 			foreach($content as $line)
 			{
-				if(preg_match('/([^\s.]*):\s(.*)/', $line, $array))
+				if(preg_match('/([^\s.]*):\s(.*)/', (string) $line, $array))
 				{
 					$entity = ucfirst(strtolower($array[1]));
 					if(empty($hash[$entity]))
@@ -767,14 +767,14 @@ class BounceHandler
 			$hash['per_message'] = self::standard_parser($hash['per_message']);
 			if(isset($hash['per_message']['X-postfix-sender']) && $hash['per_message']['X-postfix-sender'])
 			{
-				$arr = explode(';', $hash['per_message']['X-postfix-sender']);
+				$arr = explode(';', (string) $hash['per_message']['X-postfix-sender']);
 				$hash['per_message']['X-postfix-sender'] = '';
 				$hash['per_message']['X-postfix-sender']['type'] = trim($arr[0]);
 				$hash['per_message']['X-postfix-sender']['addr'] = trim($arr[1]);
 			}
 			if($hash['per_message']['Reporting-mta'])
 			{
-				$arr = explode(';', $hash['per_message']['Reporting-mta']);
+				$arr = explode(';', (string) $hash['per_message']['Reporting-mta']);
 				$hash['per_message']['Reporting-mta'] = '';
 				$hash['per_message']['Reporting-mta']['type'] = trim($arr[0]);
 				$hash['per_message']['Reporting-mta']['addr'] = trim($arr[1]);
@@ -782,16 +782,16 @@ class BounceHandler
 			//Per-Recipient DSN fields
 			for($i = 0, $iMax = count($hash['per_recipient']); $i < $iMax; $i++)
 			{
-				$temp = self::standard_parser(explode("\r\n", $hash['per_recipient'][$i]));
-				$arr = explode(';', $temp['Final-recipient']);
+				$temp = self::standard_parser(explode("\r\n", (string) $hash['per_recipient'][$i]));
+				$arr = explode(';', (string) $temp['Final-recipient']);
 				$temp['Final-recipient'] = array();
 				$temp['Final-recipient']['type'] = trim($arr[0]);
 				$temp['Final-recipient']['addr'] = trim($arr[1]);
-				$arr = explode(';', $temp['Original-recipient']);
+				$arr = explode(';', (string) $temp['Original-recipient']);
 				$temp['Original-recipient'] = array();
 				$temp['Original-recipient']['type'] = trim($arr[0]);
 				$temp['Original-recipient']['addr'] = trim($arr[1]);
-				$arr = explode(';', $temp['Diagnostic-code']);
+				$arr = explode(';', (string) $temp['Diagnostic-code']);
 				$temp['Diagnostic-code'] = array();
 				$temp['Diagnostic-code']['type'] = trim($arr[0]);
 				$temp['Diagnostic-code']['text'] = trim($arr[1]);
@@ -805,7 +805,7 @@ class BounceHandler
 
 				if($judgement == 'transient')
 				{
-					if(stripos($temp['Action'], 'failed') !== false)
+					if(stripos((string) $temp['Action'], 'failed') !== false)
 					{
 						$temp['Action'] = 'transient';
 						$temp['Status'] = '4.3.0';
@@ -825,7 +825,7 @@ class BounceHandler
 		static function get_head_from_returned_message_body_part($mime_sections)
 		{
 
-			$temp = explode("\r\n\r\n", $mime_sections['returned_message_body_part']);
+			$temp = explode("\r\n\r\n", (string) $mime_sections['returned_message_body_part']);
 			$head = self::standard_parser($temp[1]);
 			$head['From'] = self::extract_address($head['From']);
 			$head['To'] = self::extract_address($head['To']);
@@ -842,7 +842,7 @@ class BounceHandler
 
 			$from = '';
 
-			$from_stuff = preg_split('/[ \"\'\<\>:\(\)\[\]]/', $str);
+			$from_stuff = preg_split('/[ \"\'\<\>:\(\)\[\]]/', (string) $str);
 			foreach($from_stuff as $things)
 			{
 				if(strpos($things, '@') !== false)
@@ -886,7 +886,7 @@ class BounceHandler
 
 			if(!is_array($dsn_fields))
 			{
-				$dsn_fields = explode("\r\n\r\n", $dsn_fields);
+				$dsn_fields = explode("\r\n\r\n", (string) $dsn_fields);
 			}
 			$j = 0;
 			reset($dsn_fields);
@@ -899,7 +899,7 @@ class BounceHandler
 				{
 					$hash['mime_header'] = $dsn_fields[0];
 				}
-				elseif($i == 1 && !preg_match('/(Final|Original)-Recipient/', $dsn_fields[1]))
+				elseif($i == 1 && !preg_match('/(Final|Original)-Recipient/', (string) $dsn_fields[1]))
 				{
 					// some mta's don't output the per_message part, which means
 					// the second element in the array should really be
@@ -930,12 +930,12 @@ class BounceHandler
 
 			$ret = array();
 
-			if(preg_match('/([245]\.[01234567]\.[012345678])(.*)/', $code, $matches))
+			if(preg_match('/([245]\.[01234567]\.[012345678])(.*)/', (string) $code, $matches))
 			{
 				$ret['code'] = $matches[1];
 				$ret['text'] = $matches[2];
 			}
-			elseif(preg_match('/([245][01234567][012345678])(.*)/', $code, $matches))
+			elseif(preg_match('/([245][01234567][012345678])(.*)/', (string) $code, $matches))
 			{
 				preg_match_all("/./", $matches[1], $out);
 				$ret['code'] = $out[0];
@@ -1114,7 +1114,7 @@ class BounceHandler
 
 
 			$ret = self::format_status_code($code);
-			$arr = explode('.', $ret['code']);
+			$arr = explode('.', (string) $ret['code']);
 			$str = "<p><b>" . $status_code_classes[$arr[0]]['title'] . "</b> - " . $status_code_classes[$arr[0]]['descr'] . "  <B>" . $status_code_subclasses[$arr[1] . "." . $arr[2]]['title'] . "</B> - " . $status_code_subclasses[$arr[1] . "." . $arr[2]]['descr'] . "</p>";
 
 			return $str;
@@ -1157,11 +1157,11 @@ class BounceHandler
 		static function decode_diagnostic_code($dcode)
 		{
 
-			if(preg_match("/(\d\.\d\.\d)\s/", $dcode, $array))
+			if(preg_match("/(\d\.\d\.\d)\s/", (string) $dcode, $array))
 			{
 				return $array[1];
 			}
-			elseif(preg_match("/(\d\d\d)\s/", $dcode, $array))
+			elseif(preg_match("/(\d\d\d)\s/", (string) $dcode, $array))
 			{
 				return $array[1];
 			}
@@ -1176,17 +1176,17 @@ class BounceHandler
 		static function is_a_bounce($head_hash)
 		{
 
-			if(preg_match("/(mail delivery failed|failure notice|warning: message|delivery status notif|delivery failure|delivery problem|spam eater|returned mail|undeliverable|returned mail|delivery errors|mail status report|mail system error|failure delivery|delivery notification|delivery has failed|undelivered mail|returned email|returning message to sender|returned to sender|message delayed|mdaemon notification|mailserver notification|mail delivery system|nondeliverable mail|mail transaction failed)|auto.{0,20}reply|vacation|(out|away|on holiday).*office/i", $head_hash['Subject']))
+			if(preg_match("/(mail delivery failed|failure notice|warning: message|delivery status notif|delivery failure|delivery problem|spam eater|returned mail|undeliverable|returned mail|delivery errors|mail status report|mail system error|failure delivery|delivery notification|delivery has failed|undelivered mail|returned email|returning message to sender|returned to sender|message delayed|mdaemon notification|mailserver notification|mail delivery system|nondeliverable mail|mail transaction failed)|auto.{0,20}reply|vacation|(out|away|on holiday).*office/i", (string) $head_hash['Subject']))
 			{
 				return true;
 			}
 
-			if(preg_match('/auto_reply/', $head_hash['Precedence']))
+			if(preg_match('/auto_reply/', (string) $head_hash['Precedence']))
 			{
 				return true;
 			}
 
-			if(preg_match("/^(postmaster|mailer-daemon)\@?/i", $head_hash['From']))
+			if(preg_match("/^(postmaster|mailer-daemon)\@?/i", (string) $head_hash['From']))
 			{
 				return true;
 			}
@@ -1202,7 +1202,7 @@ class BounceHandler
 		{
 
 			// not finished yet.  This finds only one address.
-			if(preg_match("/\b([A-Z0-9._%-]+@[A-Z0-9.-]+\.[A-Z]{2,4})\b/i", $first_body_part, $matches))
+			if(preg_match("/\b([A-Z0-9._%-]+@[A-Z0-9.-]+\.[A-Z]{2,4})\b/i", (string) $first_body_part, $matches))
 			{
 				return array($matches[1]);
 			}

--- a/e107_handlers/cache_handler.php
+++ b/e107_handlers/cache_handler.php
@@ -76,7 +76,7 @@ class ecache {
 	 */
 	function cache_fname($CacheTag, $syscache = false)
 	{
-		if(strpos($CacheTag, "nomd5_") === 0) {
+		if(strpos((string) $CacheTag, "nomd5_") === 0) {
 			// Add 'nomd5' to indicate we are not calculating an md5
 			$CheckTag = '_nomd5';
 		}
@@ -84,7 +84,7 @@ class ecache {
 		{
 			if (defined("THEME"))
 			{
-				if (strpos($CacheTag, "nq_") === 0)
+				if (strpos((string) $CacheTag, "nq_") === 0)
 				{
 					// We do not care about e_QUERY, so don't use it in the md5 calculation
 					if (!$this->CachenqMD5)
@@ -115,7 +115,7 @@ class ecache {
 		{
 			$CheckTag = '';
 		}
-		$q = ($syscache ? "S_" : "C_").preg_replace("#\W#", "_", $CacheTag);
+		$q = ($syscache ? "S_" : "C_").preg_replace("#\W#", "_", (string) $CacheTag);
 		
 		if($syscache === true)
 		{

--- a/e107_handlers/chart_class.php
+++ b/e107_handlers/chart_class.php
@@ -175,12 +175,12 @@ class e_chart
 	function __construct()
 	{
 	//	e107::js('core','chart/Chart.min.js','jquery');	
-	
-	
-	
-		
-		
-	
+
+
+
+
+
+
 		// e107::css('inline','canvas.e-graph {  width: 100% !important;  max-width: 800px;  height: auto !important; 	}');	
 	}
 

--- a/e107_handlers/cli_class.php
+++ b/e107_handlers/cli_class.php
@@ -53,7 +53,7 @@ class eCLI
 		$_ARG = array();
 		foreach ($argv as $arg)
 		{
-			if (preg_match('#^-{1,2}([a-zA-Z0-9]*)=?(.*)$#', $arg, $matches))
+			if (preg_match('#^-{1,2}([a-zA-Z0-9]*)=?(.*)$#', (string) $arg, $matches))
 			{
 				$key = $matches[1];
 				switch ($matches[2])

--- a/e107_handlers/comment_class.php
+++ b/e107_handlers/comment_class.php
@@ -36,13 +36,13 @@ class comment
 	);
 
 	private $template;
-	
+
 	private $totalComments = 0;
-	
+
 	private $moderator = false;
-	
+
 	private $commentsPerPage = 5;
-	
+
 	private $table = null;
 
 	private $engine;
@@ -51,7 +51,7 @@ class comment
 
 	function __construct()
 	{
-		
+
 		if(getperms('B')) // moderator perms. 
 		{
 			$this->moderator = true;	
@@ -64,9 +64,9 @@ class comment
 
 		//TODO - add a pref for comments per page. 
 		// $this->commentsPerPage = pref; 
-				
+
 		global $COMMENTSTYLE;
-			
+
 		if (empty($COMMENTSTYLE) || !deftrue('THEME_LEGACY')) // v2.x
 		{		
 			//require(e107::coreTemplatePath('comment'));	 // using require_once() could cause an empty template if the template is already loaded, for example, by the comment-menu al
@@ -99,9 +99,9 @@ class comment
 				</table>
 				<br />";
 			*/	
-			
+
 			$COMMENT_TEMPLATE['ITEM'] 		= $COMMENTSTYLE;	
-			
+
 			$COMMENT_TEMPLATE['LAYOUT'] 	= "{COMMENTS}{COMMENTFORM}{MODERATE}{COMMENTNAV}";
 			$COMMENT_TEMPLATE['FORM']			= "<table style='width:100%'>
 													{SUBJECT_INPUT}
@@ -110,27 +110,27 @@ class comment
 													{COMMENT_INPUT}
 													{COMMENT_BUTTON}
 												</table>";
-			
+
 			$sc_style['SUBJECT_INPUT']['pre']		= "<tr><td style='width:20%'>".COMLAN_324."</td><td style='width:80%'>";
 			$sc_style['SUBJECT_INPUT']['post']		= "</td></tr>";
-			
+
 			$sc_style['AUTHOR_INPUT']['pre']		= "<tr><td style='width:20%; vertical-align:top;'>".COMLAN_16."</td><td style='width:80%'>";
 			$sc_style['AUTHOR_INPUT']['post']		= "</td></tr>";
-			
+
 			$sc_style['RATE_INPUT']['pre']			= "<tr><td style='width:20%; vertical-align:top;'>".LAN_RATING.":</td><td style='width:80%;'>";
 			$sc_style['RATE_INPUT']['post']			= "</td></tr>";
-			
+
 			$sc_style['COMMENT_INPUT']['pre']		= "<tr><td style='width:20%; vertical-align:top;'>".COMLAN_8.":</td><td id='commentform' style='width:80%;'>";
 			$sc_style['COMMENT_INPUT']['post']		= "</td></tr>";
-			
+
 			$sc_style['COMMENT_BUTTON']['pre']		= "<tr style='vertical-align:top'><td style='width:20%; vertical-align:top;'>&nbsp;</td><td id='commentformbutton' style='width:80%;'>";
 			$sc_style['COMMENT_BUTTON']['post']		= "</td></tr>";
-					
+
 		}	
-		
+
 		$this->template = array_change_key_case($COMMENT_TEMPLATE);
-		
-		
+
+
 	}
 
 
@@ -152,11 +152,11 @@ class comment
 			// [comment_id] =&gt; 65
 
 			return $this->form_comment('reply', $row['comment_type'], $row['comment_item_id'], $row['comment_subject'], false, true,false,false,$id);
-	
+
 		}			
 	}
-			
-		
+
+
 
 	/**
 	 * Display the comment editing form
@@ -189,8 +189,8 @@ class comment
 		}
 
 	// 	require_once(e_HANDLER."ren_help.php");
-	
-	
+
+
 		if ($this->getCommentPermissions() == 'rw')
 		{
 			$itemid = $id;
@@ -201,7 +201,7 @@ class comment
 			}
 			//FIXME - e_REQUEST_URI?
 			//e_SELF."?".e_QUERY
-			
+
 			if (vartrue($_GET['comment']) == 'edit')
 			{
 				$eaction = 'edit';
@@ -265,21 +265,21 @@ class comment
 					$rater = new rater;
 				}
 				$rate = $rater->composerating($table, $itemid, $enter = true, USERID, true);
-				
-			
+
+
 			} //end rating area
 			*/
-			
+
 			// -------------------------------------------------------------
-			
+
 			$indent = ($action == 'reply') ? " class='media offset-md-1 col-md-offset-1 offset1' " : " class='media' ";
 			$formid = ($action == 'reply') ? "e-comment-form-reply" : "e-comment-form";
-			
+
 			$text = "\n<div{$indent}>\n".e107::getMessage()->render('postcomment', true, false);//temporary here
-			
+
 		//	$text .= "Indent = ".$indent;
 			$text .= "<form id='{$formid}' method='post' action='".str_replace('http:', '', e_REQUEST_URI)."'  >";
-					
+
 			$data = array(
 				'action'	=> $action,
 				'subject' 	=> $subject,
@@ -295,27 +295,27 @@ class comment
 			$sc->setVars($data);
 			$sc->setMode('edit');
 			$sc->wrapper('comment/form');
-	
+
 			$text .= $tp->parseTemplate($this->template['form'], true, $sc);
-			
+
 			$text .= "\n<div>\n"; // All Hidden Elements. 
-			
+
 			$text .= (varset($action) == "reply" && $pid ? "<input type='hidden' name='pid' value='{$pid}' />" : '');
 			$text .=(isset($eaction) && $eaction == "edit" ? "<input type='hidden' name='editpid' value='{$id}' />" : "");
 			$text .=(isset($content_type) && $content_type ? "<input type='hidden' name='content_type' value='{$content_type}' />" : '');
 		//	$text .= (!$pref['nested_comments']) ? "<input type='hidden' name='subject' value='".$tp->toForm($subject)."'  />\n" : "";
-	
+
 			$text .= "
 			<input type='hidden' name='subject' value='".$tp->toForm($subject)."'  />
 			<input type='hidden' name='e-token' value='".defset('e_TOKEN')."' />
 			<input type='hidden' name='table' value='".$table."' />
 			<input type='hidden' name='itemid' value='".$itemid."' />
-			
+
 			</div>
 			</form>\n";
-			
+
 			$text .= "</div>";
-			
+
 			if ($tablerender)
 			{
 				$text = e107::getRender()->tablerender($caption, $text, '', true);
@@ -385,12 +385,12 @@ class comment
 			$this->totalComments = $this->totalComments - 1;
 			return true;
 		}
-		
+
 		return false;		
 	}
-		
-	
-	
+
+
+
 	/**
 	 * Render a single comment and any nested comments it may have. 
 	 *
@@ -418,19 +418,19 @@ class comment
 
 		//addrating	: boolean, to show rating system in rendered comment
 		global $sc_style, $gen;
-			
+
 		$tp 	= e107::getParser();
 		$sql 	= e107::getDb();
 		$pref 	= e107::getPref();
-		
+
 		if (!empty($pref['comments_disabled']))
 		{
 			return null;
 		}
-				
+
 		global $NEWIMAGE, $USERNAME, $RATING, $datestamp;
 		global $thisaction,$thistable,$thisid,$e107;
-				
+
 		$comrow 		= $row;			
 		$thistable 		= $table;
 		$thisid 		= $id;
@@ -447,30 +447,30 @@ class comment
 		{
 			define("IMAGE_new_comments", (file_exists(THEME."images/new_comments.png") ? "<img src='".THEME_ABS."images/new_comments.png' alt=''  /> " : "<img src='".e_IMAGE_ABS."generic/new_comments.png' alt=''  /> "));
 		}
-		
+
 //		$ns = new e107table;
-		
+
 		if (!$gen || !is_object($gen))
 		{
 			$gen = new convert;
 		}	
-		
+
 		$row['rating_enabled'] = true; // Toggles rating shortcode. //TODO add pref
 
 		$comment_shortcodes = e107::getScBatch('comment');
 		$comment_shortcodes->setVars($row);
 		$comment_shortcodes->wrapper('comment/item');
-		
-		
+
+
 		$COMMENT_TEMPLATE 					= $this->template; 
-		
+
 	//	$COMMENT_TEMPLATE['ITEM_START'] 	= "\n\n<div id='{COMMENT_ITEMID}' class='comment-box clearfix'>\n";
 	//	$COMMENT_TEMPLATE['ITEM_END']		= "\n</div><div class='clear_b'><!-- --></div>\n";
-		
+
 		//XXX Do NOT add to template - too important to allow for modification. 
 		$COMMENT_TEMPLATE['item_start'] 	= "\n\n<li id='{COMMENT_ITEMID}' class='media comment-box d-flex clearfix'>\n";
 		$COMMENT_TEMPLATE['item_end']		= "\n</li>\n";
-		
+
 		if(defset('BOOTSTRAP') === 2 || defset('BOOTSTRAP') === true) // Convert Bootstrap3 to Bootstrap 2 when detected. 
 		{
 			$COMMENT_TEMPLATE['item'] = str_replace("row", "row-fluid", $COMMENT_TEMPLATE['item']);
@@ -491,7 +491,7 @@ class comment
 			}
 			else
 			{
-					
+
 				$renderstyle = $COMMENT_TEMPLATE['item_start'].$COMMENT_TEMPLATE['item'].$COMMENT_TEMPLATE['item_end'];
 
 			}
@@ -516,13 +516,13 @@ class comment
 			$renderstyle = $COMMENT_TEMPLATE['item'];
 		}
 		$highlight_search = FALSE;
-		
-		
+
+
 		if (isset($_POST['highlight_search']))
 		{
 			$highlight_search = true;
 		}
-		
+
 		if (!defined("IMAGE_rank_main_admin_image"))
 		{
 			define("IMAGE_rank_main_admin_image", (isset($pref['rank_main_admin_image']) && $pref['rank_main_admin_image'] && file_exists(THEME."forum/".$pref['rank_main_admin_image']) ? "<img src='".THEME_ABS."forum/".$pref['rank_main_admin_image']."' alt='' />" : "<img src='".e_PLUGIN_ABS."forum/images/lite/main_admin.png' alt='' />"));
@@ -535,11 +535,11 @@ class comment
 		{
 			define("IMAGE_rank_admin_image", (isset($pref['rank_admin_image']) && $pref['rank_admin_image'] && file_exists(THEME."forum/".$pref['rank_admin_image']) ? "<img src='".THEME_ABS."forum/".$pref['rank_admin_image']."' alt='' />" : "<img src='".e_PLUGIN_ABS."forum/images/lite/admin.png' alt='' />"));
 		}
-		
-	//	$RATING = ($addrating == true && $comrow['user_id'] ? $rater->composerating($thistable, $thisid, FALSE, $comrow['user_id']) : "");
-		
 
-		
+	//	$RATING = ($addrating == true && $comrow['user_id'] ? $rater->composerating($thistable, $thisid, FALSE, $comrow['user_id']) : "");
+
+
+
 		$text = $tp->parseTemplate($renderstyle, true, $comment_shortcodes);
 
 		if ($action == "comment" && !empty($pref['nested_comments']))
@@ -558,7 +558,7 @@ class comment
 
 				$this->totalComments += count($nested);
 			}
-			
+
 
 		} // End (nested comment handling)
 
@@ -606,7 +606,7 @@ class comment
 		{
 			return;	
 		}
-		
+
 		return e107::getDb()->update("comments","comment_blocked=0 WHERE comment_id = ".intval($id)."");
 	}
 
@@ -629,9 +629,9 @@ class comment
 		{
 			$comment = $tp->toText($comment);
 		}
-		
+
 		$comment = trim($comment);
-		
+
 		if(!e107::getDb()->update("comments","comment_comment=\"".$tp->toDB($comment)."\" WHERE comment_id = ".(int) $id.' AND comment_author_id = '.(int) USERID))
 		{
 			return "Update Failed"; // trigger ajax error message. 
@@ -649,15 +649,15 @@ class comment
 		{
 			return (USER == true && ADMIN == false);
 		}
-		
+
 		return check_class($var);
 	}
-			
-		
-	
-	
-	
-	
+
+
+
+
+
+
 	/**
 	 * Add a comment to an item
 	 * e-token POST value should be always valid when using this method.
@@ -699,7 +699,7 @@ class comment
 		}
 
 
-		
+
 		global $e107,$rater;
 
 		$sql 		= e107::getDb();
@@ -749,7 +749,7 @@ class comment
 		$cuser_id = 0;
 		$cuser_name = 'Anonymous'; // Preset as an anonymous comment
 		$cuser_mail = '';
-		
+
 		if (!$sql->select("comments", "*", "comment_comment='".$comment."' AND comment_item_id='".intval($id)."' AND comment_type='".$tp->toDB($type, true)."' "))
 		{
 			if ($_POST['comment'])
@@ -898,8 +898,8 @@ class comment
 			{
 				return emessage;	
 			}
-			
-			
+
+
 			message_handler("ALERT", emessage);
 		}
 		return false;
@@ -1005,7 +1005,7 @@ class comment
 
 		if(isset($pref['comments_disabled']) && $pref['comments_disabled'] == true)
 		{
-			
+
         	return false;
 		}
 		if (isset($pref['comments_class']))
@@ -1059,7 +1059,7 @@ class comment
 		//rate				: boolean, to show/hide rating system in comment, default false
 		global  $totcc;
 
-		
+
 		$tp = e107::getParser();
 		$ns = e107::getRender();
 		$pref = e107::getPref();
@@ -1071,7 +1071,7 @@ class comment
 
 		if($this->engine != 'e107')
 		{
-			list($plugin,$method) = explode("::", $this->engine);
+			list($plugin,$method) = explode("::", (string) $this->engine);
 			$obj = e107::getAddon($plugin,'e_comment');
 			$text = e107::callMethod($obj, $method, $params);
 
@@ -1116,7 +1116,7 @@ class comment
 			'rate'		=> $rate
 		);
 		$text = $lock = $modcomment ='';
-		
+
 		if($action != 'reply')
 		{
 			$tmp = $this->getComments($table,$id,0,$options); // render all comments;
@@ -1125,17 +1125,17 @@ class comment
 			unset($tmp);
 		}
 		// -------------------------------------------------------
-		
+
 		if($text)
 		{
 			$modcomment = "<div class='comment-options'>";		
 			if($this->totalComments && getperms("B"))
 			{
-					
+
 				//	$modcomment .= "<a href='".e_ADMIN_ABS."modcomment.php?$table.$id'>".COMLAN_314."</a>";
 					$modcomment .= "<a class='btn btn-default btn-secondary btn-mini btn-sm' href='".e_ADMIN_ABS."comment.php?searchquery={$id}&filter_options=comment_type__".$this->getCommentType($table)."'>".COMLAN_314."</a>";
-					
-					
+
+
 			}
 
 			$from = 0;
@@ -1143,7 +1143,7 @@ class comment
 			$modcomment .= "</div>";
 		}	
 	// ---------------------------
-		
+
 		if ($lock != '1')
 		{
 			$comment = $this->form_comment($action, $table, $id, $subject, "", true, $rate, false); // tablerender turned off.
@@ -1183,7 +1183,7 @@ class comment
 		{		
 			if ($tablerender)
 			{
-					
+
 					echo $ns->tablerender("<span id='e-comment-total'>".$this->totalComments."</span> ".LAN_COMMENTS, $TEMPL, 'comment', true);
 			}
 			else
@@ -1203,7 +1203,7 @@ class comment
 			$comment = $ns->tablerender(COMLAN_9, $comment, 'comment', true );
 		}
 
-		
+
 
 		$ret = array();
 		$ret['comment'] = $text;
@@ -1244,21 +1244,21 @@ class comment
 		$sql 		= e107::getDb();
 		$tp 		= e107::getParser();
 		$pref 		= e107::getPref();
-		
+
 		$action 	= varset($att['action']);
 		$subject 	= varset($att['subject']);
 		$rate		= varset($att['rate']);
-			
+
 		$type = $this->getCommentType($table);
 		$sort = vartrue($pref['comments_sort'],'desc');
-		
+
 		if(!empty($pref['nested_comments']))
 		{
 			$query = "SELECT c.*, u.*, ue.*, r.* FROM #comments AS c
 			LEFT JOIN #user AS u ON c.comment_author_id = u.user_id
 			LEFT JOIN #user_extended AS ue ON c.comment_author_id = ue.user_extended_id 
 			LEFT JOIN #rate AS r ON c.comment_id = r.rate_itemid AND r.rate_table = 'comments' 
-			
+
 			WHERE c.comment_item_id='".intval($id)."' AND c.comment_type='".$tp->toDB($type, true)."' AND c.comment_pid='0' 
 			ORDER BY c.comment_datestamp ".$sort;
 		}
@@ -1271,11 +1271,11 @@ class comment
 			$query .= "WHERE c.comment_item_id='".intval($id)."' AND c.comment_type='".$tp->toDB($type, true)."' 		
 			ORDER BY c.comment_datestamp ".$sort;
 		}
-		
+
 		$this->totalComments = $sql->gen($query);
-			
+
 		$query .= " LIMIT ".$from.",".$this->commentsPerPage;
-		
+
 		$text 			= "";
 		$lock 			= '';
 
@@ -1287,25 +1287,25 @@ class comment
 			}
 
 		//	$text .= "<ul class='comments'>";
-						
+
 			$width = 0; 	
-			
+
 			foreach ($rows as $row)
 			{
-				
+
 				if($this->isPending($row))
 				{
 				 	continue;	
 				}					
-									
+
 				$lock = $row['comment_lock'];
 
 				$text .= $this->render_comment($row, $table, $action, $id, $width, $tp->toHTML($subject), $rate);
 
 			} // end loop
-			
+
 		//	$text .= "</ul>";
-			
+
 		} // end if
 
 		return array('comments'=> $text,'lock'=> $lock);		
@@ -1336,7 +1336,7 @@ class comment
 			return "<a class='e-ajax btn btn-default btn-secondary btn-mini btn-sm {$navid}' href='#' data-nav-id='{$navid}' data-nav-total='{$this->totalComments}' data-nav-dir='down' data-nav-inc='{$this->commentsPerPage}' data-target='{$target}' data-src='{$prev}'>" . LAN_PREVIOUS . "</a>
 			<a class='e-ajax btn btn-default btn-secondary btn-mini btn-sm {$navid}' href='#' data-nav-id='{$navid}' data-nav-total='{$this->totalComments}' data-nav-dir='up' data-nav-inc='{$this->commentsPerPage}' data-target='{$target}' data-src='{$next}'>" . LAN_NEXT . "</a>";
 		}
-		
+
 	}
 
 
@@ -1377,7 +1377,7 @@ class comment
 	function get_author_list($id, $comment_type)
 		{
 			$sql = e107::getDb();
-			
+
 			$authors = array();
 			$qry = "
 		SELECT DISTINCT(comment_author_id) AS author
@@ -1409,12 +1409,12 @@ class comment
 			$type 	= $this->getCommentType($table);
 			$type 	= $tp->toDB($type, true);
 			$id 	= intval($id);
-			
+
 			$author_list = $this->get_author_list($id, $type);
 			$num_deleted = $sql->delete("comments", "comment_item_id='{$id}' AND comment_type='{$type}'");
-			
+
 			$this->recalc_user_comments($author_list);
-			
+
 			return $num_deleted;
 		}
 
@@ -1478,7 +1478,7 @@ class comment
 						}
 					}
 				}
-				
+
 				e107::setRegistry('e_comment', $data);
 				return $data;
 			}
@@ -1559,7 +1559,7 @@ class comment
 					$comment_author_name = $row['comment_author_name'];
 					$ret['comment_author'] = (USERID ? "<a href='".e107::getUrl()->create('user/profile/view', array('id' => $comment_author_id, 'name' => $comment_author_name))."'>".$comment_author_name."</a>" : $comment_author_name);
 					//comment text
-					$comment = strip_tags(preg_replace("/\[.*?\]/", "", $row['comment_comment'])); // remove bbcode - but leave text in between
+					$comment = strip_tags((string) preg_replace("/\[.*?\]/", "", (string) $row['comment_comment'])); // remove bbcode - but leave text in between
 					$ret['comment_comment'] = $tp->toHTML($comment, false, "", "", $pref['main_wordwrap']);
 					//subject
 					$ret['comment_subject'] = $tp->toHTML($row['comment_subject'], true);
@@ -1715,7 +1715,7 @@ class comment
 					LEFT JOIN #user AS u ON c.comment_author_id = u.user_id
 					LEFT JOIN #user_extended AS ue ON c.comment_author_id = ue.user_extended_id 
 					LEFT JOIN #rate AS r ON c.comment_id = r.rate_itemid AND r.rate_table = 'comments' 
-					
+
 					WHERE c.comment_item_id='" . intval($id) . "' AND c.comment_type='" . $tp->toDB($type, true) . "' AND c.comment_pid > 0 
 					ORDER BY c.comment_datestamp " . $sort;
 

--- a/e107_handlers/core_functions.php
+++ b/e107_handlers/core_functions.php
@@ -271,7 +271,7 @@ function array_diff_recursive($array1, $array2)
  */
 function array_stripslashes($data)
 {
-	return is_array($data) ? array_map('array_stripslashes', $data) : stripslashes($data);
+	return is_array($data) ? array_map('array_stripslashes', $data) : stripslashes((string) $data);
 }
 
 /**
@@ -284,11 +284,11 @@ function echo_gzipped_page()
 	{
         $encoding = false;
     }
-	elseif( strpos($_SERVER["HTTP_ACCEPT_ENCODING"], 'x-gzip') !== false )
+	elseif( strpos((string) $_SERVER["HTTP_ACCEPT_ENCODING"], 'x-gzip') !== false )
 	{
         $encoding = 'x-gzip';
     }
-	elseif( strpos($_SERVER["HTTP_ACCEPT_ENCODING"],'gzip') !== false )
+	elseif( strpos((string) $_SERVER["HTTP_ACCEPT_ENCODING"],'gzip') !== false )
 	{
         $encoding = 'gzip';
     }
@@ -464,7 +464,7 @@ if (!function_exists('r_emote'))
 			$key = preg_replace("#_(\w{3})$#", ".\\1", $key);	// '_' followed by exactly 3 chars is file extension
 			$key = e_IMAGE_ABS."emotes/" . $pack . "/" .$key;		// Add in the file path
 	
-			$value2 = substr($value, 0, strpos($value, " "));
+			$value2 = substr((string) $value, 0, strpos((string) $value, " "));
 			$value = ($value2 ? $value2 : $value);
 			$value = ($value === '&|') ? ':((' : $value;
 			$value = " ".$value." ";
@@ -510,7 +510,7 @@ if (!function_exists('multiarray_sort'))
     {
         if(!is_array($array)) return $array;
 
-        $order = strtolower($order);
+        $order = strtolower((string) $order);
         foreach ($array as $i => $arr)
         {
            $sort_values[$i] = varset($arr[$key]);
@@ -615,7 +615,7 @@ class e_array {
 
 		// below is var_export() format using eval();
 
-        $ArrayData = trim($ArrayData);
+        $ArrayData = trim((string) $ArrayData);
 
         if(strpos($ArrayData, "\$data = ") === 0) // Fix for buggy old value.
 		{

--- a/e107_handlers/cron_class.php
+++ b/e107_handlers/cron_class.php
@@ -167,7 +167,7 @@ class _system_cron
 			error_log('e107: Cron running _system_cron::sendEmail(); ', E_USER_NOTICE);
 		}
 
-		
+
 	  //  require_once(e_HANDLER.'mail.php');
 		$message = "Your Cron test worked correctly. Sent on ".date("r").".";
 
@@ -337,7 +337,7 @@ class _system_cron
 		}
 		elseif(file_exists($file))
 		{
-			e107::getLog()->addSuccess(LAN_CRON_56." ".basename($file))->save('BACKUP');
+			e107::getLog()->addSuccess(LAN_CRON_56." ".basename((string) $file))->save('BACKUP');
 		}
 
 		return null;
@@ -484,9 +484,9 @@ class CronParser
 	{
 		$ret = [];
 
-		if (strpos($str, ",") !== false)
+		if (strpos((string) $str, ",") !== false)
 		{
-			$arParts = explode(',', $str);
+			$arParts = explode(',', (string) $str);
 			foreach ($arParts AS $part)
 			{
 				if (strpos($part, '-') !== false)
@@ -503,9 +503,9 @@ class CronParser
 				}
 			}
 		}
-		elseif (strpos($str, '-') !== false)
+		elseif (strpos((string) $str, '-') !== false)
 		{
-			$arRange = explode('-', $str);
+			$arRange = explode('-', (string) $str);
 			for ($i = $arRange[0]; $i <= $arRange[1]; $i++)
 			{
 				$ret[] = $i;
@@ -549,7 +549,7 @@ class CronParser
 		$this->minutes_arr = array();
 		$this->months_arr = array();
 
-		$string = preg_replace('/\s{2,}/', ' ', $string);
+		$string = preg_replace('/\s{2,}/', ' ', (string) $string);
 
 		if (preg_match('/[^-,* \\d]/', $string) !== 0)
 		{
@@ -679,7 +679,7 @@ class CronParser
 		}
 		else
 		{
-			$lastDue = $this->year.'-'.(strlen($this->month) === 1 ? '0'.$this->month : $this->month).'-'.(strlen($this->day) === 1 ? '0'.$this->day : $this->day).'T'.(strlen($this->hour) === 1 ? '0'.$this->hour : $this->hour) . ":" . (strlen($this->minute) === 1 ? '0'.$this->minute : $this->minute);
+			$lastDue = $this->year.'-'.(strlen((string) $this->month) === 1 ? '0'.$this->month : $this->month).'-'.(strlen((string) $this->day) === 1 ? '0'.$this->day : $this->day).'T'.(strlen((string) $this->hour) === 1 ? '0'.$this->hour : $this->hour) . ":" . (strlen($this->minute) === 1 ? '0'.$this->minute : $this->minute);
 			$this->debug(__METHOD__.' ('.__LINE__.'): '.date_default_timezone_get());
 			$this->debug(__METHOD__.' ('.__LINE__.'): Setting lastDue to ' . $lastDue);
 			$this->lastDue = $lastDue;
@@ -1306,7 +1306,7 @@ class cronScheduler
 		}
 		elseif(!empty($_SERVER['argv'][1]))
 		{
-			$pwd = trim($_SERVER['argv'][1]);
+			$pwd = trim((string) $_SERVER['argv'][1]);
 		}
 
 		if(!empty($_GET['token']))
@@ -1387,7 +1387,7 @@ class cronScheduler
 		{
 			while($row = $sql->fetch())
 			{
-				list($class, $function) = explode("::", $row['cron_function'], 2);
+				list($class, $function) = explode("::", (string) $row['cron_function'], 2);
 				$key = $class . "__" . $function;
 
 				$list[$key] = array(

--- a/e107_handlers/date_handler.php
+++ b/e107_handlers/date_handler.php
@@ -98,7 +98,7 @@ class e_date
 			return $marray;
 		}	
 		
-		if(strpos($type, 'day') === 0)
+		if(strpos((string) $type, 'day') === 0)
 		{
 			$days = array();
 			for ($i=2; $i < 9; $i++) 
@@ -250,20 +250,20 @@ class e_date
 			'%m'	=> 'mm',	// month number 2-digits
 			'%B'	=> 'MM', 	// Full month name, based on the locale
 			'%A'	=> 'DD', 	// A full textual representation of the day
-	
+
 			'%y'	=> 'yy',
 			'%a'	=> 'D', 	// An abbreviated textual representation of the day
 			'%b'	=> 'M', 	// Abbreviated month name, based on the locale
 			'%h'	=> 'M', 	// Abbreviated month name, based on the locale (an alias of %b)
 			'%I'	=> 'HH',	// Two digit representation of the hour in 12-hour format 
 			'%l'	=> 'H',		// 12 hour format - no leading zero
-			
+
 			'%H'	=> 'hh',	// 24 hour format - leading zero
 			'%M'	=> 'ii',	// Two digit representation of the minute 
 			'%S'	=> 'ss',	// Two digit representation of the second 
 			'%P'	=> 'p',		// %P	lower-case 'am' or 'pm' based on the given time
 			'%p'	=> 'P',	    // %p   UPPER-CASE 'AM' or 'PM' based on the given time
-		
+
 			'%T' 	=> 'hh:mm:ss',
 			'%r' 	=> "hh:mmm:ss TT" // 12 hour format
 		);
@@ -304,24 +304,24 @@ class e_date
 
 		$s = array_keys($convert);
 		$r = array_values($convert);	
-		
-		if(strpos($mask, '%') === false && $legacy === true)
+
+		if(strpos((string) $mask, '%') === false && $legacy === true)
 		{
 			$ret = str_replace($r, $s,$mask);
 			return str_replace('%%p', '%P', $ret); // quick fix.
 		}
-		elseif(strpos($mask,'%')!==false)
+		elseif(strpos((string) $mask,'%')!==false)
 		{
 			return str_replace($s,$r, $mask);
 
 		}
-		
+
 		return $mask; 
-		
+
 		// Keep this info here: 
 		/*
 				 * $options allowed keys:
-	
+
 		 * 
 		 *   d - day of month (no leading zero)
 		    dd - day of month (two digit)
@@ -340,7 +340,7 @@ class e_date
 		    '...' - literal text
 		    '' - single quote
 		    anything else - literal text 
-		
+
 		    ATOM - 'yy-mm-dd' (Same as RFC 3339/ISO 8601)
 		    COOKIE - 'D, dd M yy'
 		    ISO_8601 - 'yy-mm-dd'
@@ -365,7 +365,7 @@ class e_date
 		 * T    A or P for AM/PM
 		 * tt    am or pm for AM/PM
 		 * TT    AM or PM for AM/PM 
-			
+
 			*/
 	}
 
@@ -386,7 +386,7 @@ class e_date
 			case 'long':
 				$mask = e107::getPref('longdate');
 			break;
-			
+
 			case 'short':
 				$mask = e107::getPref('shortdate');
 			break;
@@ -395,12 +395,12 @@ class e_date
 			case 'inputdate': 
 				$mask = e107::getPref('inputdate', '%Y/%m/%d');
 			break;
-			
+
 			case 'inputdatetime': 
 				$mask = e107::getPref('inputdate', '%Y/%m/%d');
 				$mask .= " ".e107::getPref('inputtime', '%H:%M');
 			break;
-			
+
 			case 'inputtime': 
 				$mask = e107::getPref('inputtime', '%H:%M');
 			break;
@@ -424,8 +424,8 @@ class e_date
 
 		/*
 		$tdata = $this->strptime($date_string, $mask);
-		
-		
+
+
 		if(empty($tdata))
 		{
 			if(!empty($date_string) && ADMIN)
@@ -434,13 +434,13 @@ class e_date
 			}
 			return null;
 		}
-		
+
 		if(STRPTIME_COMPAT !== TRUE) // returns months from 0 - 11 on Unix so we need to +1 
 		{
 			$tdata['tm_mon'] = $tdata['tm_mon'] +1;	 
 		}
-				
-		
+
+
 		$unxTimestamp = mktime( 
 			$tdata['tm_hour'], 
 			$tdata['tm_min'], 
@@ -755,8 +755,8 @@ class e_date
 		  if (($i > 4) || ($result[$i] != 0))
 		  {  // Only show non-zero values, except always show minutes/seconds
 		    $outputArray[] = $result[$i]." ".($result[$i] == 1 ? $params[$i][2] : $params[$i][3]) ;
-			
-			
+
+
 		  }
 		  if($format == 'short' && count($outputArray) == 1) { break; }
 		}

--- a/e107_handlers/db_debug_class.php
+++ b/e107_handlers/db_debug_class.php
@@ -225,7 +225,7 @@ class e107_db_debug
 			$sql = e107::getDb($rli);
 
 			// Explain the query, if possible...
-			list($qtype, $args) = explode(" ", ltrim($query), 2);
+			list($qtype, $args) = explode(" ", ltrim((string) $query), 2);
 
 			unset($args);
 			$nFields = 0;
@@ -432,7 +432,7 @@ class e107_db_debug
 					$text .= $cQuery['explain'];
 				}
 
-				if(strlen($cQuery['error']))
+				if(strlen((string) $cQuery['error']))
 				{
 					$text .= "<tr><td  ><b>Error in query:</b></td></tr>\n<tr><td>" . $cQuery['error'] . "</td></tr>\n";
 				}
@@ -507,7 +507,7 @@ class e107_db_debug
 
 			foreach($this->aTimeMarks as $item)
 			{
-				$item['What'] = str_pad($item['What'], 50, " ", STR_PAD_RIGHT);
+				$item['What'] = str_pad((string) $item['What'], 50, " ", STR_PAD_RIGHT);
 				$text .= implode("\t\t\t", $item) . "\n";
 			}
 
@@ -913,7 +913,7 @@ class e107_db_debug
 
 			foreach($prefix as $c)
 			{
-				if(strpos($value, $c) === 0)
+				if(strpos((string) $value, $c) === 0)
 				{
 					return true;
 				}

--- a/e107_handlers/db_table_admin_class.php
+++ b/e107_handlers/db_table_admin_class.php
@@ -58,7 +58,7 @@ class db_table_admin
 			return FALSE;
 		}
 		$row = $sql->fetch('num');
-		$tmp = str_replace("`", "", stripslashes($row[1])).';'; // Add semicolon to work with our parser
+		$tmp = str_replace("`", "", stripslashes((string) $row[1])).';'; // Add semicolon to work with our parser
 		$count = preg_match_all("#CREATE\s+?TABLE\s+?`?({$prefix}{$table_name})`?\s+?\((.*?)\)\s+?(?:TYPE|ENGINE)\s*\=\s*(.*?);#is", $tmp, $matches, PREG_SET_ORDER);
 		if ($count === FALSE)
 		{
@@ -109,7 +109,7 @@ class db_table_admin
 				// Strip any php header
 				$temp = preg_replace("#\<\?php.*?\?\>#mis", '', $temp);
 				// Strip any comments  (only /*...*/ supported
-				$this->file_buffer = preg_replace("#\/\*.*?\*\/#mis", '', $temp);
+				$this->file_buffer = preg_replace("#\/\*.*?\*\/#mis", '', (string) $temp);
 				$this->last_file = $file_name;
 			}
 		}
@@ -118,7 +118,7 @@ class db_table_admin
 			$table_name = '\w+?';
 		}
 		// Regex should be identical to that in get_current_table (apart from the source text variable name)
-		$count = preg_match_all("#CREATE\s+?TABLE\s+?`?({$table_name})`?\s+?\((.*?)\)\s+?(?:TYPE|ENGINE)\s*\=\s*(.*?);#is", $this->file_buffer, $matches, PREG_SET_ORDER);
+		$count = preg_match_all("#CREATE\s+?TABLE\s+?`?({$table_name})`?\s+?\((.*?)\)\s+?(?:TYPE|ENGINE)\s*\=\s*(.*?);#is", (string) $this->file_buffer, $matches, PREG_SET_ORDER);
 		if ($count === false)
 		{
 			return "Error occurred";
@@ -364,7 +364,7 @@ class db_table_admin
 				elseif ($list1[$i]['type'] == $list2[0]['type'])
 				{ // Worth doing a compare - fields are same type
 					//		echo $i.': compare - '.$list1[$i]['name'].', '.$list2[0]['name'].'<br />';
-					if (strcasecmp($list1[$i]['name'], $list2[0]['name']) != 0)
+					if (strcasecmp((string) $list1[$i]['name'], (string) $list2[0]['name']) != 0)
 					{ // Names differ, so need to add or subtract a field.
 						//		  echo $i.': names differ - '.$list1[$i]['name'].', '.$list2[0]['name'].'<br />';
 						if ($stop_on_error)
@@ -375,7 +375,7 @@ class db_table_admin
 						for ($k = $i + 1, $kMax = count($list1); $k < $kMax; $k++)
 						{
 							//		    echo "Compare ".$list1[$k]['name'].' with '.$list2[0]['name'];
-							if (strcasecmp($list1[$k]['name'], $list2[0]['name']) == 0)
+							if (strcasecmp((string) $list1[$k]['name'], (string) $list2[0]['name']) == 0)
 							{ // Field in list2 found later in list1; do nothing
 								//			  echo " - match<br />";
 								$found = TRUE;
@@ -383,7 +383,7 @@ class db_table_admin
 							}
 							//			echo " - no match<br />";
 						}
-						
+
 						if (!$found)
 						{ // Field in existing DB no longer required
 							$error_list[] = 'Obsolete field: '.$list2[0]['name'];
@@ -391,12 +391,12 @@ class db_table_admin
 							array_shift($list2);
 							continue;
 						}
-						
+
 						$found = FALSE;
 						for ($k = 0, $kMax = count($list2); $k < $kMax; $k++)
 						{
 							//		    echo "Compare ".$list1[$i]['name'].' with '.$list2[$k]['name'];
-							if (strcasecmp($list1[$i]['name'], $list2[$k]['name']) == 0)
+							if (strcasecmp((string) $list1[$i]['name'], (string) $list2[$k]['name']) == 0)
 							{ // Field found; we need to move it up
 								//			  echo " - match<br />";
 								$found = TRUE;
@@ -427,7 +427,7 @@ class db_table_admin
 									$created_list[$j] = $list1[$i]['name'];
 									$j++;
 								break;
-								
+
 								case 'field':
 									$change_list[] = 'ADD '.$this->make_def($list1[$i]).(count($created_list) ? ' AFTER '.$created_list[count($created_list) - 1] : ' FIRST');
 									$error_list[] = 'Missing field: '.$list1[$i]['name'].' (found: '.$list2[0]['type'].' '.$list2[0]['name'].')';
@@ -444,15 +444,15 @@ class db_table_admin
 						foreach ($list1[$i] as $fi=>$v)
 						{
 							$t = $list2[0][$fi];
-							if (stripos($v, 'varchar') !== FALSE)
+							if (stripos((string) $v, 'varchar') !== FALSE)
 							{
-								$v = substr($v, 3);
+								$v = substr((string) $v, 3);
 							} // Treat char, varchar the same
-							if (stripos($t, 'varchar') !== FALSE)
+							if (stripos((string) $t, 'varchar') !== FALSE)
 							{
-								$t = substr($t, 3);
+								$t = substr((string) $t, 3);
 							} // Treat char, varchar the same
-							if (strcasecmp($t, $v) !== 0)
+							if (strcasecmp((string) $t, (string) $v) !== 0)
 							{
 								if ($stop_on_error)
 								{
@@ -495,18 +495,18 @@ class db_table_admin
 								$j++;
 							}
 						break;
-						
+
 						case 'field': // Require a field - got a key. so add a field at the end
 							$error_list[] = 'Missing field: '.$list1[$i]['name'].' (found: '.$list2[0]['type'].' '.$list2[0]['name'].')';
 							$change_list[] = 'ADD '.$this->make_def($list1[$i]);
 						break;
-						
+
 						default:
 							$error_list[] = 'Unknown field type: '.$list1[$i]['type'];
 							$change_list[] = ''; // Null entry to keep them in step
 					}
 				} // End - missing or extra field
-				
+
 				$i++; // On to next field
 			}
 			if (count($list2))
@@ -698,7 +698,7 @@ class db_table_admin
 				{
 					echo 'Actual table structure: <br />'.$this->make_field_list($actualFields);
 				}
-				
+
 				$diffs = $this->compare_field_lists($reqFields, $actualFields); // Work out any differences
 				if (count($diffs[0]))
 				{ // Changes needed
@@ -753,7 +753,7 @@ class db_table_admin
 			}
 			if ($newTableName != $tableName)
 			{
-				$createText = preg_replace('#create +table +(\w*?) +#i', 'CREATE TABLE '.$newTableName.' ', $createText);
+				$createText = preg_replace('#create +table +(\w*?) +#i', 'CREATE TABLE '.$newTableName.' ', (string) $createText);
 			}
 			return e107::getDb()->gen($createText);
 		}
@@ -778,7 +778,7 @@ class db_table_admin
 							//break;		Probably include autoinc fields in array
 					//	}
 
-						$baseType = preg_replace('#\(.*?\)#', '', $v['fieldtype']);		// Should strip any length
+						$baseType = preg_replace('#\(.*?\)#', '', (string) $v['fieldtype']);		// Should strip any length
 
 						switch ($baseType)
 						{

--- a/e107_handlers/db_verify_class.php
+++ b/e107_handlers/db_verify_class.php
@@ -161,8 +161,8 @@ class db_verify
 		// Permit actual text types that default to null even when
 		// expected does not explicitly default to null
 		if(
-			0 === strcasecmp($expected['type'], $actual['type']) &&
-			1 === preg_match('/[A-Z]*TEXT/i', $expected['type']) &&
+			0 === strcasecmp((string) $expected['type'], (string) $actual['type']) &&
+			1 === preg_match('/[A-Z]*TEXT/i', (string) $expected['type']) &&
 			0 === strcasecmp($actual['default'], "DEFAULT NULL")
 		)
 		{
@@ -170,9 +170,9 @@ class db_verify
 		}
 
 		// Loosely typed default value for numeric types
-		if(1 === preg_match('/([A-Z]*INT|NUMERIC|DEC|FIXED|FLOAT|REAL|DOUBLE)/i', $expected['type']))
+		if(1 === preg_match('/([A-Z]*INT|NUMERIC|DEC|FIXED|FLOAT|REAL|DOUBLE)/i', (string) $expected['type']))
 		{
-			$expected['default'] = preg_replace("/DEFAULT '(\d*\.?\d*)'/i", 'DEFAULT $1', $expected['default']);
+			$expected['default'] = preg_replace("/DEFAULT '(\d*\.?\d*)'/i", 'DEFAULT $1', (string) $expected['default']);
 			$actual['default'] = preg_replace("/DEFAULT '(\d*\.?\d*)'/i", 'DEFAULT $1', $actual['default']);
 		}
 
@@ -181,17 +181,17 @@ class db_verify
 		 *
 		 * @see https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-19.html
 		 */
-		if(1 === preg_match('/([A-Z]*INT)/i', $expected['type']))
+		if(1 === preg_match('/([A-Z]*INT)/i', (string) $expected['type']))
 		{
 			$expected['value'] = '';
 			$actual['value'] = '';
 		}
 
 		// Correct difference on CREATE TABLE statement between MariaDB and MySQL
-		if(1 === preg_match('/(DATE|DATETIME|TIMESTAMP|TIME|YEAR)/i', $expected['default']))
+		if(1 === preg_match('/(DATE|DATETIME|TIMESTAMP|TIME|YEAR)/i', (string) $expected['default']))
 		{
-			$expected['default'] = preg_replace("/CURRENT_TIMESTAMP\(\)/i", 'CURRENT_TIMESTAMP', $expected['default']);
-			$actual['default'] = preg_replace("/CURRENT_TIMESTAMP\(\)/i", 'CURRENT_TIMESTAMP', $actual['default']);
+			$expected['default'] = preg_replace("/CURRENT_TIMESTAMP\(\)/i", 'CURRENT_TIMESTAMP', (string) $expected['default']);
+			$actual['default'] = preg_replace("/CURRENT_TIMESTAMP\(\)/i", 'CURRENT_TIMESTAMP', (string) $actual['default']);
 		}
 
 		return array_diff_assoc($expected, $actual);
@@ -784,7 +784,7 @@ class db_verify
 
 		$text .= "
 			</div>
-			
+
 			</fieldset>
 			</form>
 		";
@@ -892,7 +892,7 @@ class db_verify
 
 		}
 
-		if(!in_array(strtolower($data['type']), $this->fieldTypes))
+		if(!in_array(strtolower((string) $data['type']), $this->fieldTypes))
 		{
 			$ret = $data['type'] . "(" . $data['value'] . ") " . $data['attributes'] . " " . $data['null'] . " " . $data['default'];
 
@@ -939,9 +939,9 @@ class db_verify
 
 		$key = array_flip($tabl);
 
-		if(strpos($cur, "lan_") === 0) // language table adjustment.
+		if(strpos((string) $cur, "lan_") === 0) // language table adjustment.
 		{
-			list($tmp, $lang, $cur) = explode("_", $cur, 3);
+			list($tmp, $lang, $cur) = explode("_", (string) $cur, 3);
 		}
 
 		if(isset($key[$cur]))
@@ -1123,7 +1123,7 @@ class db_verify
 
 		$ret = array();
 
-		$sql_data = preg_replace("#\/\*.*?\*\/#mis", '', $sql_data);    // remove comments
+		$sql_data = preg_replace("#\/\*.*?\*\/#mis", '', (string) $sql_data);    // remove comments
 
 		//	$regex = "/CREATE TABLE (?:IF NOT EXISTS )?`?([\w]*)`?\s*?\(([^;]*)\)\s*((?:[\w\s]+=[^\s]+)+\s*)*;/i";
 		// 	$regex = "/CREATE TABLE (?:IF NOT EXISTS )?`?(\w*)`?\s*?\(([^;]*)\)\s*((?:[\w\s]+=\S+)+\s*)*;/i";
@@ -1219,7 +1219,7 @@ class db_verify
 	{
 
 		// Clean $data and add ` ` arond field-names - prevents issues when field == field-type. 
-		$tmp = explode("\n", $data);
+		$tmp = explode("\n", (string) $data);
 		$newline = array();
 
 		foreach($tmp as $line)
@@ -1381,7 +1381,7 @@ class db_verify
 
 			//return $row[1];
 
-			return stripslashes($row[1]) . ';'; // backticks needed.
+			return stripslashes((string) $row[1]) . ';'; // backticks needed.
 			// return str_replace("`", "", stripslashes($row[1])).';';
 		}
 		else
@@ -1407,7 +1407,7 @@ class db_verify
 
 		foreach($list as $tb)
 		{
-			list($tmp, $lang, $table) = explode("_", $tb, 3);
+			list($tmp, $lang, $table) = explode("_", (string) $tb, 3);
 			$array[$lang][] = $table;
 		}
 
@@ -1777,7 +1777,7 @@ function check_tables($what)
 					$xl = preg_replace('/\r?\n$|\r[^\n]$/', '', $xl);
 					$xl = str_replace('  ',' ',$xl);				// Remove double spaces
 					list($xfname, $xfparams) = explode(" ", $xl, 2);	// Field name and the rest
-					
+
 					if ($xfname == 'UNIQUE' || $xfname == 'FULLTEXT')
 					{
 						list($key, $key1, $keyname, $keyparms) = explode(" ", $xl, 4);
@@ -1790,7 +1790,7 @@ function check_tables($what)
 						$xfname = $key." ".$keyname;
 						$xfparams = $keyparms;
 					}
-					
+
 					if ($xfname != "CREATE" && $xfname != ")")
 					{
 						$xfields[$xfname] = 1;
@@ -1862,8 +1862,8 @@ function check_tables($what)
 
 							";
 						}
-						
-						
+
+
 						// DISABLED for now (show only errors), could be page setting
 						// else
 						// {
@@ -1919,8 +1919,8 @@ function check_tables($what)
 					";
 				}
 			}
-			
-			
+
+
 		}
 		else
 		{	// Table Missing.
@@ -1937,7 +1937,7 @@ function check_tables($what)
 			$fix_active = TRUE;
 			$xfield_errors++;
 		}
-		
+
 		if(!$xfield_errors)
 		{
 			//no errors, so no table rows yet
@@ -1947,13 +1947,13 @@ function check_tables($what)
 					</tr>
 			";
 		}
-	
+
 		$ttext .= "
 					</tbody>
 				</table>
 				<br/>
 		";
-		
+
 		//FIXME - add 'show_if_ok' switch
 		if($xfield_errors || (!$xfield_errors && varsettrue($_GET['show_if_ok'])))
 		{
@@ -1961,12 +1961,12 @@ function check_tables($what)
 			$ttcount++;
 		}
 	}
-	
+
 	if(!$fix_active)
 	{
 		//Everything should be OK
 		$emessage->add('DB successfully verified - no problems were found.', E_MESSAGE_SUCCESS);
-		
+
 		if(!$ttcount)
 		{
 			//very tired and sick of this page, so quick and dirty
@@ -1977,7 +1977,7 @@ function check_tables($what)
 			";
 		}
 	}
-	
+
 	if($fix_active)
 	{
 		$text .= "
@@ -1988,7 +1988,7 @@ function check_tables($what)
 			</div>
 		";
 	}
-	
+
 	foreach(array_keys($_POST) as $j) 
 	{
 		$match = array();
@@ -2038,7 +2038,7 @@ if(isset($_POST['do_fix']))
 
 
 		$field= $key;
-		
+
 		switch($mode)
 		{
 			case 'alter':
@@ -2049,23 +2049,23 @@ if(isset($_POST['do_fix']))
 				if($after) $after = " AFTER {$after}";
 				$query = "ALTER TABLE `".MPREFIX.$table."` ADD `$field` $newval{$after}";
 			break;
-			
+
 			case 'drop':
 				$query = "ALTER TABLE `".MPREFIX.$table."` DROP `$field` ";
 			break;
-			
+
 			case 'index':
 				$query = "ALTER TABLE `".MPREFIX.$table."` ADD INDEX `$field` ($newval)";
 			break;
-			
+
 			case 'indexalt':
 				$query = "ALTER TABLE `".MPREFIX.$table."` ADD $field ($newval)";
 			break;
-			
+
 			case 'indexdrop':
 				$query = "ALTER TABLE `".MPREFIX.$table."` DROP INDEX `$field`";
 			break;
-			
+
 			case 'create':
 			$query = "CREATE TABLE `".MPREFIX.$table."` ({$newval}";
 			if (!preg_match('#.*?\s+?(?:TYPE|ENGINE)\s*\=\s*(.*?);#is', $newval))
@@ -2137,7 +2137,7 @@ exit;
 function fix_form($table,$field, $newvalue,$mode,$after ='')
 {
 	global $frm;
-	
+
 	if($mode == 'create')
 	{
 		$newvalue = implode("\n",$newvalue);
@@ -2153,7 +2153,7 @@ function fix_form($table,$field, $newvalue,$mode,$after ='')
 			$newvalue = str_replace($search,'',$newvalue);
 			$after = '';
 		}
-		
+
 		if($mode == 'index' && (stristr($field, 'FULLTEXT ') !== FALSE || stristr($field, 'UNIQUE ') !== FALSE))
 		{
 			$mode = 'indexalt';
@@ -2194,9 +2194,9 @@ function table_list()
 	$exclude[] = "user_extended_struct";
 	$exclude[] = "pm_messages";
 	$exclude[] = "pm_blocks";
-	
+
 	$replace = array();
-	
+
 	$lanlist = explode(",",e_LANLIST);
 	foreach($lanlist as $lang)
 	{

--- a/e107_handlers/debug_handler.php
+++ b/e107_handlers/debug_handler.php
@@ -118,7 +118,7 @@ class e107_debug {
 
 		$keys = array_flip($a);
 
-		list($tmp,$level) = explode('=',$_COOKIE['e107_debug_level']);
+		list($tmp,$level) = explode('=',(string) $_COOKIE['e107_debug_level']);
 
 		$level = (int) $level;
 
@@ -156,7 +156,7 @@ class e107_debug {
             if (!isset($debug_param[1]) || ($debug_param[1] == '')) $debug_param[1] = '=';
             if (isset($_COOKIE['e107_debug_level']))
             {
-                $dVals = substr($_COOKIE['e107_debug_level'], 6);
+                $dVals = substr((string) $_COOKIE['e107_debug_level'], 6);
             }
 
             if (preg_match('/debug(=?)(.*?),?(!|\+|stick|-|unstick|$)/', e_MENU))

--- a/e107_handlers/e107_class.php
+++ b/e107_handlers/e107_class.php
@@ -385,7 +385,7 @@ class e107
 				if($bodyTag)
 				{
 					echo "\n<!-- Start custom body-start tag -->\n";
-					echo trim($opts['bodyStart'])."\n";
+					echo trim((string) $opts['bodyStart'])."\n";
 					echo "<!-- End custom body-start tag -->\n\n";
 				}
 
@@ -484,7 +484,7 @@ class e107
 			}
 		}
 
-		$location = trim($location);
+		$location = trim((string) $location);
 
 
 		// Defaults to news
@@ -543,7 +543,7 @@ class e107
 		{
 			foreach($e107_paths as $dir => $path)
 			{
-				$newKey = strtoupper($dir).'_DIRECTORY';
+				$newKey = strtoupper((string) $dir).'_DIRECTORY';
 				$e107_paths[$newKey] = $path;
 				unset($e107_paths[$dir]);
 			}
@@ -716,19 +716,19 @@ class e107
 	//	$this->e107_dirs['SYSTEM_BASE_DIRECTORY'] = $this->e107_dirs['SYSTEM_BASE_DIRECTORY'];
 
 		// $this->site_path is appended to MEDIA_DIRECTORY in defaultDirs(), which is called above.
-		if(strpos($this->e107_dirs['MEDIA_DIRECTORY'],$this->site_path) === false)
+		if(strpos((string) $this->e107_dirs['MEDIA_DIRECTORY'],(string) $this->site_path) === false)
 		{
 			$this->e107_dirs['MEDIA_DIRECTORY'] .= $this->site_path."/"; // multisite support.
 		}
 
 		// FIXME - remove this condition because:
 		// $this->site_path is appended to SYSTEM_DIRECTORY in defaultDirs(), which is called above.
-		if(strpos($this->e107_dirs['SYSTEM_DIRECTORY'],$this->site_path) === false)
+		if(strpos((string) $this->e107_dirs['SYSTEM_DIRECTORY'],(string) $this->site_path) === false)
 		{
 			$this->e107_dirs['SYSTEM_DIRECTORY'] .= $this->site_path."/"; // multisite support.
 		}
 
-		if(strpos($this->e107_dirs['CACHE_DIRECTORY'], $this->site_path) === false)
+		if(strpos((string) $this->e107_dirs['CACHE_DIRECTORY'], (string) $this->site_path) === false)
 		{
 			$this->e107_dirs['CACHE_DIRECTORY'] = $this->e107_dirs['SYSTEM_DIRECTORY']."cache/"; // multisite support.
 		}
@@ -1387,7 +1387,7 @@ class e107
 	 */
 	public static function getPlugLan($dir, $type='name')
 	{
-		$lan = "LAN_PLUGIN_".strtoupper($dir)."_".strtoupper($type);
+		$lan = "LAN_PLUGIN_".strtoupper((string) $dir)."_".strtoupper($type);
 
 		return defset($lan,false);
 	}
@@ -1530,7 +1530,7 @@ class e107
 			foreach($custom as $glyphConfig)
 			{
 
-				if(strpos($glyphConfig['path'], 'http') !== 0)
+				if(strpos((string) $glyphConfig['path'], 'http') !== 0)
 				{
 					$glyphConfig['path'] = e_THEME."$theme/".$glyphConfig['path'];
 				}
@@ -2391,7 +2391,7 @@ class e107
 				$admin = (bool) defset('e_ADMIN_AREA', false);
 
 				// Try to detect and load CDN version.
-				if(!$admin && $cdn && strpos($library, 'cdn.') !== 0)
+				if(!$admin && $cdn && strpos((string) $library, 'cdn.') !== 0)
 				{
 					$lib = $libraryHandler->detect('cdn.' . $library);
 
@@ -2801,22 +2801,22 @@ class e107
 	        {
 	            $object = json_encode($var);
 
-	           $text .= 'var object'.preg_replace('~[^A-Z|0-9]~i',"_",$name).' = \''.str_replace("'","\'",$object).'\';'.$nl;
-	           $text .= 'var val'.preg_replace('~[^A-Z|0-9]~i',"_",$name).' = eval("(" + object'.preg_replace('~[^A-Z|0-9]~i',"_",$name).' + ")" );'.$nl;
+	           $text .= 'var object'.preg_replace('~[^A-Z|0-9]~i',"_",(string) $name).' = \''.str_replace("'","\'",$object).'\';'.$nl;
+	           $text .= 'var val'.preg_replace('~[^A-Z|0-9]~i',"_",(string) $name).' = eval("(" + object'.preg_replace('~[^A-Z|0-9]~i',"_",(string) $name).' + ")" );'.$nl;
 
 	            switch($type)
 	            {
 	                case 'log':
-	                   $text .= 'console.debug(val'.preg_replace('~[^A-Z|0-9]~i',"_",$name).');'.$nl;
+	                   $text .= 'console.debug(val'.preg_replace('~[^A-Z|0-9]~i',"_",(string) $name).');'.$nl;
 	                break;
 	                case 'info':
-	                   $text .= 'console.info(val'.preg_replace('~[^A-Z|0-9]~i',"_",$name).');'.$nl;
+	                   $text .= 'console.info(val'.preg_replace('~[^A-Z|0-9]~i',"_",(string) $name).');'.$nl;
 	                break;
 	                case 'warning':
-	                   $text .= 'console.warn(val'.preg_replace('~[^A-Z|0-9]~i',"_",$name).');'.$nl;
+	                   $text .= 'console.warn(val'.preg_replace('~[^A-Z|0-9]~i',"_",(string) $name).');'.$nl;
 	                break;
 	                case 'error':
-	                   $text .= 'console.error(val'.preg_replace('~[^A-Z|0-9]~i',"_",$name).');'.$nl;
+	                   $text .= 'console.error(val'.preg_replace('~[^A-Z|0-9]~i',"_",(string) $name).');'.$nl;
 	                break;
 	            }
 	        }
@@ -3621,7 +3621,7 @@ class e107
 				$match = false;
 				foreach ($filter_mask as $mask)
 				{
-					if(preg_match($mask, $key)) //e.g. retrieve only keys starting with 'layout_'
+					if(preg_match($mask, (string) $key)) //e.g. retrieve only keys starting with 'layout_'
 					{
 						$match = true;
 						break;
@@ -3637,7 +3637,7 @@ class e107
 				$templates[$key] = defset($tmp_info[$key]['title'], $tmp_info[$key]['title']);
 				continue;
 			}
-			$templates[$key] = implode(' ', array_map('ucfirst', explode('_', $key)));
+			$templates[$key] = implode(' ', array_map('ucfirst', explode('_', (string) $key)));
 		}
 		return ($allinfo ? array($templates, $tmp_info) : $templates);
 	}
@@ -4429,7 +4429,7 @@ class e107
 		}
 
 
-		preg_match_all('#{([a-z_]*)}#', $tmp[$plugin][$key]['sef'], $matches);
+		preg_match_all('#{([a-z_]*)}#', (string) $tmp[$plugin][$key]['sef'], $matches);
 
 		$active = true;
 
@@ -4458,7 +4458,7 @@ class e107
 
 			if ($options['mode'] === 'full')
 			{
-				$siteURL = !empty($tmp[$plugin][$key]['domain']) ? 'https://'.rtrim($tmp[$plugin][$key]['domain'],'/').'/' : SITEURL;
+				$siteURL = !empty($tmp[$plugin][$key]['domain']) ? 'https://'.rtrim((string) $tmp[$plugin][$key]['domain'],'/').'/' : SITEURL;
 				$sefUrl = $siteURL . $rawUrl;
 			}
 			elseif ($options['mode'] === 'raw')
@@ -4493,7 +4493,7 @@ class e107
 
 			// Avoid duplicate query keys. eg. URL has ?id=x and $options['query']['id'] exists.
 			// @see forum/e_url.php - topic/redirect and forum/view_shortcodes.php sc_post_url()
-			list($legacyUrl, $tmp) = array_pad(explode("?", $legacyUrl), 2, null);
+			list($legacyUrl, $tmp) = array_pad(explode("?", (string) $legacyUrl), 2, null);
 
 			if (!empty($tmp))
 			{
@@ -4525,7 +4525,7 @@ class e107
 		// Append the query.
 		if (is_array($options['query']) && !empty($options['query']))
 		{
-			$sefUrl .= (strpos($sefUrl, '?') !== FALSE ? '&' : '?') . self::httpBuildQuery($options['query']);
+			$sefUrl .= (strpos((string) $sefUrl, '?') !== FALSE ? '&' : '?') . self::httpBuildQuery($options['query']);
 		}
 
 		return htmlspecialchars($sefUrl . $options['fragment'], ENT_QUOTES);
@@ -4635,7 +4635,7 @@ class e107
 
 		foreach($query as $key => $value)
 		{
-			$key = ($parent ? $parent . '[' . rawurlencode($key) . ']' : rawurlencode($key));
+			$key = ($parent ? $parent . '[' . rawurlencode((string) $key) . ']' : rawurlencode((string) $key));
 
 			// Recurse into children.
 			if(is_array($value))
@@ -4650,7 +4650,7 @@ class e107
 			else
 			{
 				// For better readability of paths in query strings, we decode slashes.
-				$params [] = $key . '=' . str_replace('%2F', '/', rawurlencode($value));
+				$params [] = $key . '=' . str_replace('%2F', '/', rawurlencode((string) $value));
 			}
 		}
 
@@ -4853,7 +4853,7 @@ class e107
 		}
 
 		// A better way to detect an AJAX request. No need for "ajax_used=1";
-		if(!empty($_SERVER['HTTP_X_REQUESTED_WITH']) && strtolower($_SERVER['HTTP_X_REQUESTED_WITH']) === 'xmlhttprequest')
+		if(!empty($_SERVER['HTTP_X_REQUESTED_WITH']) && strtolower((string) $_SERVER['HTTP_X_REQUESTED_WITH']) === 'xmlhttprequest')
 		{
   			define('e_AJAX_REQUEST', true);
 		}
@@ -4902,7 +4902,7 @@ class e107
 
 
 		// If url contains a .php in it, PHP_SELF is set wrong (imho), affecting all paths.  We need to 'fix' it if it does.
-		$_SERVER['PHP_SELF'] = (($pos = stripos($_SERVER['PHP_SELF'], '.php')) !== false ? substr($_SERVER['PHP_SELF'], 0, $pos+4) : $_SERVER['PHP_SELF']);
+		$_SERVER['PHP_SELF'] = (($pos = stripos((string) $_SERVER['PHP_SELF'], '.php')) !== false ? substr((string) $_SERVER['PHP_SELF'], 0, $pos+4) : $_SERVER['PHP_SELF']);
 		$_SERVER['SERVER_NAME'] = $_SERVER['SERVER_NAME'] ?? '';
 		$_SERVER['HTTP_HOST'] = $_SERVER['HTTP_HOST'] ?? '';
 		$_SERVER['HTTP_HOST'] = !empty($_SERVER['SERVER_NAME']) ? $_SERVER['SERVER_NAME'] : $_SERVER['HTTP_HOST'];
@@ -4963,32 +4963,32 @@ class e107
 			}
 
 			$regex = "/(base64_decode|chr|php_uname|fwrite|fopen|fputs|passthru|popen|proc_open|shell_exec|exec|proc_nice|proc_terminate|proc_get_status|proc_close|pfsockopen|apache_child_terminate|posix_kill|posix_mkfifo|posix_setpgid|posix_setsid|posix_setuid|phpinfo) *?\((.*) ?\;?/i";
-			if(preg_match($regex,$input))
+			if(preg_match($regex,(string) $input))
 			{
 				self::die_http_400();
 			}
 
 			// Check for XSS JS
 			$regex = "/(document\.location|document\.write|document\.cookie)/i";
-			if(preg_match($regex,$input))
+			if(preg_match($regex,(string) $input))
 			{
 				self::die_http_400();
 			}
 
 
 			// Suspicious HTML.
-			if(strpos($input, '<body/onload')!==false)
+			if(strpos((string) $input, '<body/onload')!==false)
 			{
 				self::die_http_400();
 			}
 
-			if(preg_match("/system\((.*);.*\)/i",$input))
+			if(preg_match("/system\((.*);.*\)/i",(string) $input))
 			{
 				self::die_http_400();
 			}
 
 			$regex = "/(wget |curl -o |lwp-download|onmouse)/i";
-			if(preg_match($regex,$input))
+			if(preg_match($regex,(string) $input))
 			{
 				self::die_http_400();
 			}
@@ -4997,7 +4997,7 @@ class e107
 
 		if($type === '_GET') // Basic XSS check.
 		{
-			if(stripos($input, "<script")!==false || stripos($input, "%3Cscript")!==false)
+			if(stripos((string) $input, "<script")!==false || stripos((string) $input, "%3Cscript")!==false)
 			{
 				self::die_http_400();
 			}
@@ -5006,7 +5006,7 @@ class e107
 
 		if($type === "_SERVER")
 		{
-			$input = strtolower($input);
+			$input = strtolower((string) $input);
 
 			if(($key === "QUERY_STRING") && (
 				strpos($input,"../../")!==FALSE
@@ -5033,7 +5033,7 @@ class e107
 
 		if(!$base64)
 		{
-			self::filter_request(base64_decode($input, true),$key,$type,true);
+			self::filter_request(base64_decode((string) $input, true),$key,$type,true);
 		}
 
 
@@ -5102,7 +5102,7 @@ class e107
 		{
 
 			$host = !empty($_SERVER['SERVER_NAME']) ? $_SERVER['SERVER_NAME'] : $_SERVER['HTTP_HOST'];
-			$domain = preg_replace('/^www\.|:\d*$/', '', $host); // remove www. and port numbers.
+			$domain = preg_replace('/^www\.|:\d*$/', '', (string) $host); // remove www. and port numbers.
 
 			$dtemp = explode(".", $domain);
 
@@ -5215,7 +5215,7 @@ class e107
 			$SCRIPT_NAME = $_SERVER['_'];
 		}
 
-		$http_path = dirname($SCRIPT_NAME);
+		$http_path = dirname((string) $SCRIPT_NAME);
 		$http_path = explode("/", $http_path);
 		for ($i = 0; $i < substr_count($path, "../"); $i ++)
 		{
@@ -5256,7 +5256,7 @@ class e107
 	  	define('e_BASE', $this->relative_base_path);
 
 		// Base dir of web stuff in server terms. e_ROOT should always end with e_HTTP, even if e_HTTP = '/'
-		define('SERVERBASE', substr(e_ROOT, 0, -strlen(e_HTTP) + 1));
+		define('SERVERBASE', substr(e_ROOT, 0, -strlen((string) e_HTTP) + 1));
 
 		if(isset($_SERVER['DOCUMENT_ROOT']))
 		{
@@ -5400,8 +5400,8 @@ class e107
 	 */
 	private static function getRelativePath($from, $to)
 	{
-		$from = is_dir($from) ? rtrim($from, '\/') . '/' : $from;
-		$to = is_dir($to) ? rtrim($to, '\/') . '/' : $to;
+		$from = is_dir($from) ? rtrim((string) $from, '\/') . '/' : $from;
+		$to = is_dir($to) ? rtrim((string) $to, '\/') . '/' : $to;
 		$from = str_replace('\\', '/', $from);
 		$to = str_replace('\\', '/', $to);
 
@@ -5471,7 +5471,7 @@ class e107
 		{
 			if(!empty($_SERVER['argv']) && isset($_SERVER['argv'][1]) && empty($_GET))
 			{
-				parse_str($_SERVER['argv'][1], $_GET); // convert argv to $_GET for script testing via CLI.
+				parse_str((string) $_SERVER['argv'][1], $_GET); // convert argv to $_GET for script testing via CLI.
 			}
 
 			if(!empty($_SERVER['_']) && empty($_SERVER['SCRIPT_FILENAME']))
@@ -5514,7 +5514,7 @@ class e107
 			}
 		}
 
-		$check = rawurldecode($requestUri); // urlencoded by default
+		$check = rawurldecode((string) $requestUri); // urlencoded by default
 
 		// a bit aggressive XSS protection... convert to e.g. htmlentities if you are not a bad guy
 		$checkregx = $no_cbrace ? '[<>\{\}]' : '[<>]';
@@ -5555,11 +5555,11 @@ class e107
 
 		if(!deftrue('e_SINGLE_ENTRY') && !deftrue('e_SELF_OVERRIDE') )
 		{
-			$page = substr(strrchr($_SERVER['PHP_SELF'], '/'), 1);
+			$page = substr(strrchr((string) $_SERVER['PHP_SELF'], '/'), 1);
 
 			if(!empty($_SERVER['_']) && self::isCli())
 			{
-				$page = basename($_SERVER['_']);
+				$page = basename((string) $_SERVER['_']);
 			}
 
 
@@ -5572,7 +5572,7 @@ class e107
 
 			if(deftrue('e_SELF_OVERRIDE')) // see multisite plugin.
 			{
-				define('e_PAGE', basename($_SERVER['SCRIPT_FILENAME']));
+				define('e_PAGE', basename((string) $_SERVER['SCRIPT_FILENAME']));
 			}
 		}
 
@@ -5580,7 +5580,7 @@ class e107
 
 		unset($requestUrl, $requestUri);
 		// END request uri/url detection, XSS protection
-		$curPage = !empty($_SERVER['SCRIPT_FILENAME']) ? basename($_SERVER['SCRIPT_FILENAME']) : '';
+		$curPage = !empty($_SERVER['SCRIPT_FILENAME']) ? basename((string) $_SERVER['SCRIPT_FILENAME']) : '';
 		$_SERVER['REQUEST_URI'] = isset($_SERVER['REQUEST_URI']) ? $_SERVER['REQUEST_URI'] : '';
 
 		$isPluginDir = strpos($_self,'/'.$PLUGINS_DIRECTORY) !== FALSE;		// True if we're in a plugin
@@ -5664,7 +5664,7 @@ class e107
 	public function set_urls_deferred()
 	{
 		$siteurl        = self::getPref('siteurl');
-		$defaultHost    = (array) parse_url($siteurl, PHP_URL_HOST);
+		$defaultHost    = (array) parse_url((string) $siteurl, PHP_URL_HOST);
 		$defaultHost    = preg_replace('/^www\./', '', $defaultHost);
 
 		$hosts          = !empty($this->hosts) ? $this->hosts : $defaultHost;
@@ -5672,7 +5672,7 @@ class e107
 		if(self::isCli())
 		{
 			define('SITEURL', $siteurl);
-			define('SITEURLBASE', rtrim(SITEURL,'/'));
+			define('SITEURLBASE', rtrim((string) SITEURL,'/'));
 		}
 		elseif(!empty($hosts) && !$this->isAllowedHost($hosts, $_SERVER['HTTP_HOST']))
 		{
@@ -5722,8 +5722,8 @@ class e107
 				continue;
 			}
 
-			$host = preg_replace('/^www\./', '', $host);
-			if ($httpHost === $host || str_ends_with($httpHost, '.' . $host))
+			$host = preg_replace('/^www\./', '', (string) $host);
+			if ($httpHost === $host || str_ends_with((string) $httpHost, '.' . $host))
 			{
 				return true;
 			}
@@ -5749,7 +5749,7 @@ class e107
 
 		foreach($inArray as $res)
 		{
-			if(stripos($queryString, $res) !== false)
+			if(stripos((string) $queryString, $res) !== false)
 			 {
 				die('Access denied.');
 			}
@@ -5777,7 +5777,7 @@ class e107
 
 		if ($no_cbrace)
 		{
-			$e_QUERY = str_replace(array('{', '}', '%7B', '%7b', '%7D', '%7d'), '', rawurldecode($e_QUERY));
+			$e_QUERY = str_replace(array('{', '}', '%7B', '%7b', '%7D', '%7d'), '', rawurldecode((string) $e_QUERY));
 		}
 
 		$replacements = array(
@@ -6153,7 +6153,7 @@ class e107
 	 */
 	private static function autoload_namespaced($className)
 	{
-		$levels = explode('\\', $className);
+		$levels = explode('\\', (string) $className);
 
 		// Guard against classes that are not ours
 		if ($levels[0] !== 'e107')

--- a/e107_handlers/e_customfields_class.php
+++ b/e107_handlers/e_customfields_class.php
@@ -569,13 +569,13 @@
 
 			unset($new_data[$fieldname]); // Reset.
 
-			$len = strlen($fieldname);
+			$len = strlen((string) $fieldname);
 
 			foreach($new_data as $k=>$v)
 			{
-				if(strpos($k, $fieldname) === 0)
+				if(strpos((string) $k, (string) $fieldname) === 0)
 				{
-					list($tmp,$newkey) = explode('__',$k);
+					list($tmp,$newkey) = explode('__',(string) $k);
 					$new_data[$fieldname][$newkey] = $v;
 					unset($new_data[$k]);
 

--- a/e107_handlers/e_db_pdo_class.php
+++ b/e107_handlers/e_db_pdo_class.php
@@ -338,7 +338,7 @@ class e_db_pdo implements e_db
 		{
 			$this->dbg->log($query);
 		}
-		if ($debug !== false || strpos($_SERVER['QUERY_STRING'], 'showsql') !== false)
+		if ($debug !== false || strpos((string) $_SERVER['QUERY_STRING'], 'showsql') !== false)
 		{
 			$debugQry = is_array($query) ? print_a($query,true) : $query;
 			$queryinfo[] = "<b>{$qry_from}</b>: ".$debugQry;
@@ -1561,7 +1561,7 @@ class e_db_pdo implements e_db
 		}
 		elseif ($this->mySQLresult === TRUE)
 		{	// Successful query which may return a row count (because it operated on a number of rows without returning a result set)
-			if(preg_match('#^(DELETE|INSERT|REPLACE|UPDATE)#',$query, $matches))
+			if(preg_match('#^(DELETE|INSERT|REPLACE|UPDATE)#',(string) $query, $matches))
 			{
 				/** @var PDOStatement $resource */
 				$resource = $this->mySQLresult;
@@ -1593,7 +1593,7 @@ class e_db_pdo implements e_db
 			$this->tabset = true;
 		}
 
-		return " ".$this->mySQLPrefix.$table.substr($matches[0],-1);
+		return " ".$this->mySQLPrefix.$table.substr((string) $matches[0],-1);
 	}
 
 
@@ -1643,9 +1643,9 @@ class e_db_pdo implements e_db
 			foreach($this->mySQLtableList as $tab)
 			{
 
- 				if(strpos($tab,"lan_") === 0)
+ 				if(strpos((string) $tab,"lan_") === 0)
 				{
-					list($tmp,$lng,$tableName) = explode("_",$tab,3);
+					list($tmp,$lng,$tableName) = explode("_",(string) $tab,3);
 
                     foreach($table as $t)
 					{
@@ -1869,7 +1869,7 @@ class e_db_pdo implements e_db
 
       	foreach($tmp as $val)
 		{
-   			if(strpos($val,$this->mySQLPrefix) !== false) // search for table names references using the mprefix
+   			if(strpos($val,(string) $this->mySQLPrefix) !== false) // search for table names references using the mprefix
 			{
     			$table[] = str_replace(array($this->mySQLPrefix,"`"),"", $val);
 				$search[] = str_replace("`","",$val);
@@ -2206,9 +2206,9 @@ class e_db_pdo implements e_db
 		$database = !empty($this->mySQLdefaultdb) ? "FROM  `".$this->mySQLdefaultdb."`" : "";
 		$prefix = $this->mySQLPrefix;
 
-		if(strpos($prefix, ".") !== false) // eg. `my_database`.$prefix
+		if(strpos((string) $prefix, ".") !== false) // eg. `my_database`.$prefix
 		{
-			$tmp = explode(".",$prefix);
+			$tmp = explode(".",(string) $prefix);
 			$prefix = $tmp[1];
 		}
 
@@ -2217,7 +2217,7 @@ class e_db_pdo implements e_db
 			if(!isset($this->mySQLtableListLanguage[$language]))
 			{
 				$table = array();
-				if($res = $this->db_Query("SHOW TABLES ".$database." LIKE '".$prefix."lan_".strtolower($language)."%' "))
+				if($res = $this->db_Query("SHOW TABLES ".$database." LIKE '".$prefix."lan_".strtolower((string) $language)."%' "))
 				{
 					while($rows = $this->fetch('num'))
 					{
@@ -2239,10 +2239,10 @@ class e_db_pdo implements e_db
 
 			if($res = $this->db_Query("SHOW TABLES ".$database." LIKE '".$prefix."%' "))
 			{
-				$length = strlen($prefix);
+				$length = strlen((string) $prefix);
 				while($rows = $this->fetch('num'))
 				{
-					$table[] = substr($rows[0],$length);
+					$table[] = substr((string) $rows[0],$length);
 				}
 			}
 			return $table;
@@ -2284,7 +2284,7 @@ class e_db_pdo implements e_db
 			$ret = array();
 			foreach($this->mySQLtableList as $table)
 			{
-				if(substr($table,-4) != '_log' && $table != 'download_requests')
+				if(substr((string) $table,-4) != '_log' && $table != 'download_requests')
 				{
 					$ret[] = $table;
 				}
@@ -2307,7 +2307,7 @@ class e_db_pdo implements e_db
 
 			foreach($this->mySQLtableList as $tab)
 			{
-				if(strpos($tab,'lan_') === 0)
+				if(strpos((string) $tab,'lan_') === 0)
 				{
 					$lan[] = $tab;
 				}
@@ -2413,7 +2413,7 @@ class e_db_pdo implements e_db
 			$row = $this->fetch('num');
 			$qry = $row[1];
 			//        $qry = str_replace($old, $new, $qry);
-			$qry = preg_replace("#CREATE\sTABLE\s`?".$old."`?\s#", "CREATE TABLE {$new} ", $qry, 1); // More selective search
+			$qry = preg_replace("#CREATE\sTABLE\s`?".$old."`?\s#", "CREATE TABLE {$new} ", (string) $qry, 1); // More selective search
 		}
 		else
 		{
@@ -2463,7 +2463,7 @@ class e_db_pdo implements e_db
 
 	//	$dbtable 		= $this->mySQLdefaultdb;
 		$fileName		= ($table =='*') ? str_replace(" ","_",SITENAME) : $table;
-		$fileName	 	= preg_replace('/[\W]/',"",$fileName);
+		$fileName	 	= preg_replace('/[\W]/',"",(string) $fileName);
 
 		$backupFile 	= ($file) ? e_BACKUP.$file  :  e_BACKUP.strtolower($fileName)."_".$this->mySQLPrefix.date("Y-m-d-H-i-s").".sql";
 
@@ -2474,7 +2474,7 @@ class e_db_pdo implements e_db
 		}
 		else
 		{
-			$tableList 	= explode(",",$table);
+			$tableList 	= explode(",",(string) $table);
 		}
 
 		if(!empty($options['gzip']))
@@ -2505,7 +2505,7 @@ class e_db_pdo implements e_db
 
         foreach($tableList as $tab)
         {
-            $dumpSettings['include-tables'][] = $this->mySQLPrefix.trim($tab);
+            $dumpSettings['include-tables'][] = $this->mySQLPrefix.trim((string) $tab);
         }
 
 

--- a/e107_handlers/e_emote_class.php
+++ b/e107_handlers/e_emote_class.php
@@ -37,13 +37,13 @@ class e_emote
 		foreach($this->emotes as $key => $value)
 		{
 
-			$value = trim($value);
+			$value = trim((string) $value);
 
 			if($value)
 			{    // Only 'activate' emote if there's a substitution string set
 
 
-				$key = preg_replace("#!(\w{3,}?)$#si", ".\\1", $key);
+				$key = preg_replace("#!(\w{3,}?)$#si", ".\\1", (string) $key);
 				// Next two probably to sort out legacy issues - may not be required any more
 				//	$key = preg_replace("#_(\w{3})$#", ".\\1", $key);
 
@@ -113,7 +113,7 @@ class e_emote
 			return '';
 		}
 
-		if(!empty($this->singleSearch) && (strlen($text) < 12) && in_array($text, $this->singleSearch)) // just one emoticon with no space, line-break or html tags around it.
+		if(!empty($this->singleSearch) && (strlen((string) $text) < 12) && in_array($text, $this->singleSearch)) // just one emoticon with no space, line-break or html tags around it.
 		{
 			return str_replace($this->singleSearch, $this->singleReplace, $text);
 		}

--- a/e107_handlers/e_file_inspector.php
+++ b/e107_handlers/e_file_inspector.php
@@ -340,7 +340,7 @@ abstract class e_file_inspector implements e_file_inspector_interface
             $defaultDir = $this->defaultDirsCache[$dirType];
             if ($customDir === $defaultDir) continue;
 
-            if (substr($path, 0, strlen($customDir)) === $customDir)
+            if (substr($path, 0, strlen((string) $customDir)) === $customDir)
                 $path = $defaultDir . substr($path, strlen($customDir));
         }
         return $path;
@@ -360,8 +360,8 @@ abstract class e_file_inspector implements e_file_inspector_interface
             $defaultDir = $this->defaultDirsCache[$dirType];
             if ($customDir === $defaultDir) continue;
 
-            if (substr($path, 0, strlen($defaultDir)) === $defaultDir)
-                $path = $customDir . substr($path, strlen($defaultDir));
+            if (substr((string) $path, 0, strlen($defaultDir)) === $defaultDir)
+                $path = $customDir . substr((string) $path, strlen($defaultDir));
         }
         return $path;
     }

--- a/e107_handlers/e_file_inspector_json.php
+++ b/e107_handlers/e_file_inspector_json.php
@@ -32,7 +32,7 @@ class e_file_inspector_json extends e_file_inspector
     {
         global $core_image;
         @include($this->database);
-        $this->coreImage = json_decode($core_image, true);
+        $this->coreImage = json_decode((string) $core_image, true);
         if (!is_array($this->coreImage)) $this->coreImage = [];
         $this->coreImage = self::array_slash($this->coreImage);
         if (!$this->coreImage) $this->coreImage = [];
@@ -91,7 +91,7 @@ class e_file_inspector_json extends e_file_inspector
             {
                 foreach ($value as $versionWithV => $checksum)
                 {
-                    $value[ltrim($versionWithV, 'v')] = $checksum;
+                    $value[ltrim((string) $versionWithV, 'v')] = $checksum;
                     unset($value[$versionWithV]);
                 }
                 $results[$prepend . $key] = $value;

--- a/e107_handlers/e_marketplace.php
+++ b/e107_handlers/e_marketplace.php
@@ -54,7 +54,7 @@ class e_marketplace
 	 */
 	public function generateAuthKey($username, $password)
 	{
-		if(trim($username) == '' || trim($password) == '')
+		if(trim((string) $username) == '' || trim((string) $password) == '')
 		{
 			return false;	
 		}
@@ -87,7 +87,7 @@ class e_marketplace
 	public function makeAuthKey($username, $password = '', $plain = false)
 	{
 		$now 	= gmdate('y-m-d H');
-		if($plain && !empty($password)) $password = md5($password);
+		if($plain && !empty($password)) $password = md5((string) $password);
 		return sha1($username.$password.$now);
 	}
 
@@ -222,7 +222,7 @@ class e_marketplace
 	 */
 	public function __call($method, $arguments)
 	{
-		if(strpos($method, 'get') === 0 || strpos($method, 'do') === 0)
+		if(strpos((string) $method, 'get') === 0 || strpos((string) $method, 'do') === 0)
 		{
 			return $this->adapter()->call($method, $arguments);
 		}
@@ -1284,7 +1284,7 @@ class eAuth
 		$realm = isset($params['realm']) ? $params['realm'] : null;
 		if($realm)
 		{
-			$out = 'Authorization: eAuth realm="'.rawurlencode($realm).'"';
+			$out = 'Authorization: eAuth realm="'.rawurlencode((string) $realm).'"';
 			$first = false;
 		}
 		else
@@ -1293,13 +1293,13 @@ class eAuth
 		$total = array();
 		foreach($params as $k => $v)
 		{
-			if(strpos($k, "eauth") !== 0) continue;
+			if(strpos((string) $k, "eauth") !== 0) continue;
 			if(is_array($v))
 			{
 				throw new Exception('Arrays not supported in headers', 200);
 			}
 			$out .= ($first) ? ' ' : ',';
-			$out .= rawurlencode($k).'="'.rawurlencode($v).'"';
+			$out .= rawurlencode((string) $k).'="'.rawurlencode((string) $v).'"';
 			$first = false;
 		}
 		return $out;
@@ -1343,7 +1343,7 @@ class eAuth
 			return sha1($string.$secretKey);
 		}
 		// use secret key if HMAC-SHA1
-		return hash_hmac('sha1', $string, $secretKey);
+		return hash_hmac('sha1', (string) $string, (string) $secretKey);
 	}
 
 	/**
@@ -1363,7 +1363,7 @@ class eAuth
 	{
 		$ret = false;
 		// mask - Y-m-d H:i:s
-		if(preg_match('#(.*?)-(.*?)-(.*?) (.*?):(.*?):(.*?)$#', $string, $matches))
+		if(preg_match('#(.*?)-(.*?)-(.*?) (.*?):(.*?):(.*?)$#', (string) $string, $matches))
 		{
 			$ret = gmmktime($matches[4], $matches[5], $matches[6], $matches[2], $matches[3], $matches[1]);
 		}

--- a/e107_handlers/e_parse_class.php
+++ b/e107_handlers/e_parse_class.php
@@ -458,10 +458,10 @@ class e_parse
 
 		if ($this->multibyte)
 		{
-			return mb_stristr($haystack, $needle, $before_needle);
+			return mb_stristr($haystack, (string) $needle, $before_needle);
 		}
 
-		return stristr($haystack, $needle, $before_needle);
+		return stristr($haystack, (string) $needle, $before_needle);
 
 	}
 
@@ -532,7 +532,7 @@ class e_parse
 
 		if (MAGIC_QUOTES_GPC === true && $nostrip === false)
 		{
-			$data = stripslashes($data);
+			$data = stripslashes((string) $data);
 		}
 
 		$core_pref = e107::getConfig();
@@ -1072,7 +1072,7 @@ class e_parse
 
 
 		// Start of the serious stuff - split into HTML tags and text between
-		$content = preg_split('#(<.*?' . '>)#mis', $str, -1, PREG_SPLIT_NO_EMPTY | PREG_SPLIT_DELIM_CAPTURE);
+		$content = preg_split('#(<.*?' . '>)#mis', (string) $str, -1, PREG_SPLIT_NO_EMPTY | PREG_SPLIT_DELIM_CAPTURE);
 		foreach ($content as $value)
 		{
 			if ($value[0] === '<')
@@ -1133,7 +1133,7 @@ class e_parse
 					//			echo "Found block length ".strlen($value).': '.substr($value,20).'<br />';
 					// Split at spaces - note that this will fail if presented with invalid utf-8 when doing the regex whitespace search
 					//			$split = preg_split('#(\s)#'.$utf8, $value, -1, PREG_SPLIT_NO_EMPTY | PREG_SPLIT_DELIM_CAPTURE );
-					$split = preg_split($whiteSpace, $value, -1, PREG_SPLIT_NO_EMPTY | PREG_SPLIT_DELIM_CAPTURE);
+					$split = preg_split($whiteSpace, (string) $value, -1, PREG_SPLIT_NO_EMPTY | PREG_SPLIT_DELIM_CAPTURE);
 					$value = '';
 					foreach ($split as $sp)
 					{
@@ -1449,12 +1449,12 @@ class e_parse
 		{
 			$this->e_highlighting = false;
 			$shr = (isset($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : '');
-			if ($pref['search_highlight'] && (strpos(e_SELF, 'search.php') === false) && ((strpos($shr, 'q=') !== false) || (strpos($shr, 'p=') !== false)))
+			if ($pref['search_highlight'] && (strpos((string) e_SELF, 'search.php') === false) && ((strpos((string) $shr, 'q=') !== false) || (strpos((string) $shr, 'p=') !== false)))
 			{
 				$this->e_highlighting = true;
 				if (!isset($this->e_query))
 				{
-					preg_match('#(q|p)=(.*?)(&|$)#', $shr, $matches);
+					preg_match('#(q|p)=(.*?)(&|$)#', (string) $shr, $matches);
 					$this->e_query = str_replace(array('+', '*', '"', ' '), array('', '.*?', '', '\b|\b'), trim(urldecode($matches[2])));
 				}
 			}
@@ -1486,7 +1486,7 @@ class e_parse
 
 		$textReplace = (!empty($opts['sub'])) ? $opts['sub'] : '';
 
-		if (substr($textReplace, -6) === '.glyph')
+		if (substr((string) $textReplace, -6) === '.glyph')
 		{
 			$textReplace = $this->toGlyph($textReplace, '');
 		}
@@ -1520,8 +1520,8 @@ class e_parse
 				$external = (!empty($opts['ext'])) ? 'target="_blank"' : '';
 
 				$text = preg_replace("/(^|[\n \(])([\w]*?)([\w]*?:\/\/[\w]+[^ \,\"\n\r\t<]*)/is", '$1$2<a class="e-url" href="$3" ' . $external . '>' . $linktext . '</a>', $text);
-				$text = preg_replace("/(^|[\n \(])([\w]*?)((www)\.[^ \,\"\t\n\r\)<]*)/is", '$1$2<a class="e-url" href="http://$3" ' . $external . '>' . $linktext . '</a>', $text);
-				$text = preg_replace("/(^|[\n ])([\w]*?)((ftp)\.[^ \,\"\t\n\r<]*)/is", '$1$2<a class="e-url" href="$4://$3" ' . $external . '>' . $linktext . '</a>', $text);
+				$text = preg_replace("/(^|[\n \(])([\w]*?)((www)\.[^ \,\"\t\n\r\)<]*)/is", '$1$2<a class="e-url" href="http://$3" ' . $external . '>' . $linktext . '</a>', (string) $text);
+				$text = preg_replace("/(^|[\n ])([\w]*?)((ftp)\.[^ \,\"\t\n\r<]*)/is", '$1$2<a class="e-url" href="$4://$3" ' . $external . '>' . $linktext . '</a>', (string) $text);
 
 				break;
 
@@ -1572,7 +1572,7 @@ class e_parse
 	public function stripAttributes($s, $allowedattr = array())
 	{
 
-		if (preg_match_all("/<[^>]*\\s([^>]*)\\/*>/msiU", $s, $res, PREG_SET_ORDER))
+		if (preg_match_all("/<[^>]*\\s([^>]*)\\/*>/msiU", (string) $s, $res, PREG_SET_ORDER))
 		{
 			foreach ($res as $r)
 			{
@@ -1670,7 +1670,7 @@ class e_parse
 
 		if ($opts['no_tags'])
 		{
-			$text = strip_tags($text);
+			$text = strip_tags((string) $text);
 		}
 		/*
 				if(MAGIC_QUOTES_GPC === true) // precaution for badly saved data.
@@ -1697,7 +1697,7 @@ class e_parse
 		{
 			// Split each text block into bits which are either within one of the 'key' bbcodes, or outside them
 			// (Because we have to match end words, the 'extra' capturing subpattern gets added to output array. We strip it later)
-			$content = preg_split('#(\[(table|html|php|code|scode|hide).*?\[\/(?:\\2)\])#mis', $text, -1, PREG_SPLIT_NO_EMPTY | PREG_SPLIT_DELIM_CAPTURE);
+			$content = preg_split('#(\[(table|html|php|code|scode|hide).*?\[\/(?:\\2)\])#mis', (string) $text, -1, PREG_SPLIT_NO_EMPTY | PREG_SPLIT_DELIM_CAPTURE);
 		}
 
 
@@ -1723,7 +1723,7 @@ class e_parse
 
 				// Have to have a good test in case a 'non-key' bbcode starts the block
 				// - so pull out the bbcode parameters while we're there
-				if (($parseBB !== false) && preg_match('#(^\[(table|html|php|code|scode|hide)(.*?)\])(.*?)(\[/\\2\]$)#is', $full_text, $matches))
+				if (($parseBB !== false) && preg_match('#(^\[(table|html|php|code|scode|hide)(.*?)\])(.*?)(\[/\\2\]$)#is', (string) $full_text, $matches))
 				{
 
 					$proc_funcs = false;
@@ -1782,7 +1782,7 @@ class e_parse
 			if ($proc_funcs && !empty($full_text)) // some more speed
 			{
 				// Split out and ignore any scripts and style blocks. With just two choices we can match the closing tag in the regex
-				$subcon = preg_split('#((?:<s)(?:cript[^>]+>.*?</script>|tyle[^>]+>.*?</style>))#mis', $full_text, -1, PREG_SPLIT_NO_EMPTY | PREG_SPLIT_DELIM_CAPTURE);
+				$subcon = preg_split('#((?:<s)(?:cript[^>]+>.*?</script>|tyle[^>]+>.*?</style>))#mis', (string) $full_text, -1, PREG_SPLIT_NO_EMPTY | PREG_SPLIT_DELIM_CAPTURE);
 				foreach ($subcon as $sub_blk)
 				{
 
@@ -1859,7 +1859,7 @@ class e_parse
 		foreach ($this->preformatted as $type)
 		{
 			$code = '[' . $type . ']';
-			if (strpos($str, $code) === 0)
+			if (strpos((string) $str, $code) === 0)
 			{
 				return true;
 			}
@@ -2024,11 +2024,11 @@ class e_parse
 
 		foreach ($attributes as $key => $value)
 		{
-			if ($value === true && (strpos($key, 'data-') !== 0))
+			if ($value === true && (strpos((string) $key, 'data-') !== 0))
 			{
 				$value = $key;
 			}
-			if (!empty($value) || is_numeric($value) || $key === "value" || strpos($key, 'data-') === 0)
+			if (!empty($value) || is_numeric($value) || $key === "value" || strpos((string) $key, 'data-') === 0)
 			{
 				$stringifiedAttributes[] = $key . "='" . $this->toAttribute($value, $pure) . "'";
 			}
@@ -2082,11 +2082,11 @@ class e_parse
 		$output = [];
 		foreach ($array as $key => $value)
 		{
-			if (!empty($unprepend) && substr($key, 0, strlen($unprepend)) == $unprepend)
+			if (!empty($unprepend) && substr((string) $key, 0, strlen($unprepend)) == $unprepend)
 			{
-				$key = substr($key, strlen($unprepend));
+				$key = substr((string) $key, strlen($unprepend));
 			}
-			$parts = explode('/', $key);
+			$parts = explode('/', (string) $key);
 			$nested = &$output;
 			while (count($parts) > 1)
 			{
@@ -2460,7 +2460,7 @@ class e_parse
 			'h'  => isset($options['h']) ? (string) intval($options['h']) : '',
 			'aw' => isset($options['aw']) ? (string) intval($options['aw']) : '',
 			'ah' => isset($options['ah']) ? (string) intval($options['ah']) : '',
-			'c'  => strtoupper(vartrue($options['c'], '0')),
+			'c'  => strtoupper((string) vartrue($options['c'], '0')),
 		);
 
 		if (!empty($options['type']))
@@ -2823,16 +2823,16 @@ class e_parse
 	public function thumbUrlDecode($src)
 	{
 
-		list($url, $qry) = array_pad(explode('?', $src), 2, null);
+		list($url, $qry) = array_pad(explode('?', (string) $src), 2, null);
 
 		$ret = array();
 
-		if (!empty($qry) && strpos($url, 'thumb.php') !== false) // Regular
+		if (!empty($qry) && strpos((string) $url, 'thumb.php') !== false) // Regular
 		{
 			parse_str($qry, $val);
 			$ret = $val;
 		}
-		elseif (preg_match('/media\/img\/(a)?([\d]*)x(a)?([\d]*)\/(.*)/', $url, $match)) // SEF
+		elseif (preg_match('/media\/img\/(a)?([\d]*)x(a)?([\d]*)\/(.*)/', (string) $url, $match)) // SEF
 		{
 			$wKey = $match[1] . 'w';
 			$hKey = $match[3] . 'h';
@@ -2843,7 +2843,7 @@ class e_parse
 				$hKey => $match[4]
 			);
 		}
-		elseif (preg_match('/theme\/img\/(a)?([\d]*)x(a)?([\d]*)\/(.*)/', $url, $match)) // Theme-image SEF Urls
+		elseif (preg_match('/theme\/img\/(a)?([\d]*)x(a)?([\d]*)\/(.*)/', (string) $url, $match)) // Theme-image SEF Urls
 		{
 			$wKey = $match[1] . 'w';
 			$hKey = $match[3] . 'h';
@@ -3008,21 +3008,21 @@ class e_parse
 
 		if (!empty($options['x']) && !empty($options['ext'])) // base64 encoded. Build URL for:  RewriteRule ^media\/img\/([-A-Za-z0-9+/]*={0,3})\.(jpg|gif|png)?$ thumb.php?id=$1
 		{
-			$ext = strtolower($options['ext']);
+			$ext = strtolower((string) $options['ext']);
 
-			return $base . 'media/img/' . base64_encode($options['thurl']) . '.' . str_replace('jpeg', 'jpg', $ext);
+			return $base . 'media/img/' . base64_encode((string) $options['thurl']) . '.' . str_replace('jpeg', 'jpg', $ext);
 		}
-		elseif (strpos($url, 'e_MEDIA_IMAGE') !== false) // media images.
+		elseif (strpos((string) $url, 'e_MEDIA_IMAGE') !== false) // media images.
 		{
 			$sefPath = 'media/img/';
 			$clean = array('{e_MEDIA_IMAGE}', 'e_MEDIA_IMAGE/');
 		}
-		elseif (strpos($url, 'e_AVATAR') !== false) // avatars
+		elseif (strpos((string) $url, 'e_AVATAR') !== false) // avatars
 		{
 			$sefPath = 'media/avatar/';
 			$clean = array('{e_AVATAR}', 'e_AVATAR/');
 		}
-		elseif (strpos($url, 'e_THEME') !== false) // theme folder images.
+		elseif (strpos((string) $url, 'e_THEME') !== false) // theme folder images.
 		{
 			$sefPath = 'theme/img/';
 			$clean = array('{e_THEME}', 'e_THEME/');
@@ -3053,7 +3053,7 @@ class e_parse
 
 			if (!is_numeric($options['crop']))
 			{
-				$sefUrl .= strtolower($options['crop']) . intval($options['w']) . 'x' . strtolower($options['crop']) . intval($options['h']);
+				$sefUrl .= strtolower((string) $options['crop']) . intval($options['w']) . 'x' . strtolower((string) $options['crop']) . intval($options['h']);
 			}
 			else
 			{
@@ -3373,7 +3373,7 @@ class e_parse
 	private function doReplace($matches)
 	{
 
-		if (defined($matches[1]) && (deftrue('ADMIN') || strpos($matches[1], 'ADMIN') === false))
+		if (defined($matches[1]) && (deftrue('ADMIN') || strpos((string) $matches[1], 'ADMIN') === false))
 		{
 			return constant($matches[1]);
 		}
@@ -3571,8 +3571,8 @@ class e_parse
 	{
 
 		$tags = array();
-		preg_match_all('#<[^>]+>#', $text, $tags);
-		$text = preg_replace('#<[^>]+>#', '<|>', $text);
+		preg_match_all('#<[^>]+>#', (string) $text, $tags);
+		$text = preg_replace('#<[^>]+>#', '<|>', (string) $text);
 		$text = preg_replace('#(\b".$match."\b)#i', '<span class="searchhighlight">\\1</span>', $text);
 		foreach ($tags[0] as $tag)
 		{
@@ -3673,7 +3673,7 @@ class e_parse
 	{
 
 		$ret = '';
-		foreach (str_split($text) as $letter)
+		foreach (str_split((string) $text) as $letter)
 		{
 			switch (mt_rand(1, 3))
 			{
@@ -4031,7 +4031,7 @@ class e_parse
 		libxml_use_internal_errors(true);
 		$doc->loadHTML($html);
 
-		$tg = explode(',', $taglist);
+		$tg = explode(',', (string) $taglist);
 		$ret = array();
 
 		foreach ($tg as $find)
@@ -4293,7 +4293,7 @@ class e_parse
 		{
 			foreach ($custom as $glyphConfig)
 			{
-				if (strpos($text, $glyphConfig['prefix']) === 0)
+				if (strpos($text, (string) $glyphConfig['prefix']) === 0)
 				{
 					$prefix = $glyphConfig['class'] . ' ';
 					$tag = $glyphConfig['tag'];
@@ -4357,7 +4357,7 @@ class e_parse
 			$type = 'default';
 		}
 
-		$tmp = explode(',', $text);
+		$tmp = explode(',', (string) $text);
 
 		$opt = array();
 		foreach ($tmp as $v)
@@ -4460,14 +4460,14 @@ class e_parse
 		if (!empty($image))
 		{
 
-			if (strpos($image, '://') !== false) // Remote Image
+			if (strpos((string) $image, '://') !== false) // Remote Image
 			{
 				$url = $image;
 			}
-			elseif (strpos($image, '-upload-') === 0)
+			elseif (strpos((string) $image, '-upload-') === 0)
 			{
 
-				$image = substr($image, 8); // strip the -upload- from the beginning.
+				$image = substr((string) $image, 8); // strip the -upload- from the beginning.
 				if (file_exists(e_AVATAR_UPLOAD . $image))
 				{
 					$file = e_AVATAR_UPLOAD . $image;
@@ -4508,7 +4508,7 @@ class e_parse
 			else
 			{
 				$content = e107::getFile()->getRemoteContent($url);
-				$ext = strtolower(pathinfo($url, PATHINFO_EXTENSION));
+				$ext = strtolower(pathinfo((string) $url, PATHINFO_EXTENSION));
 			}
 
 			if (!empty($content))
@@ -4760,7 +4760,7 @@ class e_parse
 		elseif(!empty($parm['legacy']) && !empty($file)) // Search legacy path for image in a specific folder. No path, only file name provided.
 		{
 
-			$legacyPath = rtrim($parm['legacy'], '/') . '/' . $file;
+			$legacyPath = rtrim((string) $parm['legacy'], '/') . '/' . $file;
 			$filePath = $tp->replaceConstants($legacyPath);
 
 			if (is_readable($filePath))
@@ -4984,7 +4984,7 @@ class e_parse
         |\xF0[\x90-\xBF][\x80-\xBF]{2}    # planes 1-3
         |[\xF1-\xF3][\x80-\xBF]{3}                  # planes 4-15
         |\xF4[\x80-\x8F][\x80-\xBF]{2}    # plane 16
-        )+%xs', $string);
+        )+%xs', (string) $string);
 
 	}
 
@@ -5108,9 +5108,9 @@ class e_parse
 		$ytpref = array();
 		foreach ($pref as $k => $v) // Find all Youtube Prefs.
 		{
-			if (strpos($k, 'youtube_') === 0)
+			if (strpos((string) $k, 'youtube_') === 0)
 			{
-				$key = substr($k, 8);
+				$key = substr((string) $k, 8);
 				$ytpref[$key] = $v;
 			}
 		}
@@ -5286,10 +5286,10 @@ class e_parse
 		{
 			foreach ($v as $val)
 			{
-				$tag = base64_decode($val['alt']);
+				$tag = base64_decode((string) $val['alt']);
 				$repl = ($retainTags == true) ? '$1' . $tag . '$2' : $tag;
 				//	$text = preg_replace('/(<x-bbcode[^>]*>).*(<\/x-bbcode>)/i',$repl, $text);
-				$text = preg_replace('/(<x-bbcode alt=(?:&quot;|")' . $val['alt'] . '(?:&quot;|")>).*(<\/x-bbcode>)/i', $repl, $text);
+				$text = preg_replace('/(<x-bbcode alt=(?:&quot;|")' . $val['alt'] . '(?:&quot;|")>).*(<\/x-bbcode>)/i', $repl, (string) $text);
 
 			}
 		}
@@ -5526,7 +5526,7 @@ class e_parse
 			//   $tag = strval(basename($path));
 
 
-			if (strpos($path, '/code') !== false || strpos($path, '/pre') !== false) //  treat as html.
+			if (strpos((string) $path, '/code') !== false || strpos((string) $path, '/pre') !== false) //  treat as html.
 			{
 				$this->pathList[] = $path;
 				//     $this->nodesToConvert[] =  $node->parentNode; // $node;
@@ -5535,7 +5535,7 @@ class e_parse
 			}
 
 
-			$tag = preg_replace('/([a-z0-9\[\]\/]*)?\/([\w\-]*)(\[(\d)*\])?$/i', '$2', $path);
+			$tag = preg_replace('/([a-z0-9\[\]\/]*)?\/([\w\-]*)(\[(\d)*\])?$/i', '$2', (string) $path);
 			if (!in_array($tag, $this->allowedTags))
 			{
 
@@ -5717,7 +5717,7 @@ class e_parse
 
 		foreach ($this->badAttrValues as $v) // global list because a bad value is bad regardless of the attribute it's in. ;-)
 		{
-			if (preg_match('/' . $v . '/i', $value) == true)
+			if (preg_match('/' . $v . '/i', (string) $value) == true)
 			{
 				$this->removedList['blacklist'][] = "Match found for '{$v}' in '{$value}'";
 
@@ -5920,7 +5920,7 @@ class e_parse
 				//		trigger_error('<b>tohtml_hook is deprecated.</b> Use e_parse.php instead.', E_USER_DEPRECATED); // NO LAN
 
 				//Process the older tohtml_hook pref (deprecated)
-				foreach (explode(',', $this->pref['tohtml_hook']) as $hook)
+				foreach (explode(',', (string) $this->pref['tohtml_hook']) as $hook)
 				{
 					if (!is_object($this->e_hook[$hook]) && is_readable(e_PLUGIN . $hook . '/' . $hook . '.php'))
 					{

--- a/e107_handlers/e_pluginbuilder_class.php
+++ b/e107_handlers/e_pluginbuilder_class.php
@@ -115,7 +115,7 @@ class e_pluginbuilder
 					<td><div class='input-append form-inline'>".$frm->open('createPlugin','get',e_SELF."?mode=create").$frm->select("newplugin",$newDir, false, 'size=xlarge').$frm->admin_button('step', 2,'other',LAN_GO)."</div> ".$frm->checkbox('createFiles',1,1,EPL_ADLAN_255).$frm->close()."</td>
 					<td><div class='alert alert-info'>".$info."</div></td>
 				</tr>
-				
+
 				<tr>
 					<td>".EPL_ADLAN_108."</td>
 					<td><div class='input-append form-inline'>".$frm->open('checkPluginLangs','get',e_SELF."?mode=lans").$frm->select("newplugin",$lanDir, false, 'size=xlarge').$frm->admin_button('step', 2,'other',LAN_GO)."</div> ".$frm->close()."</td>
@@ -138,7 +138,7 @@ class e_pluginbuilder
 			$text .= "				
 				</table>
 				<div class='buttons-bar center'>
-				
+
 				</div>";
 
 			$text .= $frm->close();
@@ -409,7 +409,7 @@ $content = <<<TMPL
 // Template File
 TMPL;
 
-$upperName = strtoupper($this->pluginName);
+$upperName = strtoupper((string) $this->pluginName);
 
 $content .=  "
 // ".$this->pluginName." Template file
@@ -469,7 +469,7 @@ class plugin_".$this->pluginName."_".$this->pluginName."_shortcodes extends e_sh
 
 $content .= "
 	/**
-	* {".strtoupper($key)."}
+	* {".strtoupper((string) $key)."}
 	*/
 	public function sc_".$key."(\$parm=null)
 	{
@@ -780,7 +780,7 @@ $content .= '}';
 		function xmlInput($name, $info, $default='')
 		{
 			$frm = e107::getForm();
-			list($cat,$type) = explode("-",$info);
+			list($cat,$type) = explode("-",(string) $info);
 
 			$size 		= 30; // Textbox size.
 			$help		= '';
@@ -1239,10 +1239,10 @@ TEMPLATE;
 		 */
 		function fieldType($name, $val)
 		{
-			$type = strtolower($val['type']);
+			$type = strtolower((string) $val['type']);
 			$frm = e107::getForm();
 
-			if(strtolower($val['default']) == "auto_increment")
+			if(strtolower((string) $val['default']) == "auto_increment")
 			{
 				$key = $this->table."[pid]";
 				return "Primary Id".
@@ -1357,7 +1357,7 @@ TEMPLATE;
 		// Guess Default Field Type based on name of field.
 		function guess($data, $val=null,$mode = 'type')
 		{
-			$tmp = explode("_",$data);
+			$tmp = explode("_",(string) $data);
 			$name = '';
 
 			if(count($tmp) == 3) // eg Link_page_title
@@ -1373,7 +1373,7 @@ TEMPLATE;
 				$name = $data;
 			}
 
-			$ret['title'] = ucfirst($name);
+			$ret['title'] = ucfirst((string) $name);
 			$ret['width'] = 'auto';
 			$ret['class'] = 'left';
 			$ret['thclass'] = 'left';
@@ -1408,7 +1408,7 @@ TEMPLATE;
 				case 'lastname':
 				case 'company':
 				case 'city':
-					$ret['title'] = ucfirst($name);
+					$ret['title'] = ucfirst((string) $name);
 					$ret['type'] = 'text';
 					$ret['batch'] = false;
 					$ret['filter'] = false;
@@ -1481,7 +1481,7 @@ TEMPLATE;
 
 				case 'code':
 				case 'zip':
-					$ret['title'] = ucfirst($name);
+					$ret['title'] = ucfirst((string) $name);
 					$ret['type'] = 'number';
 					$ret['batch'] = false;
 					$ret['filter'] = false;
@@ -1491,7 +1491,7 @@ TEMPLATE;
 				case 'state':
 				case 'country':
 				case 'category':
-					$ret['title'] = ($name == 'category') ? 'LAN_CATEGORY' : ucfirst($name);
+					$ret['title'] = ($name == 'category') ? 'LAN_CATEGORY' : ucfirst((string) $name);
 					$ret['type'] = 'dropdown';
 					$ret['batch'] = true;
 					$ret['filter'] = true;
@@ -1542,7 +1542,7 @@ TEMPLATE;
 				case 'comments':
 				case 'address':
 				case 'description':
-					$ret['title'] = ($name == 'description') ? 'LAN_DESCRIPTION' : ucfirst($name);
+					$ret['title'] = ($name == 'description') ? 'LAN_DESCRIPTION' : ucfirst((string) $name);
 					 $ret['type'] = ($val['type'] == 'TEXT') ? 'textarea' : 'text';
 					 $ret['width'] = '40%';
 					$ret['inline'] = false;
@@ -1575,7 +1575,7 @@ TEMPLATE;
 							'mediumblob','longblob','tinytext','mediumtext','longtext','text','date');
 
 
-			$type = strtolower($type);
+			$type = strtolower((string) $type);
 
 			if(in_array($type,$strings))
 			{
@@ -1705,7 +1705,7 @@ TEMPLATE;
 	{
 		$text = '';
 
-		$typeUpper = ucfirst($type);
+		$typeUpper = ucfirst((string) $type);
 
 		$params = ($type === 'batch') ? "\$selected, \$type" : "\$type";
 

--- a/e107_handlers/e_profanity_class.php
+++ b/e107_handlers/e_profanity_class.php
@@ -20,7 +20,7 @@ class e_profanity
 			return null;
 		}
 
-		$words = explode(',', $this->pref['profanity_words']);
+		$words = explode(',', (string) $this->pref['profanity_words']);
 		$word_array = array();
 		foreach($words as $word)
 		{
@@ -57,10 +57,10 @@ class e_profanity
 
 		if(!empty($this->pref['profanity_replace']))
 		{
-			return preg_replace("#\b" . $this->profanityList . "\b#is", $this->pref['profanity_replace'], $text);
+			return preg_replace("#\b" . $this->profanityList . "\b#is", (string) $this->pref['profanity_replace'], (string) $text);
 		}
 
-		return preg_replace_callback("#\b" . $this->profanityList . "\b#is", array($this, 'replaceProfanities'), $text);
+		return preg_replace_callback("#\b" . $this->profanityList . "\b#is", array($this, 'replaceProfanities'), (string) $text);
 	}
 
 	/**
@@ -78,6 +78,6 @@ class e_profanity
 		@result filtered text
 		*/
 
-		return preg_replace('#a|e|i|o|u#i', '*', $matches[0]);
+		return preg_replace('#a|e|i|o|u#i', '*', (string) $matches[0]);
 	}
 }

--- a/e107_handlers/e_ranks_class.php
+++ b/e107_handlers/e_ranks_class.php
@@ -190,9 +190,9 @@ class e_ranks
 	private function _getImage(&$info)
 	{
 		$img = $info['image'];
-		if($info['lan_pfx'] && strpos('_', $info['image']))
+		if($info['lan_pfx'] && strpos('_', (string) $info['image']))
 		{
-			$_tmp = explode('_', $info['image'], 2);
+			$_tmp = explode('_', (string) $info['image'], 2);
 			$img = e_LANGUAGE.'_'.$_tmp[1];
 		}
 		return $this->imageFolder.$img;

--- a/e107_handlers/e_render_class.php
+++ b/e107_handlers/e_render_class.php
@@ -168,7 +168,7 @@
 
 			foreach($types as $var)
 			{
-				$sc = '{---' . strtoupper($var) . '---}';
+				$sc = '{---' . strtoupper((string) $var) . '---}';
 				$ret[$sc] = isset($val[$var]) ? (string) $val[$var] : null;
 			}
 

--- a/e107_handlers/e_signup_class.php
+++ b/e107_handlers/e_signup_class.php
@@ -45,7 +45,7 @@ class e_signup
 	{
 		$ns = e107::getRender();
 
-		if(strpos($query,'activate.') === 0)
+		if(strpos((string) $query,'activate.') === 0)
 		{
 			$result = $this->processActivationLink($query);
 
@@ -165,7 +165,7 @@ class e_signup
 		$row = $sql -> fetch();
 		// We should have a user record here
 
-		if(trim($_POST['resend_password']) !="" && $new_email) // Need to change the email address - check password to make sure
+		if(trim((string) $_POST['resend_password']) !="" && $new_email) // Need to change the email address - check password to make sure
 		{
 			if ($userMethods->CheckPassword($_POST['resend_password'], $row['user_loginname'], $row['user_password']) === TRUE)
 			{
@@ -356,7 +356,7 @@ class e_signup
 		$log        = e107::getLog();
 
 
-		$qs = explode('.', $queryString); // ie.  activate.".$row['user_id'].".".$row['user_sess']
+		$qs = explode('.', (string) $queryString); // ie.  activate.".$row['user_id'].".".$row['user_sess']
 
 		if ($qs[0] == 'activate' && (count($qs) == 3 || count($qs) == 4) && $qs[2])
 		{

--- a/e107_handlers/e_thumbnail_class.php
+++ b/e107_handlers/e_thumbnail_class.php
@@ -91,7 +91,7 @@ class e_thumbnail
 
 		$this->_upsize = ((isset($this->_request['w']) && $this->_request['w'] > 110) || (isset($this->_request['aw']) && ($this->_request['aw'] > 110))); // don't resizeUp the icon images.
 
-		$this->_forceWebP = empty($this->_request['type']) && !empty($pref['thumb_to_webp']) && (strpos( $_SERVER['HTTP_ACCEPT'], 'image/webp' ) !== false) ? true : false;
+		$this->_forceWebP = empty($this->_request['type']) && !empty($pref['thumb_to_webp']) && (strpos( (string) $_SERVER['HTTP_ACCEPT'], 'image/webp' ) !== false) ? true : false;
 	//	var_dump($this);
 	//	exit;
 		return null;
@@ -135,7 +135,7 @@ class e_thumbnail
 
 		if(isset($_GET['id'])) // very-basic url-tampering prevention and path cloaking
 		{
-			$e_QUERY = base64_decode($_GET['id']);
+			$e_QUERY = base64_decode((string) $_GET['id']);
 		}
 
 		$e_QUERY= str_replace('e_AVATAR', 'e_AVATAR/', $e_QUERY); // FIXME  Quick and dirty fix.
@@ -479,7 +479,7 @@ class e_thumbnail
 		}
 
 		// check browser cache
-		if (@$_SERVER['HTTP_IF_MODIFIED_SINCE'] && ($thumbnfo['lmodified'] <= strtotime($_SERVER['HTTP_IF_MODIFIED_SINCE'])) && (isset($_SERVER['HTTP_IF_NONE_MATCH']) && trim($_SERVER['HTTP_IF_NONE_MATCH']) == $thumbnfo['md5s']))
+		if (@$_SERVER['HTTP_IF_MODIFIED_SINCE'] && ($thumbnfo['lmodified'] <= strtotime((string) $_SERVER['HTTP_IF_MODIFIED_SINCE'])) && (isset($_SERVER['HTTP_IF_NONE_MATCH']) && trim($_SERVER['HTTP_IF_NONE_MATCH']) == $thumbnfo['md5s']))
 		{
 			header('HTTP/1.1 304 Not Modified');
 			//$bench->end()->logResult('thumb.php', $_GET['src'].' - 304 not modified');
@@ -587,7 +587,7 @@ class e_thumbnail
 			//'bmp'  => 'image/bmp',
 		);
 
-		$ftype = strtolower($ftype);
+		$ftype = strtolower((string) $ftype);
 		if(isset($known_types[$ftype]))
 		{
 			return $known_types[$ftype];

--- a/e107_handlers/e_upgrade_class.php
+++ b/e107_handlers/e_upgrade_class.php
@@ -80,7 +80,7 @@ class e_upgrade
 		$xml = e107::getXml();
         $feed = $this->getOption('releaseUrl');
 
-	 	if(substr($feed,-4) == ".php")
+	 	if(substr((string) $feed,-4) == ".php")
 		{
         	 $feed .= "?folder=".$this->getOption('curFolder')."&version=".$this->getOption('curVersion');
 		}

--- a/e107_handlers/error_page_class.php
+++ b/e107_handlers/error_page_class.php
@@ -163,7 +163,7 @@ class error_page
 	{
 		header('HTTP/1.1 501 Not Implemented', true, 501);
 
-		$errorQuery = htmlentities($_SERVER['QUERY_STRING']);
+		$errorQuery = htmlentities((string) $_SERVER['QUERY_STRING']);
 
 		$this->template = 'DEFAULT';
 		$this->title = LAN_ERROR_13 . ' (' . $errorQuery . ')';

--- a/e107_handlers/event_class.php
+++ b/e107_handlers/event_class.php
@@ -228,9 +228,9 @@ class e107_event
 					try
 					{
 
-						if (strpos($method, '::') !== false)    // If $method contains "::", call it statically
+						if (strpos((string) $method, '::') !== false)    // If $method contains "::", call it statically
 						{
-						    [$staticClass, $staticMethod] = explode('::', $method, 2);
+						    [$staticClass, $staticMethod] = explode('::', (string) $method, 2);
 						    $ret = $staticClass::$staticMethod($data, $eventname);
 						}
 						elseif(is_callable([$class, $method]))
@@ -296,7 +296,7 @@ class e107_event
 		global $pref;
 		if(!is_array($parms))
 		{
-			parse_str($parms, $parms);
+			parse_str((string) $parms, $parms);
 		}
 		if(isset($pref['e_admin_events_list']) && is_array($pref['e_admin_events_list']))
 		{

--- a/e107_handlers/file_class.php
+++ b/e107_handlers/file_class.php
@@ -185,7 +185,7 @@ class e_file
 	{
 
 		$fullpath = $f['path'] . $f['fname'];
-		$newfile = preg_replace("/[^a-z0-9-\._]/", "-", strtolower($f['fname']));
+		$newfile = preg_replace("/[^a-z0-9-\._]/", "-", strtolower((string) $f['fname']));
 		$newpath = $f['path'] . $newfile;
 
 		if($rename == true)
@@ -1179,13 +1179,13 @@ class e_file
 			if(is_file($filename) && is_readable($filename) && connection_status() == 0)
 			{
 				$seek = 0;
-				if(strpos($_SERVER['HTTP_USER_AGENT'], "MSIE") !== false)
+				if(strpos((string) $_SERVER['HTTP_USER_AGENT'], "MSIE") !== false)
 				{
 					$file = preg_replace('/\./', '%2e', $file, substr_count($file, '.') - 1);
 				}
 				if(isset($_SERVER['HTTP_RANGE']))
 				{
-					$seek = intval(substr($_SERVER['HTTP_RANGE'], strlen('bytes=')));
+					$seek = intval(substr((string) $_SERVER['HTTP_RANGE'], strlen('bytes=')));
 				}
 				$bufsize = 2048;
 				ignore_user_abort(true);
@@ -1300,7 +1300,7 @@ class e_file
 
 		foreach($unarc as $d)
 		{
-			$target = trim($d['stored_filename'], '/');
+			$target = trim((string) $d['stored_filename'], '/');
 
 			$test = basename(str_replace(e_TEMP, "", $d['stored_filename']), '/');
 
@@ -1661,7 +1661,7 @@ class e_file
 
 		//   print_a($headers);
 
-		return (stripos($headers[0], "200 OK") || strpos($headers[0], "302"));
+		return (stripos((string) $headers[0], "200 OK") || strpos((string) $headers[0], "302"));
 	}
 
 
@@ -1966,7 +1966,7 @@ class e_file
 
 		foreach($array as $term)
 		{
-			if(strpos($file, $term) !== false)
+			if(strpos((string) $file, (string) $term) !== false)
 			{
 				return true;
 			}
@@ -2278,9 +2278,9 @@ class e_file
 
 		$remote = false;
 
-		if(strpos($targetFile, 'http') === 0) // remote file.
+		if(strpos((string) $targetFile, 'http') === 0) // remote file.
 		{
-			$tmp = parse_url($targetFile);
+			$tmp = parse_url((string) $targetFile);
 			$targetFile = $tmp['path'];
 			$remote = true;
 			if(!empty($tmp['host']) && ($tmp['host'] === 'localhost' || $tmp['host'] === '127.0.0.1'))
@@ -2289,7 +2289,7 @@ class e_file
 			}
 		}
 
-		$ext = pathinfo($targetFile, PATHINFO_EXTENSION);
+		$ext = pathinfo((string) $targetFile, PATHINFO_EXTENSION);
 
 		$types = $this->getAllowedFileTypes();
 
@@ -2590,7 +2590,7 @@ class e_file
 			if(($class === null && check_class($v['name'])) || (int) $class === (int) $v['name'])
 			{
 			//	$current_perms[$v['name']] = array('type' => $v['type'], 'maxupload' => $v['maxupload']);
-				$a_filetypes = explode(',', $v['type']);
+				$a_filetypes = explode(',', (string) $v['type']);
 				foreach($a_filetypes as $ftype)
 				{
 					$ftype = strtolower(trim(str_replace('.', '', $ftype))); // File extension

--- a/e107_handlers/form_handler.php
+++ b/e107_handlers/form_handler.php
@@ -156,7 +156,7 @@ class e_form
 		{
 			$target = e_REQUEST_URI;	
 		}
-		
+
 		if($method == null)
 		{
 			$method = 'post';
@@ -168,7 +168,7 @@ class e_form
 		{
 			parse_str($options, $options);
 		}
-	
+
 		if(!empty($options['class']))
 		{
 			$class = $options['class'];
@@ -177,13 +177,13 @@ class e_form
 		{
 			$class = "form-horizontal";
 		}
-		
+
 		if(isset($options['autocomplete'])) // leave as isset()
 		{
 			$autoComplete = $options['autocomplete'] ? 'on' : 'off';
 		}
 
-		
+
 		if($method === 'get' && strpos($target,'='))
 		{
 			list($url, $qry) = explode('?', $target);
@@ -214,14 +214,14 @@ class e_form
 		}
 		return $text;	
 	}
-	
+
 	/**
 	 * Close a Form
 	 */
 	public function close()
 	{
 		return '</form>';
-		
+
 	}
 
 
@@ -537,7 +537,7 @@ class e_form
 		$this->_required_string = $string;
 		return $this;
 	}
-	
+
 	// For Comma separated keyword tags.
 
 	/**
@@ -619,7 +619,7 @@ class e_form
 			$text .= '<li class="nav-item'.$active.'"><a class="nav-link'.$active.'" href="#'.$key.'" '.$toggle.'>'.$tab['caption'].'</a></li>';
 			$c++;
 		}
-		
+
 		$text .= '</ul>';
 
 		$tabClass = varset($options['class'],null);
@@ -629,7 +629,7 @@ class e_form
 		$text .= '
 		<!-- Tab panes -->
 		<div class="tab-content '.$tabClass.'">';
-		
+
 		$c=0;
 		$act = $initTab;
 		foreach($array as $key=>$tab)
@@ -649,7 +649,7 @@ class e_form
 			$text .= '<div class="tab-pane'.$fade.$active.'" id="'.$key.'" role="tabpanel">'.$tab['text'].'</div>';
 			$c++;
 		}
-		
+
 		$text .= '
 		</div>';
 
@@ -675,7 +675,7 @@ class e_form
 	{
 		$indicators = '';
 		$controls   = '';
-				
+
 		$act = varset($options['default'], 0);
 
 		$navigation = isset($options['navigation']) ? $options['navigation'] : true;
@@ -708,7 +708,7 @@ class e_form
 
 		$start = '
 		<!-- Carousel -->
-		
+
 		<div' .$this->attributes($att) . '>';
 
 		if($indicate && (count($array) > 1))
@@ -735,7 +735,7 @@ class e_form
 		<div class="carousel-inner">
 		';
 
-		
+
 		$c=0;
 		foreach($array as $key=>$tab)
 		{
@@ -743,16 +743,16 @@ class e_form
 			$label = !empty($tab['label']) ? ' '.$prefix.'label="'.$tab['label'].'"' : '';
 			$inner .= '<div class="carousel-item item'.$active.'" id="'.$key.'"'.$label.'>';
 			$inner .= $tab['text'];
-			
+
 			if(!empty($tab['caption']))
 			{
 				$inner .= '<div class="carousel-caption">'.$tab['caption'].'</div>';
 			}
-			
+
 			$inner .= '</div>';
 			$c++;
 		}
-		
+
 		$inner .= '
 		</div>';
 
@@ -836,12 +836,12 @@ class e_form
 			{
 				$options['class'] = 'tbox input-text span3';
 			}
-			
+
 			elseif($maxlength < 50)
 			{
 				$options['class'] = 'tbox input-text span7';	
 			}
-		
+
 			elseif($maxlength > 99)
 			{
 				 $options['class'] = 'tbox input-text span7';
@@ -1082,9 +1082,9 @@ class e_form
 
 	/*	$options['media'] = '_icon';
 		$options['legacyPath'] = "{e_IMAGE}icons";
-		
+
 		return $this->imagepicker($name, $default, $label, $options);*/
-		
+
 
 	}
 
@@ -1131,7 +1131,7 @@ class e_form
 		}
 
 		$url .= '&iframe=1';
-		
+
 		if(!empty($extras['w']))
 		{
 			$url .= '&w=' . $extras['w'];
@@ -1156,7 +1156,7 @@ class e_form
 		{
 			$url .= '&youtube=1';
 		}
-		
+
 		if(!empty($extras['video']))
 		{
 			$url .= ($extras['video'] == 2) ? '&video=2' : '&video=1';
@@ -1216,31 +1216,31 @@ class e_form
 	{
 		$tp 		= $this->tp;
 		$pref 		= e107::getPref();
-		
+
 		$attr 		= 'aw=' .$pref['im_width']. '&ah=' .$pref['im_height'];
 		$tp->setThumbSize($pref['im_width'],$pref['im_height']);
-		
+
 		$blankImg 	= $tp->thumbUrl(e_IMAGE. 'generic/blank_avatar.jpg',$attr);
 		$localonly 	= true;
 		$idinput 	= $this->name2id($name);
 		$previnput	= $idinput. '-preview';
 		$optioni 	= $idinput. '-options';
-		
-		
+
+
 		$path = (strpos($curVal,'-upload-') === 0) ? '{e_AVATAR}upload/' : '{e_AVATAR}default/';
 		$newVal = str_replace('-upload-','',$curVal);
-	
+
 		$img = (strpos($curVal, '://')!==false) ? $curVal : $tp->thumbUrl($path.$newVal);
-				
+
 		if(!$curVal)
 		{
 			$img = $blankImg;	
 		}
-		
+
 		$parm = $options;
 		$classlocal = (!empty($parm['class'])) ? "class='".$parm['class']." e-expandit  e-tip avatar'" : " class='img-rounded rounded e-expandit e-tip avatar ";
 		$class = (!empty($parm['class'])) ? "class='".$parm['class']." e-expandit '" : " class='img-rounded rounded btn btn-default btn-secondary button e-expandit ";
-	
+
 		if($localonly == true)
 		{
 			$text = "<input class='tbox' style='width:80%' id='{$idinput}' type='hidden' name='image' value='{$curVal}'  />";
@@ -1252,26 +1252,26 @@ class e_form
 			$text .= "<img src='".$img."' id='{$previnput}' style='display:none' />";
 			$text .= '<input ' .$class." type ='button' style='cursor:pointer' size='30' value=\"".LAN_EFORM_002. '"  />';
 		}
-						
+
 		$avFiles = e107::getFile()->get_files(e_AVATAR_DEFAULT, '.jpg|.png|.gif|.jpeg|.JPG|.GIF|.PNG');
-			
+
 		$text .= "\n<div id='{$optioni}' style='display:none;padding:10px' >\n"; //TODO unique id. 
 		$count = 0;
 		if (!empty($pref['avatar_upload']) && FILE_UPLOADS && !empty($options['upload']))
 		{
 				$diz = LAN_USET_32.($pref['im_width'] || $pref['im_height'] ? "\n".str_replace(array('[x]-','[y]'), array($pref['im_width'], $pref['im_height']), LAN_USER_86) : '');
-	
+
 				$text .= "<div style='margin-bottom:10px'>".LAN_USET_26."
 				<input  class='tbox' name='file_userfile[avatar]' type='file' size='47' title=\"{$diz}\" />
 				</div>";
-				
+
 				if(count($avFiles) > 0)
 				{
 					$text .= "<div class='divider'><span>".LAN_EFORM_003. '</span></div>';
 					$count = 1;
 				}
 		}
-		
+
 
 		foreach($avFiles as $fi)
 		{
@@ -1282,7 +1282,7 @@ class e_form
 
 			//TODO javascript CSS selector
 		}
-		
+
 		if($count == 0)
 		{
 			$text .= "<div class='row'>";
@@ -1298,19 +1298,19 @@ class e_form
 
 			$text .= '</div>';
 		}
-		
-		
+
+
 		$text .= '
 		</div>';
-		
+
 		// Used by usersettings.php right now. 
-		
-	
-		
-		
-		
-		
-		
+
+
+
+
+
+
+
 		return $text;
 		/*
 		//TODO discuss and FIXME
@@ -1320,7 +1320,7 @@ class e_form
 				$text .= "<br /><span class='smalltext'>".LAN_SIGNUP_25."</span> <input class='tbox' name='file_userfile[]' type='file' size='40' />
 				<br /><div class='smalltext'>".LAN_SIGNUP_34."</div>";
 			}
-		
+
 			if (false && $pref['photo_upload'] && FILE_UPLOADS)
 			{
 				$text .= "<br /><span class='smalltext'>".LAN_SIGNUP_26."</span> <input class='tbox' name='file_userfile[]' type='file' size='40' />
@@ -1581,11 +1581,11 @@ class e_form
 						dictDefaultMessage: \"".$parms['label']. '",
 				        maxFilesize: ' .(int) ini_get('upload_max_filesize').",
 				         success: function (file, response) {
-				            
+
 				            file.previewElement.classList.add('dz-success');
-				    
+
 				         //   console.log(response);
-				            
+
 				            if(response)
 				            {   
 				                var decoded = jQuery.parseJSON(response);
@@ -1601,14 +1601,14 @@ class e_form
 									$('#".$name_id."_prev').html(decoded.error.message);
 								}				            
 				            }
-				            
+
 				        },
 				        error: function (file, response) {
 				            file.previewElement.classList.add('dz-error');
 				        }
 				    });
 				});
-			
+
 			";
 
 
@@ -1634,7 +1634,7 @@ class e_form
 		$tp = $this->tp;
 		$name_id = $this->name2id($name);
 		unset($label);
-				
+
 		if(is_string($sc_parameters))
 		{
 			if(strpos($sc_parameters, '=') === false)
@@ -1667,24 +1667,24 @@ class e_form
 		{
 			$ret .=	"<input type='hidden' name='{$name}' id='{$name_id}' value='{$default}' style='width:400px' />"; 	
 		}
-		
-		
+
+
 		$default_label 				= ($default) ?: LAN_CHOOSE_FILE;
 		$label 						= "<span id='{$name_id}_prev' class='btn btn-default btn-secondary btn-small'>".basename($default_label). '</span>';
-			
+
 		$sc_parameters['mode'] 		= 'main';
 		$sc_parameters['action'] 	= 'dialog';	
-			
-		
+
+
 	//	$ret .= $this->mediaUrl($cat, $label,$name_id,"mode=dialog&action=list");
 		$ret .= $this->mediaUrl($cat, $label,$name_id,$sc_parameters);
-	
-		
-	
-		
+
+
+
+
 		return $ret;
-	
-		
+
+
 	}
 
 
@@ -1716,15 +1716,15 @@ class e_form
 			parse_str($options,$options);
 		}
 
-		$mode = !empty($options['mode']) ? trim($options['mode']) : 'date'; // OR  'datetime'
+		$mode = !empty($options['mode']) ? trim((string) $options['mode']) : 'date'; // OR  'datetime'
 
 		if(!empty($options['type'])) /** BC Fix. 'type' is @deprecated */
 		{
-			$mode = trim($options['type']);
+			$mode = trim((string) $options['type']);
 		}
 
-		$dateFormat  = !empty($options['format']) ? trim($options['format']) :e107::getPref('inputdate', '%Y-%m-%d');
-		$ampm		 = (preg_match('/%l|%I|%p|%P/',$dateFormat)) ? 'true' : 'false';
+		$dateFormat  = !empty($options['format']) ? trim((string) $options['format']) :e107::getPref('inputdate', '%Y-%m-%d');
+		$ampm		 = (preg_match('/%l|%I|%p|%P/',(string) $dateFormat)) ? 'true' : 'false';
 		$value		 = null;
 		$hiddenValue = null;
 		$useUnix     = (isset($options['return']) && ($options['return'] === 'string')) ? 'false' : 'true';
@@ -1897,7 +1897,7 @@ class e_form
 				$cname = str_replace('_',' ', trim($cname));
 				foreach($users as $u)
 				{
-					$uclass = explode(',',$u['user_class']);
+					$uclass = explode(',',(string) $u['user_class']);
 
 					if(($classList == e_UC_ADMIN) || ($classList == e_UC_MEMBER) || in_array($cls,$uclass))
 					{
@@ -2113,7 +2113,7 @@ class e_form
 	{		
 		$table 	= preg_replace('/\W/', '', $table);
 		$id 	= (int) $id;
-		
+
 		return e107::getRate()->render($table, $id, $options);	
 	}
 
@@ -2125,9 +2125,9 @@ class e_form
 	 */
 	public function like($table, $id, $options=null)
 	{
-		$table 	= preg_replace('/\W/', '', $table);
+		$table 	= preg_replace('/\W/', '', (string) $table);
 		$id 	= (int) $id;
-		
+
 		return e107::getRate()->renderLike($table,$id,$options); 	
 	}
 
@@ -2181,25 +2181,25 @@ class e_form
 		{
 			parse_str($options, $options);
 		}
-		
+
 		$addon = '';
 		$gen = '';
-		
+
 		if(!empty($options['generate']))
 		{
 			$gen = '&nbsp;<a href="#" class="btn btn-default btn-secondary btn-small e-tip" id="Spn_PasswordGenerator" title=" '.LAN_GEN_PW.' " >'.LAN_GENERATE.'</a> ';
-			
+
 			if(empty($options['nomask']))
 			{
 				$gen .= '<a class="btn btn-default btn-secondary btn-small e-tip" href="#" id="showPwd" title=" '.LAN_DISPL_PW.' ">'.LAN_SHOW.'</a><br />';
 			}
 		}
-		
+
 		if(!empty($options['strength']))
 		{
 			$addon .= "<div style='margin-top:4px'><div  class='progress' style='float:left;display:inline-block;width:218px;margin-bottom:0'><div class='progress-bar bar' id='pwdMeter' style='width:0%' ></div></div> <div id='pwdStatus' class='smalltext' style='float:left;display:inline-block;width:150px;margin-left:5px'></span></div>";
 		}
-		
+
 		$options['pattern'] = vartrue($options['pattern'],'[\S].{2,}[\S]');
 		$options['required'] = varset($options['required'], 1);
 		$options['class'] = vartrue($options['class'],'e-password tbox');
@@ -2220,7 +2220,7 @@ class e_form
 		{
 			$options['class'] .= ' form-control';
 		}
-		
+
 		if(!empty($options['size']) && !is_numeric($options['size']))
 		{
 			$options['class'] .= ' input-' . $options['size'];
@@ -2266,7 +2266,7 @@ class e_form
 		{
 			return '';
 		}
-		
+
 		if(defined('BOOTSTRAP') && BOOTSTRAP === 4)
 		{
 			return '<a' . $this->attributes([
@@ -2321,10 +2321,10 @@ class e_form
 			<div style='background-image: url($bar); width: ". (int) $value ."%; height: 14px; float: left;'></div>
 			<div style='background-image: url($barr); width: 5px; height: 14px; float: left;'></div>";
 		}
-			
+
 		$class = vartrue($options['class']);
 		$target = $this->name2id($name);
-		
+
 		$striped = (vartrue($options['btn-label'])) ? ' progress-striped active' : '';	
 
 		if(strpos($value,'/')!==false)
@@ -2357,23 +2357,23 @@ class e_form
    		$text .= $label;
    		 	$text .= '</div>
     	</div>';
-		
+
 		$loading = vartrue($options['loading'], defset('LAN_LOADING', 'Loading'));
-		
+
 		$buttonId = $target.'-start';
-		
-		
-		
+
+
+
 		if(!empty($options['btn-label']))
 		{
 			$interval = vartrue($options['interval'],1000);
 			$text .= '<a id="'.$buttonId.'" data-loading-text="'.$loading.'" data-progress-interval="'.$interval.'" data-progress-target="'.$target.'" data-progress="' . $options['url'] . '" data-progress-mode="'.varset($options['mode'],0).'" data-progress-show="'.varset($options['show'],0).'" data-progress-hide="'.$buttonId.'" class="btn btn-primary e-progress" >'.$options['btn-label'].'</a>';
 			$text .= ' <a data-progress-target="'.$target.'" class="btn btn-danger e-progress-cancel" >'.LAN_CANCEL.'</a>';
 		}
-		
-		
+
+
 		return $text;
-		
+
 	}
 
 
@@ -2454,7 +2454,7 @@ class e_form
 	//	$size = 'input-large';
 		$height = '';
 		$cols = 70;
-		
+
 		switch($size)
 		{
 			case 'tiny':
@@ -2462,17 +2462,17 @@ class e_form
 				$cols = 50;
 			//	$height = "style='height:250px'"; // inline required for wysiwyg
 			break;
-			
-			
+
+
 			case 'small':
 				$rows = '7';
 				$height = "style='height:230px'"; // inline required for wysiwyg
 				$size = 'input-block-level';
 			break;
-						
+
 			case 'medium':
 				$rows = '10';
-               
+
 				$height = "style='height:375px'"; // inline required for wysiwyg
 				$size = 'input-block-level';
 			break;
@@ -2541,7 +2541,7 @@ class e_form
 
 
 		$counter 			= vartrue($options['counter'],false); 
-		
+
 		$ret = "<div class='bbarea {$size}'>
 		<div class='field-spacer'><!-- --></div>\n";
 
@@ -2566,32 +2566,32 @@ class e_form
 					}
 				}
 			}
-		
+
             if (!check_class(e107::getConfig()->get('post_html', e_UC_MAINADMIN))) 
             {
                 $ret .=	e107::getBB()->renderButtons($template,$help_tagid);
             }
-        
+
         }
         else 
         {
             $ret .=	e107::getBB()->renderButtons($template,$help_tagid);
         }
-        
+
 		$ret .=	$this->textarea($name, $value, $rows, $cols, $options, $counter); // higher thank 70 will break some layouts.
-			
+
 		$ret .= "</div>\n";
-		
+
 		$_SESSION['media_category'] = $mediaCat; // used by TinyMce. 
 
 
-	
-		
+
+
 		return $ret;
-		
+
 		// Quick fix - hide TinyMCE links if not installed, dups are handled by JS handler
 		/*
-		
+
 				e107::getJs()->footerInline("
 						if(typeof tinyMCE === 'undefined')
 						{
@@ -2599,8 +2599,8 @@ class e_form
 						}
 				");
 		*/
-		
-		
+
+
 	}
 
 	/**
@@ -2650,13 +2650,13 @@ class e_form
 
 		if(!empty($options['class']))
 		{
-			$snip['class'] = trim($options['class']);
+			$snip['class'] = trim((string) $options['class']);
 			unset($options['class']);
 		}
 
 		if(!empty($options['label']))
 		{
-			$snip['label'] = trim($options['label']);
+			$snip['label'] = trim((string) $options['label']);
 			unset($options['label']);
 		}
 
@@ -2686,9 +2686,9 @@ class e_form
 	{
 		if(!is_array($options))
 		{
-			if(strpos($options, '=')!==false)
+			if(strpos((string) $options, '=')!==false)
 			{
-			 	parse_str($options, $options);
+			 	parse_str((string) $options, $options);
 			}
 			elseif(is_string($options))
 			{
@@ -2701,9 +2701,9 @@ class e_form
 		$labelTitle = '';
 
 		$options = $this->format_options('checkbox', $name, $options);
-		
+
 		$options['checked'] = $checked; //comes as separate argument just for convenience
-		
+
 		$text = '';
 
 
@@ -2764,9 +2764,9 @@ class e_form
 
 		if(!is_array($checked))
 		{
-			$checked = explode(',', $checked);
+			$checked = explode(',', (string) $checked);
 		}
-		
+
 		$text = array();
 
 		$cname = $name;
@@ -2814,7 +2814,7 @@ class e_form
 		}
 
 		return $text;
-		
+
 	}
 
 
@@ -2872,7 +2872,7 @@ class e_form
 	{
 		if(!is_array($field_options))
 		{
-			parse_str($field_options, $field_options);
+			parse_str((string) $field_options, $field_options);
 		}
 		return '
 			<div class="check-block">
@@ -2896,11 +2896,11 @@ class e_form
 
 		if (!is_array($current_value))
 		{
-			$tmp = explode(',', $current_value);
+			$tmp = explode(',', (string) $current_value);
 		}
 
 		$classIndex = abs($classnum);			// Handle negative class values
-		$classSign = (strpos($classnum, '-') === 0) ? '-' : '';
+		$classSign = (strpos((string) $classnum, '-') === 0) ? '-' : '';
 
 		$style = '';
 		$class = $style;
@@ -2946,12 +2946,12 @@ class e_form
 		{
 			parse_str((string) $options, $options);
 		}
-		
+
 		if(is_array($value))
 		{
 			return $this->radio_multi($name, $value, $checked, $options);
 		}
-		
+
 		$labelFound = vartrue($options['label']);
 		unset($options['label']); // label attribute not valid in html5
 
@@ -3154,15 +3154,15 @@ class e_form
 	 */
 	private function radio_multi($name, $elements, $checked, $options=array(), $help = null)
 	{
-		
-		
-		
+
+
+
 		/* // Bootstrap Test. 
 		 return'    <label class="checkbox">
     <input type="checkbox" value="">
     Option one is this and that—be sure to include why its great
     </label>
-     
+
     <label class="radio">
     <input type="radio" name="optionsRadios" id="optionsRadios1" value="option1" checked>
     Option one is this and that—be sure to include why its great
@@ -3172,10 +3172,10 @@ class e_form
     Option two can be something else and selecting it will deselect option one
     </label>';
 		*/
-		
-		
+
+
 		$text = array();
-				
+
 		if(is_string($elements))
 		{
 			parse_str($elements, $elements);
@@ -3190,26 +3190,26 @@ class e_form
 			$help = "<div class='field-help'>".$options['help']. '</div>';
 			unset($options['help']);
 		}
-		
+
 		foreach ($elements as $value => $label)
 		{
 			$label = defset($label, $label);
-			
+
 			$helpLabel = (is_array($help)) ? vartrue($help[$value]) : $help;
-		
+
 		// Bootstrap Style Code - for use later. 	
 			$options['label'] = $label;
 			$options['help'] = $helpLabel;
 			$text[] = $this->radio($name, $value, (string) $checked === (string) $value, $options);
-	
+
 		//	$text[] = $this->radio($name, $value, (string) $checked === (string) $value)."".$this->label($label, $name, $value).(isset($helpLabel) ? "<div class='field-help'>".$helpLabel."</div>" : '');
 		}
-		
+
 	//	if($multi_line === false)
 	//	{
 		//	return implode("&nbsp;&nbsp;", $text);
 	//	}
-		
+
 		// support of UI owned 'newline' parameter
 		if(!varset($options['sep']) && vartrue($options['newline']))
 		{
@@ -3218,7 +3218,7 @@ class e_form
 		$separator = varset($options['sep'], ' ');
 	//	return print_a($text,true);
 		return implode($separator, $text).$help;
-		
+
 		// return implode("\n", $text);
 		//XXX Limiting markup. 
 	//	return "<div class='field-spacer' style='width:50%;float:left'>".implode("</div><div class='field-spacer' style='width:50%;float:left'>", $text)."</div>";
@@ -3293,7 +3293,7 @@ class e_form
 
 
 		$options = $this->format_options('select', $name, $options);
-	
+
 		return "<select name='{$name}'".$this->get_attributes($options, $name). '>';
 	}
 
@@ -3359,7 +3359,7 @@ class e_form
 			$diz = is_string($defaultBlank) ? $defaultBlank : '&nbsp;';
 			$text .= $this->option($diz, '');
 		}
-		
+
 		if(!empty($options['useValues'])) // use values as keys.
 		{
 			$new = array();
@@ -3373,11 +3373,11 @@ class e_form
 		$text .= $this->option_multi($option_array, $selected, $options)."\n".$this->select_close();
 		return $text;
 	}
-	
-	
-	
-	
-	
+
+
+
+
+
 
 	/**
 	 * Universal Userclass selector - checkboxes, dropdown, everything. 
@@ -3429,8 +3429,8 @@ class e_form
 		}
 
 	}
-	
-	
+
+
 	/**
 	 * Renders a generic search box. If $filter has values, a filter box will be included with the options provided. 
 	 * 
@@ -3438,26 +3438,26 @@ class e_form
 	public function search($name, $searchVal, $submitName, $filterName='', $filterArray=false, $filterVal=false)
 	{
 		$tp = $this->tp;
-		
+
 		$text = '<span class="input-append input-group e-search">
     		'.$this->text($name, $searchVal,20,'class=search-query&placeholder='.LAN_SEARCH.'&hellip;').'
    			 <span class="input-group-btn"><button class="btn btn-primary" name="'.$submitName.'" type="submit">'.$tp->toGlyph('fa-search').'</button></span>
     	</span>';
-		
-		
-		
+
+
+
 		if(is_array($filterArray))
 		{
 			$text .= $this->select($filterName, $filterArray, $filterVal);
 		}
-		
+
 	//	$text .= $this->admin_button($submitName,LAN_SEARCH,'search');
-		
+
 		return $text;
-		
+
 		/*
 		$text .= 
-		
+
 						<select style="display: none;" data-original-title="Filter the results below" name="filter_options" id="filter-options" class="e-tip tbox select filter" title="">
 							<option value="">Display All</option>
 							<option value="___reset___">Clear Filter</option>
@@ -3469,14 +3469,14 @@ class e_form
 
 						</select><div class="btn-group bootstrap-select e-tip tbox select filter"><button id="filter-options" class="btn dropdown-toggle clearfix" data-toggle="dropdown" data-bs-toggle="dropdown"><span class="filter-option pull-left">Display All</span>&nbsp;<span class="caret"></span></button><ul style="max-height: none; overflow-y: auto;" class="dropdown-menu" role="menu"><li rel="0"><a tabindex="-1" class="">Display All</a></li><li rel="1"><a tabindex="-1" class="">Clear Filter</a></li><li rel="2"><dt class="optgroup-div">Filter by&nbsp;Category</dt><a tabindex="-1" class="opt ">General</a></li><li rel="3"><a tabindex="-1" class="opt ">Misc</a></li><li rel="4"><a tabindex="-1" class="opt ">Test 3</a></li></ul></div>
 						<div class="e-autocomplete"></div>
-						
-						
+
+
 			<button type="submit" name="etrigger_filter" value="etrigger_filter" id="etrigger-filter" class="btn filter e-hide-if-js btn-primary"><span>Filter</span></button>
-		
+
 						<span class="indicator" style="display: none;">
 							<img src="/e107_2.0/e107_images/generic/loading_16.gif" class="icon action S16" alt="Loading...">
 						</span>	
-		
+
 		*/
 	}
 
@@ -3498,7 +3498,7 @@ var_dump($uc_options);
 var_dump($select_options);*/
 
 
-		if(!empty($select_options['multiple']) && substr($name,-1) !== ']')
+		if(!empty($select_options['multiple']) && substr((string) $name,-1) !== ']')
 		{
 			$name .= '[]';
 		}
@@ -3553,14 +3553,14 @@ var_dump($select_options);*/
 	public function _uc_select_cb($treename, $classnum, $current_value, $nest_level)
 	{
 		$classIndex = abs($classnum);			// Handle negative class values
-		$classSign = (strpos($classnum, '-') === 0) ? '-' : '';
-		
+		$classSign = (strpos((string) $classnum, '-') === 0) ? '-' : '';
+
 		if($classnum == e_UC_BLANK)
 		{
 			return $this->option('&nbsp;', '');
 		}
 
-		$tmp = explode(',', $current_value);
+		$tmp = explode(',', (string) $current_value);
 		if($nest_level == 0)
 		{
 			$prefix = '';
@@ -3879,9 +3879,9 @@ var_dump($select_options);*/
 		{
 		//	$options = $this->format_options('admin_button', $name, $options);
 			$options['class'] = vartrue($options['class']);
-			
+
 			$align = vartrue($options['align'],'left');
-					
+
 			$text = '<div class="btn-group pull-'.$align.'">
 			    <a class="btn dropdown-toggle '.$options['class'].'" data-toggle="dropdown" data-bs-toggle="dropdown" href="#">
 			    '.($label ?: LAN_NO_LABEL_PROVIDED).'
@@ -3889,23 +3889,23 @@ var_dump($select_options);*/
 			    </a>
 			    <ul class="dropdown-menu">
 			    ';
-			
+
 			foreach($value as $k=>$v)
 			{
 				$text .= '<li class="dropdown-item">'.$v.'</li>';
 			}
-			
+
 			$text .= '
 			    </ul>
 			    </div>';
-			
+
 			return $text;	
 		}			
-				
 
-		
+
+
 		return $this->admin_button($name, $value, $action, $label, $options);
-		
+
 	}
 
 	/**
@@ -3929,7 +3929,7 @@ var_dump($select_options);*/
 		}
 
 		if(!is_array($array)){ return; }
-		
+
 		$opt = array();
 
 		if(!empty($array['home']['icon'])) // custom home icon.
@@ -3943,7 +3943,7 @@ var_dump($select_options);*/
 			$homeIcon = ($this->_fontawesome) ? $this->tp->toGlyph('fa-home.glyph') : $fallbackIcon;
 		}
 
-		
+
 		$opt[] = "<a href='".e_HTTP."' aria-label='Homepage'>".$homeIcon. '</a>'; // Add Site-Pref to disable?
 
 		$text = "\n<ul class=\"breadcrumb\">\n";
@@ -3960,21 +3960,21 @@ var_dump($select_options);*/
 			$ret .= !empty($val['url']) ? "<a href='".$val['url']."'>" : '';
 			$ret .= vartrue($val['text']);
 			$ret .= !empty($val['url']) ? '</a>' : '';
-			
+
 			if($ret != '')
 			{
 				$opt[] = $ret;
 			}	
 		}
-	
+
 		$sep = (deftrue('BOOTSTRAP')) ? '' : "<span class='divider'>/</span>";
-	
+
 		$text .= implode($sep."</li>\n<li class='breadcrumb-item'>",$opt);
-	
+
 		$text .= "</li>\n</ul>";
-		
+
 	//	return print_a($opt,true);
-	
+
 		return $text;	
 
 	}
@@ -4307,7 +4307,7 @@ var_dump($select_options);*/
 					break;
 
 				default:
-					if(strpos($option,'data-') === 0)
+					if(strpos((string) $option,'data-') === 0)
 					{
 						$ret .= $this->attributes([$option => $optval]);
 					}
@@ -4315,7 +4315,7 @@ var_dump($select_options);*/
 			}
 
 
-				
+
 		}
 
 		return $ret;
@@ -4343,7 +4343,7 @@ var_dump($select_options);*/
 
 		//format data first
 		$name = trim($this->name2id($name), '-');
-		$value = trim(preg_replace('#[^a-zA-Z0-9\-]#', '-', $value), '-');
+		$value = trim((string) preg_replace('#[^a-zA-Z0-9\-]#', '-', (string) $value), '-');
 		//$value = trim(preg_replace('#[^a-z0-9\-]#/i','-', $value), '-');		// This should work - but didn't for me!
 		$value = trim(str_replace('/', '-', $value), '-');                    // Why?
 		if (!$id_value && is_numeric($value))
@@ -4394,7 +4394,7 @@ var_dump($select_options);*/
 	 */
 	public function name2id($name)
 	{
-		$name = strtolower($name);
+		$name = strtolower((string) $name);
 		$name = $this->tp->toASCII($name);
 		return rtrim(str_replace(array('[]', '[', ']', '_', '/', ' ','.', '(', ')', '::', ':', '?','=',"'",','), array('-', '-', '', '-', '-', '-', '-','','','-','','-','-','',''), $name), '-');
 	}
@@ -4416,15 +4416,15 @@ var_dump($select_options);*/
 		}
 
 		$def_options = $this->_default_options($type);
-	
+
 
 		if(is_array($user_options))
 		{
 			$user_options['name'] = $name; //required for some of the automated tasks
-			
+
 			foreach (array_keys($user_options) as $key)
 			{
-				if(!isset($def_options[$key]) && strpos($key,'data-') !== 0)
+				if(!isset($def_options[$key]) && strpos((string) $key,'data-') !== 0)
 				{
 					unset($user_options[$key]); // data-xxxx exempt //remove it?
 				}
@@ -4434,7 +4434,7 @@ var_dump($select_options);*/
 		{
 			$user_options = array('name' => $name); //required for some of the automated tasks	
 		}
-		
+
 		return array_merge($def_options, $user_options);
 	}
 
@@ -4564,17 +4564,17 @@ var_dump($select_options);*/
 			}
 		}
 
-		
+
 	// navbar-header nav-header
 	// navbar-header nav-header
 		$text = '<div class="col-selection dropdown e-tip pull-right float-right" data-placement="left">
     <a class="dropdown-toggle" title="'.LAN_EFORM_008.'" data-toggle="dropdown" data-bs-toggle="dropdown" href="#"><i class="icon fas fa-sliders"></i></a>
     <ul class="list-group dropdown-menu  col-selection e-noclick" role="menu" aria-labelledby="dLabel">
-   
+
     <li class="list-group-item "><h5 class="list-group-item-heading">'.LAN_EFORM_009.'</h5></li>
     <li class="list-group-item col-selection-list">
      <ul class="nav scroll-menu" >';
-		
+
         unset($columnsArray['options'], $columnsArray['checkboxes']);
 
 		foreach($columnsArray as $key => $fld)
@@ -4621,12 +4621,12 @@ var_dump($select_options);*/
 				 </li>
 				</ul>
 			</div>';
-			
+
 	//	$text .= "</div></div>";
 
 		$text .= '';
-	
-	
+
+
 	/*
 	$text = '<div class="dropdown">
     <a class="dropdown-toggle" data-toggle="dropdown" data-bs-toggle="dropdown" href="#"><b class="caret"></b></a>
@@ -4678,12 +4678,12 @@ var_dump($select_options);*/
 	{
         $text = '';
 
-        $querypattern = strip_tags($querypattern);
+        $querypattern = strip_tags((string) $querypattern);
         if(!$requeststr)
         {
 	        $requeststr = rawurldecode(e_QUERY);
         }
-        $requeststr = strip_tags($requeststr);
+        $requeststr = strip_tags((string) $requeststr);
 
 		// Recommended pattern: mode=list&field=[FIELD]&asc=[ASC]&from=[FROM]
 		if(strpos($querypattern,'&')!==FALSE)
@@ -4779,15 +4779,15 @@ var_dump($select_options);*/
 	public function renderHooks($data)
 	{
 		$hooks = e107::getEvent()->triggerHook($data);
-				
+
 		$text = '';
-		
+
 		if(!empty($hooks))
 		{
 			foreach($hooks as $plugin => $hk)
 			{
 				$text .= "\n\n<!-- Hook : {$plugin} -->\n";
-				
+
 				if(!empty($hk))
 				{
 					foreach($hk as $hook)
@@ -4799,17 +4799,17 @@ var_dump($select_options);*/
 						$text .= "</td>\n\t\t\t</tr>\n";
 					}
 
-					
+
 				}
 			}
 		}
-		
+
 		return $text;			
 	}
 
 
 
-			
+
 	/**
 	 * Render Related Items for the current page/news-item etc. 
 	 * @param array $parm : comma separated list. ie. plugin folder names.
@@ -4819,7 +4819,7 @@ var_dump($select_options);*/
 	 */
 	public function renderRelated($parm, $tags, $curVal, $template=null) //XXX TODO Cache!
 	{
-		
+
 		if(empty($tags))
 		{
 			return;	
@@ -4833,7 +4833,7 @@ var_dump($select_options);*/
 		{
 			$parm = array('limit' => 5);
 		}
-		
+
 		if(!varset($parm['types']))
 		{
 			$parm['types'] = 'news';	
@@ -4851,30 +4851,30 @@ var_dump($select_options);*/
 			$TEMPLATE = $template;
 		}
 
-		
-			
+
+
 		$tp = $this->tp;
-			
-		$types = explode(',',$parm['types']);
+
+		$types = explode(',',(string) $parm['types']);
 		$list = array();
-		
+
 		$head = $tp->parseTemplate($TEMPLATE['start']);
 
 		foreach($types as $plug)
 		{
-		
+
 			if(!$obj = e107::getAddon($plug,'e_related'))
 			{
 				continue;
 			}
-			
+
 			$parm['current'] = (int) varset($curVal[$plug]);
 
 
 
-		
+
 			$tmp = $obj->compile($tags,$parm);	
-		
+
 			if(is_array($tmp) && count($tmp))
 			{
 				foreach($tmp as $val)
@@ -4893,7 +4893,7 @@ var_dump($select_options);*/
 				}
 			}		
 		}
-		
+
 		if(count($list))
 		{
 			$text = "<div class='e-related clearfix hidden-print'>".$head.implode("\n",$list).$tp->parseTemplate($TEMPLATE['end']). '</div>';
@@ -4901,7 +4901,7 @@ var_dump($select_options);*/
 			return e107::getRender()->tablerender($caption, $text, 'related', true);
 
 		}
-		
+
 	}		
 
 
@@ -5070,7 +5070,7 @@ var_dump($select_options);*/
 	public function renderInline($dbField, $pid, $fieldName, $curVal, $linkText, $type='text', $array=null, $options=array())
 	{
 		$jsonArray = array();
-				
+
 		if(!empty($array))
 		{
 			foreach($array as $k=>$v)
@@ -5080,8 +5080,8 @@ var_dump($select_options);*/
 		}
 
 		$source = $this->tp->toJSON($jsonArray);
-		
-		$mode = preg_replace('/[\W]/', '', vartrue($_GET['mode']));
+
+		$mode = preg_replace('/[\W]/', '', (string) vartrue($_GET['mode']));
 
 		if(!isset($options['url']))
 		{
@@ -5258,7 +5258,7 @@ var_dump($select_options);*/
 
 		if(!empty($parms['sort']) && empty($attributes['grid']))
 		{
-			$mode = preg_replace('/[\W]/', '', vartrue($_GET['mode']));
+			$mode = preg_replace('/[\W]/', '', (string) vartrue($_GET['mode']));
 			$from = (int) vartrue($_GET['from'], 0);
 			$text .= "<a" . $this->attributes([
 					'class'       => 'e-sort sort-trigger btn btn-default',
@@ -5313,7 +5313,7 @@ var_dump($select_options);*/
 			{
 				$att['data-modal-submit'] = 'true';
 			}
-			
+
 			$text .= '<a' . $this->attributes($att) . '>' . $editIconDefault . '</a>';
 		}
 
@@ -5369,7 +5369,7 @@ var_dump($select_options);*/
 		{
 			if(!is_array($attributes['readParms']))
 			{
-				parse_str($attributes['readParms'], $attributes['readParms']);
+				parse_str((string) $attributes['readParms'], $attributes['readParms']);
 			}
 			$parms = $attributes['readParms'];
 		}
@@ -5391,7 +5391,7 @@ var_dump($select_options);*/
 		{
 			$parms['sort'] = true;
 		} // attribute alias
-		
+
 		if(!empty($parms['type'])) // Allow the use of a different 'type' in readMode. eg. type=method.
 		{
 			$attributes['type'] = $parms['type'];	
@@ -5403,7 +5403,7 @@ var_dump($select_options);*/
 		switch($field) // special fields
 		{
 			case 'options':
-				
+
 				if(!empty($attributes['type']) && ($attributes['type'] === 'method')) // Allow override with 'options' function.
 				{
 					$attributes['mode'] = 'read';
@@ -5411,7 +5411,7 @@ var_dump($select_options);*/
 					{
 						$method = $attributes['method'];
 						return $this->$method($parms, $value, $id, $attributes);
-						
+
 					}
 					elseif(method_exists($this, 'options'))
 					{
@@ -5555,12 +5555,12 @@ var_dump($select_options);*/
 				//	$value = vartrue($parms['pre']).vartrue($parms[$value]).vartrue($parms['post']);
 				//	break; 
 			//	}
-				
+
 				// NEW - multiple (array values) support
 				// FIXME - add support for multi-level arrays (option groups)
 				if(!is_array($attributes['writeParms']))
 				{
-					parse_str($attributes['writeParms'], $attributes['writeParms']);
+					parse_str((string) $attributes['writeParms'], $attributes['writeParms']);
 				}
 				$wparms = $attributes['writeParms'];
 
@@ -5582,16 +5582,16 @@ var_dump($select_options);*/
 				$opts = $wparms['__options'];
 				unset($wparms['__options']);
 				$_value = $value;
-				
+
 				if($attributes['type'] === 'checkboxes' || $attributes['type'] === 'comma')
 				{
 					$opts['multiple'] = true;	
 				}
-			
+
 				if(!empty($opts['multiple']))
 				{
 					$ret = array();
-					$value = is_array($value) ? $value : explode(',', $value);
+					$value = is_array($value) ? $value : explode(',', (string) $value);
 					foreach ($value as $v)
 					{
 						if(isset($wparms[$v]))
@@ -5612,15 +5612,15 @@ var_dump($select_options);*/
 					}
 					$value = $ret;
 				}
-			
+
 				$value = ($value ? vartrue($parms['pre']).defset($value, $value).vartrue($parms['post']) : '');
-				
+
 				if(empty($attributes['noedit']) && !empty($parms['editable']) && empty($parms['link'])) // avoid bad markup, better solution coming up
 				{				
 					$xtype = ($attributes['type'] === 'dropdown') ? 'select' : 'checklist';
 					$value = $this->renderInline($field, $id, $attributes['title'], $_value, $value, $xtype, $wparms);
 				}
-								
+
 				// return ;
 			break;
 
@@ -5635,7 +5635,7 @@ var_dump($select_options);*/
 
 				if(!is_array($attributes['writeParms']))
 				{
-					parse_str($attributes['writeParms'], $attributes['writeParms']);
+					parse_str((string) $attributes['writeParms'], $attributes['writeParms']);
 				}
 
 				if(!empty($attributes['writeParms']['optArray']))
@@ -5708,7 +5708,7 @@ var_dump($select_options);*/
 
 					$tpl = $this->text($field, $value, $maxlength, $options);
 
-					$mode = preg_replace('/[\W]/', '', vartrue($_GET['mode']));
+					$mode = preg_replace('/[\W]/', '', (string) vartrue($_GET['mode']));
 					$value = "<a" . $this->attributes([
 							'id'             => "{$field}_{$id}",
 							'class'          => 'e-tip e-editable editable-click editable-tags',
@@ -5768,7 +5768,7 @@ var_dump($select_options);*/
 					}
 				}
 
-					
+
 				if(empty($attributes['noedit']) && !empty($parms['editable']) && empty($parms['link'])) // avoid bad markup, better solution coming up
 				{
 					$value = $this->renderInline($field,$id,$attributes['title'],$value, $value);
@@ -5776,16 +5776,16 @@ var_dump($select_options);*/
 
 				$value = vartrue($parms['pre']).$value.vartrue($parms['post']);
 			break;
-            
-            
+
+
 
 			case 'bbarea':
 			case 'textarea':
-				
-				
+
+
 				if($attributes['type'] === 'textarea' && !vartrue($attributes['noedit']) && vartrue($parms['editable']) && !vartrue($parms['link'])) // avoid bad markup, better solution coming up
 				{
-					return $this->renderInline($field,$id,$attributes['title'],$value,substr($value,0,50). '...','textarea'); //FIXME.
+					return $this->renderInline($field,$id,$attributes['title'],$value,substr((string) $value,0,50). '...','textarea'); //FIXME.
 				}
 
 
@@ -5808,14 +5808,14 @@ var_dump($select_options);*/
 						$dataAttr = "data-text-more='" . LAN_MORE . "' data-text-less='" . LAN_LESS . "'";
 						$ttl = $expand."<button class='btn btn-default btn-secondary btn-xs btn-mini pull-right' {$dataAttr}>" . LAN_MORE . '</button>';
 					}
-					
+
 					$expands = '<a href="#'.$elid.'-expand" class="e-show-if-js e-expandit e-expandit-inline">'.defset($ttl, $ttl). '</a>';
 				}
 
 				$oldval = $value;
 				if(!empty($parms['truncate']))
 				{
-					$oldval = strip_tags($value);
+					$oldval = strip_tags((string) $value);
 					$value = $oldval;
 					$value = $tp->text_truncate($value, $parms['truncate'], '');
 					$toexpand = $value != $oldval;
@@ -5831,17 +5831,17 @@ var_dump($select_options);*/
 					$value .= '<span class="expand-c" style="display: none" id="'.$elid.'-expand"><span>'.str_replace($value,'',$oldval).'</span></span>';
 					$value .= varset($expands); 	// 'More..' button. Keep it at the bottom so it does't cut the sentence.
 				}
-				
-				
-				
+
+
+
 			break;
 
 			case 'icon':
 
 				$value = "<span class='icon-preview'>".$tp->toIcon($value,$parms). '</span>';
-				
+
 			break;
-			
+
 			case 'file':
 				if(!empty($parms['base']))
 				{
@@ -5851,7 +5851,7 @@ var_dump($select_options);*/
 				{
 					$url = $this->tp->replaceConstants($value, 'full');
 				}
-				$name = basename($value);
+				$name = basename((string) $value);
 				$value = '<a href="'.$url.'" title="Direct link to '.$name.'" rel="external">'.$name.'</a>';
 			break;
 
@@ -5872,27 +5872,27 @@ var_dump($select_options);*/
 
 				if($value)
 				{
-					
-					if(strpos($value, ',')!==false)
+
+					if(strpos((string) $value, ',')!==false)
 					{
-						$tmp = explode(',',$value);
+						$tmp = explode(',',(string) $value);
 						$value = $tmp[0];
 						unset($tmp);	
 					}		
 
-					if(empty($parms['thumb_aw']) && !empty($parms['thumb']) && strpos($parms['thumb'],'x')!==false)
+					if(empty($parms['thumb_aw']) && !empty($parms['thumb']) && strpos((string) $parms['thumb'],'x')!==false)
 					{
-						list($parms['thumb_aw'],$parms['thumb_ah']) = explode('x',$parms['thumb']);
+						list($parms['thumb_aw'],$parms['thumb_ah']) = explode('x',(string) $parms['thumb']);
 					}
 
 					$vparm = array('thumb'=>'tag','w'=> vartrue($parms['thumb_aw'],'80'));
-					
+
 					if($video = $tp->toVideo($value,$vparm))
 					{
 						return $video;
 					}
 
-					$fileOnly = basename($value);
+					$fileOnly = basename((string) $value);
 
 					// Not an image but a file.  (media manager)  
 					if(!preg_match("/\.(png|jpg|jpeg|gif|webp|PNG|JPG|JPEG|GIF|WEBP)/", $fileOnly) && strpos($fileOnly,'.') !== false)
@@ -5905,7 +5905,7 @@ var_dump($select_options);*/
 					}
 
 
-					
+
 					if(!empty($parms['thumb']))
 					{
 
@@ -5913,13 +5913,13 @@ var_dump($select_options);*/
 						{
 							$createLink = false;
 						}
-						
+
 						// Support readParms example: thumb=200x300 (wxh)
-						if(strpos($parms['thumb'],'x')!==false)
+						if(strpos((string) $parms['thumb'],'x')!==false)
 						{
-							list($thparms['w'],$thparms['h']) = explode('x',$parms['thumb']); 	
+							list($thparms['w'],$thparms['h']) = explode('x',(string) $parms['thumb']); 	
 						}
-						
+
 						// Support readParms example: thumb={width}
 						if(!isset($parms['w']) && is_numeric($parms['thumb']) && $parms['thumb'] != '1')
 						{
@@ -5933,7 +5933,7 @@ var_dump($select_options);*/
 						if(!empty($parms['legacyPath']))
 						{
 							$thparms['legacy'] = $parms['legacyPath'];
-							$parms['pre'] = rtrim($parms['legacyPath'],'/').'/';
+							$parms['pre'] = rtrim((string) $parms['legacyPath'],'/').'/';
 						}
 					//	return print_a($thparms,true); 
 
@@ -5998,7 +5998,7 @@ var_dump($select_options);*/
 				$firstItem = !empty($value[0]['path']) ? $value[0]['path'] : null; // display first item.
 				return e107::getMedia()->previewTag($firstItem, $parms);
 			break;
-			
+
 			case 'files':
 
 				if(!empty($value))
@@ -6026,11 +6026,11 @@ var_dump($select_options);*/
 
 
 			break; 
-			
+
 			case 'datestamp':
 				$value = $value ? e107::getDate()->convert_date($value, vartrue($parms['mask'], 'short')) : '';
 			break;
-			
+
 			case 'date':
 
 				if(empty($attributes['noedit']) && !empty($parms['editable']) && empty($parms['link'])) // avoid bad markup, better solution coming up
@@ -6063,7 +6063,7 @@ var_dump($select_options);*/
 
 			case 'userclasses':
 			//	return $value;
-				$classes = explode(',', $value);
+				$classes = explode(',', (string) $value);
 
 				$uv = array();
 				foreach ($classes as $cid)
@@ -6096,7 +6096,7 @@ var_dump($select_options);*/
 				}
 
 				unset($parms['classlist']);
-				
+
 			break;
 
 			/*case 'user_name':
@@ -6105,7 +6105,7 @@ var_dump($select_options);*/
 			case 'user_customtitle':
 			case 'user_email':*/
 			case 'user':
-				
+
 				/*if(is_numeric($value))
 				{
 					$value = e107::user($value);
@@ -6179,7 +6179,7 @@ var_dump($select_options);*/
 					//	$tpl = $this->userpicker($field, '', $ttl, $id, array('id' => $fieldID, 'selectize' => array('e_editable' => $eEditableID)));
 
 					$tpl = $this->userpicker($fieldID, array('user_id' => $id, 'user_name' => $ttl), array('id' => $fieldID, 'inline' => $eEditableID));
-					$mode = preg_replace('/[\W]/', '', vartrue($_GET['mode']));
+					$mode = preg_replace('/[\W]/', '', (string) vartrue($_GET['mode']));
 					$value = "<a" . $this->attributes([
 							'id'         => $eEditableID,
 							'class'      => 'e-tip e-editable editable-click editable-userpicker',
@@ -6195,7 +6195,7 @@ var_dump($select_options);*/
 							'href'       => '#'
 						]) . ">" . $ttl . '</a>';
 				}
-				
+
 			break;
 
 			/**
@@ -6233,14 +6233,14 @@ var_dump($select_options);*/
 
 						$false = ($value === '') ? '&square;' : '&#10799;'; // "&cross;";
 					}
-					
+
 					$true = varset($parms['true'], '&#10004;' /*'&check;'*/); // custom representation for 'true'. (supports font-awesome when set by css)
 
 			//		$true = '&#xf00c';
 			//		$false = '\f00d';
 
 					$value = (int) $value;
-							
+
 					$wparms = (vartrue($parms['reverse'])) ? array(0=>$true, 1=>$false) : array(0=>$false, 1=>$true);
 					$dispValue = $wparms[$value];
 					$styleClass = '';
@@ -6256,7 +6256,7 @@ var_dump($select_options);*/
 					}
 					return $this->renderInline($field, $id, $attributes['title'], $value, $dispValue, 'select', $wparms, array('class'=>'e-editable-boolean '.$styleClass));
 				}
-				
+
 				if(!empty($parms['reverse']))
 				{
 					$value = ($value) ? $false : $true;
@@ -6265,7 +6265,7 @@ var_dump($select_options);*/
 				{
 					$value = $value ? $true : $false;
 				}	
-							
+
 			break;
 
 			case 'url':
@@ -6322,9 +6322,9 @@ var_dump($select_options);*/
 
 				$meth = (!empty($attributes['method'])) ? $attributes['method'] : $method;
 
-				if(strpos($meth,'::')!==false)
+				if(strpos((string) $meth,'::')!==false)
 				{
-					list($className,$meth) = explode('::', $meth);
+					list($className,$meth) = explode('::', (string) $meth);
 					$cls = new $className();
 				}
 				else
@@ -6348,8 +6348,8 @@ var_dump($select_options);*/
 					// Inline Editing.  
 				if(empty($attributes['noedit']) && !empty($parms['editable'])) // avoid bad markup, better solution coming up
 				{
-					
-					$mode = preg_replace('/[\W]/', '', vartrue($_GET['mode']));
+
+					$mode = preg_replace('/[\W]/', '', (string) vartrue($_GET['mode']));
 					$methodParms = call_user_func_array(array($this, $meth), array($_value, 'inline', $parms));
 
 					$inlineParms = (!empty($methodParms['inlineParms'])) ? $methodParms['inlineParms'] : null;
@@ -6366,21 +6366,21 @@ var_dump($select_options);*/
 					{
 						switch ($attributes['inline']) 
 						{
-					
+
 							case 'checklist':
 								$xtype = 'checklist';		
 							break;
-							
+
 							case 'select':
 							case 'dropdown':
 								$xtype = 'select';		
 							break;
-							
+
 							case 'textarea':
 								$xtype = 'textarea';		
 							break;
-							
-							
+
+
 							default:
 								$xtype = 'text';
 								 $methodParms = null;
@@ -6394,7 +6394,7 @@ var_dump($select_options);*/
 					}
 
 				}
-							
+
 			break;
 
 			case 'hidden':
@@ -6405,26 +6405,26 @@ var_dump($select_options);*/
 
 				return '';
 			break;
-			
+
 			case 'language': // All Known Languages. 
-					
+
 				if(!empty($value))
 				{
 					$_value = $value;
-					if(strlen($value) === 2)
+					if(strlen((string) $value) === 2)
 					{
 						$value = e107::getLanguage()->convert($value);
 					}
 				}
-				
+
 				if(!vartrue($attributes['noedit']) && vartrue($parms['editable'])) 
 				{
 					$wparms = e107::getLanguage()->getList();
 					return $this->renderInline($field, $id, $attributes['title'], $_value, $value, 'select', $wparms);	
 				}	
-				
+
 				return $value;
-				
+
 			break;
 
 			case 'lanlist': // installed languages. 
@@ -6434,18 +6434,18 @@ var_dump($select_options);*/
 				{
 					if(!is_array($attributes['writeParms']))
 					{
-						parse_str($attributes['writeParms'], $attributes['writeParms']);
+						parse_str((string) $attributes['writeParms'], $attributes['writeParms']);
 					}
 					$wparms = $attributes['writeParms'];
 					if(!is_array(varset($wparms['__options'])))
 					{
-						parse_str($wparms['__options'], $wparms['__options']);
+						parse_str((string) $wparms['__options'], $wparms['__options']);
 					}
 					$opts = $wparms['__options'];
 					if($opts['multiple'])
 					{
 						$ret = array();
-						$value = is_array($value) ? $value : explode(',', $value);
+						$value = is_array($value) ? $value : explode(',', (string) $value);
 						foreach ($value as $v)
 						{
 							if(isset($options[$v]))
@@ -6571,7 +6571,7 @@ var_dump($select_options);*/
 
 			return $ret;
 		}
-		
+
 		// FIXME standard - writeParams['__options'] is introduced for list elements, bundle adding to writeParms is non reliable way
 		$writeParamsOptionable =  array('dropdown', 'comma', 'radio', 'lanlist', 'language', 'user');
 		$writeParamsDisabled =  array('layouts', 'templates', 'userclass', 'userclasses');
@@ -6589,7 +6589,7 @@ var_dump($select_options);*/
 				$parms['required'] = 1;	
 			}
 		}
-		
+
 		// FIXME it breaks all list like elements - dropdowns, radio, etc
 		if(!empty($required_data[3]) || !empty($attributes['pattern'])) // HTML5 'pattern' attribute
 		{
@@ -6616,7 +6616,7 @@ var_dump($select_options);*/
 		}
 
 		$this->renderElementTrigger($key, $value, $parms, $required_data, $id);
-		
+
 		switch($attributes['type'])
 		{
 			case 'number':
@@ -6655,10 +6655,10 @@ var_dump($select_options);*/
 				$maxlength = vartrue($parms['maxlength'], 255);
 				unset($parms['maxlength']);
 				$ret =  vartrue($parms['pre']).$this->url($key, $value, $maxlength, $parms).vartrue($parms['post']); // vartrue($parms['__options']) is limited. See 'required'=>true
-		
+
 			break; 
 		//	case 'email':
-		
+
 			case 'password': // encrypts to md5 when saved. 
 				$maxlength = vartrue($parms['maxlength'], 255);
 				unset($parms['maxlength']);
@@ -6668,7 +6668,7 @@ var_dump($select_options);*/
 					$parms['required'] = false;
 				}
 				$ret =  vartrue($parms['pre']).$this->password($key, $value, $maxlength, $parms).vartrue($parms['post']); // vartrue($parms['__options']) is limited. See 'required'=>true
-			
+
 			break; 
 
 			case 'text':
@@ -6730,9 +6730,9 @@ var_dump($select_options);*/
 					$msize = vartrue($parms['size'], 'xxlarge');
 					$ret = "<span class='input-group input-".$msize."'>".$ret. '</span>';
 				}
-				
+
 			break;
-			
+
 			case 'tags':
 				$maxlength = vartrue($parms['maxlength'], 255);
 				$ret =  vartrue($parms['pre']).$this->tags($key, $value, $maxlength, $parms).vartrue($parms['post']); // vartrue($parms['__options']) is limited. See 'required'=>true
@@ -6743,11 +6743,11 @@ var_dump($select_options);*/
 				if(!empty($parms['append']) && !empty($value)) // similar to comments - TODO TBD. a 'comment' field type may be better.
 				{
 					$attributes['readParms'] = 'bb=1';
-					
+
 					$text = $this->renderValue($key, $value, $attributes);					
 					$text .= '<br />';
 					$value = '';
-					
+
 					// Appending needs is  performed and customized using function: beforeUpdate($new_data, $old_data, $id)
 				}
 
@@ -6760,7 +6760,7 @@ var_dump($select_options);*/
 				{
 					$parms['class'] = 'tbox e-count';
 
-					if(!empty($value) && (strlen($value) > (int) $parms['counter']))
+					if(!empty($value) && (strlen((string) $value) > (int) $parms['counter']))
 					{
 						$parms['class'] .= " has-error";
 					}
@@ -6812,7 +6812,7 @@ var_dump($select_options);*/
 
 				$ret =  $this->imagepicker($key, $value, defset($label, $label), $parms);
 			break;
-			
+
 			case 'images':
 
 				$ret = '';
@@ -6825,7 +6825,7 @@ var_dump($select_options);*/
 				{				
 					$k 		= $key.'['.$i.'][path]';
 					$ival 	= $value[$i]['path'];
-					
+
 					$ret .=  $this->imagepicker($k, $ival, defset($label, $label), $parms);		
 				}
 
@@ -6850,7 +6850,7 @@ var_dump($select_options);*/
 
 				return $ret;
 			break;
-			
+
 			case 'files':
 
 
@@ -6871,7 +6871,7 @@ var_dump($select_options);*/
 				}
 				$ret .= '</ol>';
 			break;
-			
+
 			case 'file': //TODO - thumb, image list shortcode, js tooltip...
 				$label = varset($parms['label'], 'LAN_EDIT');
 				unset($parms['label']);
@@ -6894,7 +6894,7 @@ var_dump($select_options);*/
 				{
 					$value = time();
 				}
-				
+
 				if(!empty($parms['readonly'])) // different to 'attribute-readonly' since the value may be auto-generated.
 				{
 					$ret =  $this->renderValue($key, $value, $attributes).$this->hidden($key, $value);
@@ -6999,7 +6999,7 @@ var_dump($select_options);*/
 
 					if(!is_array($value) && !empty($value))
 					{
-						$value = explode(',',$value);
+						$value = explode(',',(string) $value);
 					}
 
 
@@ -7038,7 +7038,7 @@ var_dump($select_options);*/
 				unset($parms['__options']);
 				if(!empty($eloptions['multiple']) && !is_array($value))
 				{
-					$value = explode(',', $value);
+					$value = explode(',', (string) $value);
 				}
 
 				// Allow Ajax API.
@@ -7092,7 +7092,7 @@ var_dump($select_options);*/
 				}
 				if(!is_array($parms['__options']))
 				{
-					parse_str($parms['__options'], $parms['__options']);
+					parse_str((string) $parms['__options'], $parms['__options']);
 				}
 
 				if((empty($value) || (!empty($parms['currentInit']) && empty($parms['default']))) || !empty($parms['current']) || (vartrue($parms['default']) === 'USERID')) // include current user by default.
@@ -7178,9 +7178,9 @@ var_dump($select_options);*/
 				$meth = (!empty($attributes['method'])) ? $attributes['method'] : $key;
 				$parms['field'] = $key;
 
-				if(strpos($meth,'::')!==false)
+				if(strpos((string) $meth,'::')!==false)
 				{
-					list($className,$meth) = explode('::', $meth);
+					list($className,$meth) = explode('::', (string) $meth);
 					$cls = new $className;
 				}
 				else
@@ -7227,18 +7227,18 @@ var_dump($select_options);*/
 
 			case 'lanlist': // installed languages
 			case 'language': // all languages
-				
+
 				$options = ($attributes['type'] === 'language') ? e107::getLanguage()->getList() : e107::getLanguage()->getLanSelectArray();
 
 				$eloptions  = vartrue($parms['__options'], array());
 				if(!is_array($eloptions))
 				{
-					parse_str($eloptions, $eloptions);
+					parse_str((string) $eloptions, $eloptions);
 				}
 				unset($parms['__options']);
 				if(vartrue($eloptions['multiple']) && !is_array($value))
 				{
-					$value = explode(',', $value);
+					$value = explode(',', (string) $value);
 				}
 				$ret =  vartrue($eloptions['pre']).$this->select($key, $options, $value, $eloptions).vartrue($eloptions['post']);
 			break;
@@ -7409,7 +7409,7 @@ var_dump($select_options);*/
 
 		foreach ($form_options as $fid => $options)
 		{
-			list($type,$plugin) = explode('-',$fid,2);
+			list($type,$plugin) = explode('-',(string) $fid,2);
 
 			$plugin = str_replace('-','_',$plugin);
 
@@ -7420,11 +7420,11 @@ var_dump($select_options);*/
 			$tree = $tree_model->getTree();
 			$total = $tree_model->getTotal();
 
-		
+
 			$amount = $options['perPage'];
 			$from = vartrue($options['from'], 0);
 			$field = vartrue($options['field'], $options['pid']);
-			$asc = strtoupper(vartrue($options['asc'], 'asc'));
+			$asc = strtoupper((string) vartrue($options['asc'], 'asc'));
 			$elid = $fid;//$options['id'];
 			$query = vartrue($options['query'],e_QUERY); //  ? $options['query'] :  ;
 			if(vartrue($_GET['action']) === 'list')
@@ -7437,7 +7437,7 @@ var_dump($select_options);*/
 			$current_fields = varset($options['fieldpref']) ? $options['fieldpref'] : array_keys($options['fields']);
 			$legend_class = vartrue($options['legend_class'], 'e-hideme');
 
-			
+
 
 	        $text .= "
 				<form method='post' action='{$formurl}' id='{$elid}-list-form'>
@@ -7478,7 +7478,7 @@ var_dump($select_options);*/
 				$text .= "<div id='admin-ui-list-no-records-found' class=' alert alert-block alert-info center middle'>".LAN_NO_RECORDS_FOUND. '</div>'; // not prone to column-count issues.
 			}
 
-			
+
 			$text .= vartrue($options['table_post']); 
 
 
@@ -7492,7 +7492,7 @@ var_dump($select_options);*/
 				{
 					$parms .= '&tmpl_prefix=admin';
 				}
-				
+
 				// NOTE - the whole url is double encoded - reason is to not break parms query string
 				// 'np_query' should be proper (urlencode'd) url query string
 				$url = rawurlencode($url.'?'.(varset($options['np_query']) ? str_replace(array('&amp;', '&'), array('&', '&amp;'),  $options['np_query']).'&amp;' : '').'from=[FROM]');
@@ -7589,7 +7589,7 @@ var_dump($select_options);*/
 			$amount = $options['perPage'];
 			$from = vartrue($options['from'], 0);
 			$field = vartrue($options['field'], $options['pid']);
-			$asc = strtoupper(vartrue($options['asc'], 'asc'));
+			$asc = strtoupper((string) vartrue($options['asc'], 'asc'));
 			$elid = $fid;//$options['id'];
 			$query = vartrue($options['query'],e_QUERY); //  ? $options['query'] :  ;
 			if(vartrue($_GET['action']) === 'list')
@@ -7663,7 +7663,7 @@ var_dump($select_options);*/
 
 					foreach($gridFields as $k=>$v)
 					{
-						$key = strtoupper($k);
+						$key = strtoupper((string) $k);
 						$fields[$v]['grid'] = true;
 						$vars[$key] = $this->renderValue($v, varset($data[$v]), $fields[$v], $id);
 					}
@@ -7828,7 +7828,7 @@ var_dump($select_options);*/
 				}
 
 				$text .= $this->renderCreateButtonsBar( $data, $model->getId());	// Create/Update Buttons etc.
-				
+
 			}
 
 			$text .= '
@@ -7836,7 +7836,7 @@ var_dump($select_options);*/
 			</div>
 			</form>
 			';
-			
+
 			// e107::js('footer-inline',"Form.focusFirstElement('{$form['id']}-form');",'prototype');
 			// e107::getJs()->footerInline("Form.focusFirstElement('{$form['id']}-form');");
 		}
@@ -7901,12 +7901,12 @@ var_dump($select_options);*/
 			$parms = vartrue($att['formparms'], array());
 			if(!is_array($parms))
 			{
-				parse_str($parms, $parms);
+				parse_str((string) $parms, $parms);
 			}
 			$label = !empty($att['note']) ? '<div class="label-note">'.deftrue($att['note'], $att['note']).'</div>' : '';
 
 
-			$valPath = trim(vartrue($att['dataPath'], $key), '/');
+			$valPath = trim((string) vartrue($att['dataPath'], $key), '/');
 			$keyName = $key;
 			if(strpos($valPath, '/')) //not TRUE, cause string doesn't start with /
 			{
@@ -7917,10 +7917,10 @@ var_dump($select_options);*/
 					$keyName .= '['.$path.']';
 				}
 			}
-			
+
 			if(!empty($att['writeParms']) && !is_array($att['writeParms']))
 			{
-				 parse_str(varset($att['writeParms']), $writeParms);
+				 parse_str((string) varset($att['writeParms']), $writeParms);
 			}
 			else
 			{
@@ -7940,10 +7940,10 @@ var_dump($select_options);*/
 				}
 
 			}
-			
+
 			if($att['type'] === 'hidden')
 			{
-				
+
 				if(empty($writeParms['show'])) // hidden field and not displayed. Render element after the field-set.
 				{
 					$hidden_fields[] = $this->renderElement($keyName, $model->getIfPosted($valPath), $att, varset($model_required[$key], array()));
@@ -7997,14 +7997,14 @@ var_dump($select_options);*/
 				$att['writeParms'] = $writeParms;
 
 				$text .= $this->renderCreateFieldRow($leftCell, $rightCell, $att);
-				
-				
-				
+
+
+
 			}
 
 
 		}
-		
+
 
 		if(!empty($text) || !empty($hidden_fields))
 		{
@@ -8026,9 +8026,9 @@ var_dump($select_options);*/
 		}
 
 
-		
+
 		return false;
-		
+
 
 	}
 
@@ -8163,7 +8163,7 @@ var_dump($select_options);*/
 
 		$text .= '
 				</div>
-	
+
 		';
 
 		return $text;
@@ -8212,7 +8212,7 @@ var_dump($select_options);*/
 		}
 		return $text;
 	}
-  
+
     /**
      * Generic renderFieldset solution, will be split to renderTable, renderCol/Row/Box etc - Still in use. 
      */
@@ -8313,7 +8313,7 @@ var_dump($select_options);*/
 		';
 		return $text;
 	}
-	
+
 	/**
 	 * Render Value Trigger - override to modify field/value/parameters
 	 * @param string $field field name
@@ -8323,9 +8323,9 @@ var_dump($select_options);*/
 	 */
 	public function renderValueTrigger(&$field, &$value, &$params, $id)
 	{
-		
+
 	}
-	
+
 	/**
 	 * Render Element Trigger - override to modify field/value/parameters/validation data
 	 * @param string $field field name
@@ -8336,7 +8336,7 @@ var_dump($select_options);*/
 	 */
 	public function renderElementTrigger(&$field, &$value, &$params, &$required_data, $id)
 	{
-		
+
 	}
 }
 

--- a/e107_handlers/iphandler_class.php
+++ b/e107_handlers/iphandler_class.php
@@ -497,7 +497,7 @@ class eIPHandler
 
 		foreach ($checkLists as $val)
 		{
-			if (strpos($addr, $val['ip']) === 0)	// See if our address begins with an entry - handles wildcards
+			if (strpos($addr, (string) $val['ip']) === 0)	// See if our address begins with an entry - handles wildcards
 			{	// Match found
 
 				if($this->debug)
@@ -532,7 +532,7 @@ class eIPHandler
 	 */
 	private function ip4Encode($ip, $wildCards = FALSE, $div = ':')
 	{
-		$ipa = explode('.', $ip);
+		$ipa = explode('.', (string) $ip);
 		$temp = '';
 		for ($s = 0; $s < 4; $s++)
 		{

--- a/e107_handlers/js_manager.php
+++ b/e107_handlers/js_manager.php
@@ -796,9 +796,9 @@ class e_jsmanager
 
 			foreach($this->_libraries[$this->_dependence] as $inc)
 			{
-				if(strpos($inc,".css")!==false)
+				if(strpos((string) $inc,".css")!==false)
 				{
-					if(strpos($inc,"://")!==false) // cdn 
+					if(strpos((string) $inc,"://")!==false) // cdn 
 					{
 
 						$this->addJs('other_css', $inc, 'all', $opts);
@@ -825,9 +825,9 @@ class e_jsmanager
 				{
 					continue;
 				}
-				if(strpos($inc,".css")!==false)
+				if(strpos((string) $inc,".css")!==false)
 				{
-					if(strpos($inc,"://")!==false) // cdn 
+					if(strpos((string) $inc,"://")!==false) // cdn 
 					{
 						$this->addJs('other_css', $inc, 'all', $opts);
 					}
@@ -1020,7 +1020,7 @@ class e_jsmanager
 					$loc = $runtime_location;
 				}
 				
-				$type = (strpos($fp,".css")!==false && $type == 'core') ? "core_css" : $type;
+				$type = (strpos((string) $fp,".css")!==false && $type == 'core') ? "core_css" : $type;
 				
 							
 				 $this->addJs($type, $fp, $loc);
@@ -1266,7 +1266,7 @@ class e_jsmanager
 					foreach ($lib as $path) 
 					{
 						$erase = array_search($path, $this->_e_jslib_core);
-						if($erase !== false && strpos($path, 'http') === 0)
+						if($erase !== false && strpos((string) $path, 'http') === 0)
 						{
 							unset($this->_e_jslib_core[$erase]);
 							$fw[] = $path;
@@ -1459,17 +1459,17 @@ class e_jsmanager
 		$lmodified = 0;
 		foreach ($file_path_array as $path)
 		{
-            if (substr($path, - 4) == '.php')
+            if (substr((string) $path, - 4) == '.php')
             {
             	if('css' === $external)
 				{
-					$path = explode($this->_sep, $path, 4);
+					$path = explode($this->_sep, (string) $path, 4);
 					$media = $path[0] ? $path[0] : 'all';
 					// support of IE checks
 					$pre = varset($path[2]) ? $path[2]."\n" : '';
 					$post = varset($path[3]) ? "\n".$path[3] : '';
 					$path = $path[1];
-					if(strpos($path, 'http') !== 0)
+					if(strpos((string) $path, 'http') !== 0)
 					{
 						$path = $tp->replaceConstants($path, 'abs').'?external=1'; // &amp;'.$this->getCacheId();
 						$path = $this->url($path);
@@ -1482,9 +1482,9 @@ class e_jsmanager
 				}
 				elseif($external) //true or 'js'
 				{
-					if(strpos($path, 'http') === 0 || strpos($path, '//') === 0) continue; // not allowed
+					if(strpos((string) $path, 'http') === 0 || strpos((string) $path, '//') === 0) continue; // not allowed
 					
-					$path = explode($this->_sep, $path, 3);
+					$path = explode($this->_sep, (string) $path, 3);
 					$pre = varset($path[1]);
 					if($pre) $pre .= "\n";
 					$post = varset($path[2]);
@@ -1508,7 +1508,7 @@ class e_jsmanager
             {
             	// CDN fix, ignore URLs inside consolidation script, render as external scripts
             	$isExternal = false;
-				if(strpos($path, 'http') === 0 || strpos($path, '//') === 0)
+				if(strpos((string) $path, 'http') === 0 || strpos((string) $path, '//') === 0)
 				{
 					if($external !== 'css') $isExternal = true;
 				}
@@ -1520,7 +1520,7 @@ class e_jsmanager
 				            	
 				if('css' === $external)
 				{
-					$path = explode($this->_sep, $path, 4);
+					$path = explode($this->_sep, (string) $path, 4);
 
 
 
@@ -1533,7 +1533,7 @@ class e_jsmanager
 					$insertID ='';
 
 					// issue #3390 Fix for protocol-less path
-					if(strpos($path, 'http') !== 0 && strpos($path, '//') !== 0) // local file.
+					if(strpos((string) $path, 'http') !== 0 && strpos((string) $path, '//') !== 0) // local file.
 					{
 
 						if($label === 'Theme CSS') // add an id for local theme stylesheets. 
@@ -1559,7 +1559,7 @@ class e_jsmanager
 					continue;
 				}
 
-				$path = explode($this->_sep, $path, 4);
+				$path = explode($this->_sep, (string) $path, 4);
 				$pre = varset($path[1], '');
 				if($pre) $pre .= "\n";
 				$post = varset($path[2], '');
@@ -1661,7 +1661,7 @@ class e_jsmanager
 
 		if(!defined('e_HTTP_STATIC'))
 		{
-			if(strpos($path,'?')!==false)
+			if(strpos((string) $path,'?')!==false)
 			{
 				$path .= "&amp;".$this->getCacheId();
 			}
@@ -1709,7 +1709,7 @@ class e_jsmanager
 	 */
 	private function addCache($type,$path)
 	{
-		if($this->_cache_enabled != true  || $this->isInAdmin() || strpos($path, '//') === 0 || strpos($path, 'wysiwyg.php')!==false )
+		if($this->_cache_enabled != true  || $this->isInAdmin() || strpos((string) $path, '//') === 0 || strpos((string) $path, 'wysiwyg.php')!==false )
 		{
 			return false;
 		}
@@ -1765,7 +1765,7 @@ class e_jsmanager
 
 			}
 
-			echo "\n\n<!-- [JSManager] Cached ".strtoupper($type)." -->\n";
+			echo "\n\n<!-- [JSManager] Cached ".strtoupper((string) $type)." -->\n";
 
 			if($type == 'js')
 			{
@@ -1859,7 +1859,7 @@ class e_jsmanager
 	 */
 	private function normalizePath($path)
 	{
-	    $parts = preg_split(":[\\\/]:", $path); // split on known directory separators
+	    $parts = preg_split(":[\\\/]:", (string) $path); // split on known directory separators
 
 	    // resolve relative paths
 	    for ($i = 0, $iMax = count($parts); $i < $iMax; $i +=1)
@@ -1966,7 +1966,7 @@ class e_jsmanager
 			$script = array();
 			foreach($content_array as $code)
 			{
-				$start = substr($code,0,7);
+				$start = substr((string) $code,0,7);
 				if($start == '<script' || $start == '<iframe')
 				{
 					$raw[] = $code;	
@@ -2143,7 +2143,7 @@ class e_jsmanager
 		}
 		$core = e107::getConfig();
 		$plugname = '';
-		if(strpos($mod, 'plugin:') === 0)
+		if(strpos((string) $mod, 'plugin:') === 0)
 		{
 			$plugname = str_replace('plugin:', '', $mod);
 			$mod = 'plugin';
@@ -2170,7 +2170,7 @@ class e_jsmanager
 		if(!$libs) $libs = array();
 		foreach ($array_newlib as $path => $location)
 		{
-			$path = trim($path, '/');
+			$path = trim((string) $path, '/');
 
 			if(!$path) continue;
 
@@ -2196,7 +2196,7 @@ class e_jsmanager
 		}
 		$core = e107::getConfig();
 		$plugname = '';
-		if(strpos($mod, 'plugin:') === 0)
+		if(strpos((string) $mod, 'plugin:') === 0)
 		{
 			$plugname = str_replace('plugin:', '', $mod);
 			$mod = 'plugin';
@@ -2223,7 +2223,7 @@ class e_jsmanager
 		if(!$libs) $libs = array();
 		foreach ($array_removelib as $path => $location)
 		{
-			$path = trim($path, '/');
+			$path = trim((string) $path, '/');
 			if(!$path) continue;
 
 			unset($libs[$path]);

--- a/e107_handlers/jslib_handler.php
+++ b/e107_handlers/jslib_handler.php
@@ -108,44 +108,44 @@ class e_jslib
     function getContent()
     {
         //global $pref, $eplug_admin, $THEME_JSLIB, $THEME_CORE_JSLIB;
-        
+
 		ob_start(); 
 	    ob_implicit_flush(0);
-		
+
 		$e_jsmanager = e107::getJs();
-		
+
 		$lmodified = array();
 		$e_jsmanager->renderJs('core', null, false);
 		$lmodified[] = $e_jsmanager->getLastModfied('core');
-		
+
 		$e_jsmanager->renderJs('plugin', null, false);
 		$lmodified[] = $e_jsmanager->getLastModfied('plugin');
-		
+
 		$e_jsmanager->renderJs('theme', null, false);
 		$lmodified[] = $e_jsmanager->getLastModfied('theme');
-		
+
 		$lmodified[] = $e_jsmanager->getCacheId(); //e107::getPref('e_jslib_browser_cache', 0)
-		
+
 		// last modification time for loaded files
 		$lmodified = max($lmodified);
-				
+
 		// send content type
 		header('Content-type: text/javascript', true);
 		$this->content_out($lmodified);
-		
+
 		// IT CAUSES GREAT TROUBLES ON SOME BROWSERS!
 		/*
 		if (function_exists('date_default_timezone_set')) 
 		{
 		    date_default_timezone_set('UTC');
 		}
-		
+
 
 		// send last modified date
 		if(deftrue('e_NOCACHE')) header('Cache-Control: must-revalidate', true);
 		if($lmodified) header('Last-modified: '.gmdate("D, d M Y H:i:s", $lmodified).' GMT', true);
 		//if($lmodified) header('Last-modified: '.gmdate('r', $lmodified), true);
-		
+
 		// Expire header - 1 year
 		$time = time()+ 365 * 86400;
 		header('Expires: '.gmdate("D, d M Y H:i:s", $time).' GMT', true);
@@ -200,14 +200,14 @@ class e_jslib
             $gzdata = "\x1f\x8b\x08\x00\x00\x00\x00\x00";
             $size = strlen($contents);
             $crc = crc32($contents);
-            
+
             $gzdata .= gzcompress($contents, 9);
             $gzdata = substr($gzdata, 0, -4);
             $gzdata .= pack("V", $crc) . pack("V", $size);
-            
+
             $gsize = strlen($gzdata);
             $this->set_cache($gzdata, $encoding, $lmodified);
-            
+
             header('Content-Length: '.$gsize);
             header('X-Content-size: ' . $size);
             print($gzdata);
@@ -254,7 +254,7 @@ class e_jslib
     function browser_enc()
     {
 		//NEW - option to disable completely gzip compression
-		if(strpos($_SERVER['QUERY_STRING'], '_nogzip'))
+		if(strpos((string) $_SERVER['QUERY_STRING'], '_nogzip'))
 		{
 			return '';
 		}
@@ -263,11 +263,11 @@ class e_jslib
 		{
 			$encoding = '';
 		}
-		elseif (strpos($_SERVER["HTTP_ACCEPT_ENCODING"], 'x-gzip') !== false)
+		elseif (strpos((string) $_SERVER["HTTP_ACCEPT_ENCODING"], 'x-gzip') !== false)
 		{
 			$encoding = 'x-gzip';
 		}
-		elseif (strpos($_SERVER["HTTP_ACCEPT_ENCODING"], 'gzip') !== false)
+		elseif (strpos((string) $_SERVER["HTTP_ACCEPT_ENCODING"], 'gzip') !== false)
 		{
 			$encoding = 'gzip';
 		}

--- a/e107_handlers/language_class.php
+++ b/e107_handlers/language_class.php
@@ -304,7 +304,7 @@ class language{
 			$lang = $pref['adminlanguage'];
 		}
 
-		if(strlen($lang)== 2)
+		if(strlen((string) $lang)== 2)
 		{
 			$iso = $lang;
 			$lang = $this->convert($lang);	
@@ -346,7 +346,7 @@ class language{
 		}
 		
 		global $pref;
-		$mtmp = explode("\n", $pref['multilanguage_subdomain']);
+		$mtmp = explode("\n", (string) $pref['multilanguage_subdomain']);
         foreach($mtmp as $val)
 		{
         	if($domain == trim($val))
@@ -359,7 +359,7 @@ class language{
 		{
 			foreach($pref['multilanguage_domain'] as $lng=>$val)
 			{
-				if($domain == trim($val))
+				if($domain == trim((string) $val))
 				{
 					return $lng;
 				}
@@ -616,7 +616,7 @@ class language{
 			
 			if(varset($_COOKIE['e107_language'])!=$this->detect && (defset('MULTILANG_SUBDOMAIN') != TRUE))
 			{
-				setcookie('e107_language', $this->detect, time() + 86400, e_HTTP);
+				setcookie('e107_language', (string) $this->detect, time() + 86400, e_HTTP);
 				$_COOKIE['e107_language'] = $this->detect; // Used only when a user returns to the site. Not used during this session. 
 			}
 			else // Multi-lang SubDomains should ignore cookies and remove old ones if they exist. 

--- a/e107_handlers/library_manager.php
+++ b/e107_handlers/library_manager.php
@@ -2334,7 +2334,7 @@ class e_library_manager
 		$p_major = '(?P<major>\d+)';
 		// By setting the minor version to x, branches can be matched.
 		$p_minor = '(?P<minor>(?:\d+|x)(?:-[A-Za-z]+\d+)?)';
-		$parts = explode('(', $dependency, 2);
+		$parts = explode('(', (string) $dependency, 2);
 		$value['name'] = trim($parts[0]);
 
 		if(isset($parts[1]))
@@ -2481,7 +2481,7 @@ class e_library_manager
 			if($exclude)
 			{
 				// Split string into array and remove whitespaces.
-				$excludedLibraries = array_map('trim', explode(',', $exclude));
+				$excludedLibraries = array_map('trim', explode(',', (string) $exclude));
 			}
 		}
 

--- a/e107_handlers/login.php
+++ b/e107_handlers/login.php
@@ -90,7 +90,7 @@ class userlogin
 		$e_event = e107::getEvent();
 		$_E107 = e107::getE107();
 		
-		$username = trim($username);
+		$username = trim((string) $username);
 		$userpass = trim($userpass);
 
 		if(!empty($_E107['cli']) && ($username == ''))
@@ -177,7 +177,7 @@ class userlogin
 			}
 		}
 
-		$username = preg_replace("/\sOR\s|\=|\#/", "", $username);
+		$username = preg_replace("/\sOR\s|\=|\#/", "", (string) $username);
 
 		// Check secure image
 		if (!$forceLogin && !empty($pref[$this->secImageType]) && extension_loaded('gd'))
@@ -324,9 +324,9 @@ class userlogin
 			{
 				if (in_array($fk,$class_list))
 				{  // We've found the entry of interest
-					if (strlen($fp))
+					if (strlen((string) $fp))
 					{
-						if (strpos($fp, 'http') === FALSE)
+						if (strpos((string) $fp, 'http') === FALSE)
 						{
 							$fp = str_replace(e_HTTP, '', $fp);		// This handles sites in a subdirectory properly (normally, will replace nothing)
 							$fp = SITEURL.$fp;
@@ -405,7 +405,7 @@ class userlogin
 
 		// User is in DB here
 		$this->userData = e107::getDb()->fetch();		// Get user info
-		$this->userData['user_perms'] = trim($this->userData['user_perms']);
+		$this->userData['user_perms'] = trim((string) $this->userData['user_perms']);
 		$this->lookEmail = ($username == $this->userData['user_email']) ? 1 : 0;		// Know whether login name or email address used now
 		
 		return TRUE;
@@ -421,7 +421,7 @@ class userlogin
 		$pref = e107::getPref();
 		$tp = e107::getParser();
 
-		$username = preg_replace("/\sOR\s|\=|\#/", "", $username);
+		$username = preg_replace("/\sOR\s|\=|\#/", "", (string) $username);
 		
 		if($forceLogin === 'provider')
 		{

--- a/e107_handlers/magpie_rss.php
+++ b/e107_handlers/magpie_rss.php
@@ -124,7 +124,7 @@ class MagpieRSS {
                         
         xml_set_character_data_handler( $this->parser, 'feed_cdata' ); 
     
-        $status = xml_parse( $this->parser, $source );
+        $status = xml_parse( $this->parser, (string) $source );
         
         if (! $status ) {
             $errorcode = xml_get_error_code( $this->parser );
@@ -150,7 +150,7 @@ class MagpieRSS {
 	 * @return void
 	 */
 	function feed_start_element($p, $element, $attrs) {
-        $el = $element = strtolower($element);
+        $el = $element = strtolower((string) $element);
         $attrs = array_change_key_case($attrs, CASE_LOWER);
         
         // check for a namespace, and split if found
@@ -285,7 +285,7 @@ class MagpieRSS {
 	 * @return void
 	 */
 	function feed_end_element ($p, $el) {
-        $el = strtolower($el);
+        $el = strtolower((string) $el);
         
         if ( $el == 'item' or $el == 'entry' ) 
         {
@@ -542,7 +542,7 @@ class MagpieRSS {
         }
         
         if (!$in_enc) {
-            if (preg_match('/<?xml.*encoding=[\'"](.*?)[\'"].*?>/m', $source, $m)) {
+            if (preg_match('/<?xml.*encoding=[\'"](.*?)[\'"].*?>/m', (string) $source, $m)) {
                 $in_enc = strtoupper($m[1]);
                 $this->source_encoding = $in_enc;
             }
@@ -562,7 +562,7 @@ class MagpieRSS {
         // @see http://php.net/iconv
        
         if (function_exists('iconv'))  {
-            $encoded_source = iconv($in_enc,'UTF-8', $source);
+            $encoded_source = iconv((string) $in_enc,'UTF-8', (string) $source);
             if ($encoded_source) {
                 return array(xml_parser_create('UTF-8'), $encoded_source);
             }
@@ -590,7 +590,7 @@ class MagpieRSS {
 	 * @return false|string
 	 */
 	function known_encoding($enc) {
-        $enc = strtoupper($enc);
+        $enc = strtoupper((string) $enc);
         if ( in_array($enc, $this->_KNOWN_ENCODINGS) ) {
             return $enc;
         }
@@ -645,7 +645,7 @@ function parse_w3cdtf ($date_str ) {
     # regex to match wc3dtf
     $pat = "/(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2})(:(\d{2}))?(?:([-+])(\d{2}):?(\d{2})|(Z))?/";
     
-    if ( preg_match( $pat, $date_str, $match ) ) {
+    if ( preg_match( $pat, (string) $date_str, $match ) ) {
         list( $year, $month, $day, $hours, $minutes, $seconds) = 
             array( $match[1], $match[2], $match[3], $match[4], $match[5], $match[6]);
         

--- a/e107_handlers/mail.php
+++ b/e107_handlers/mail.php
@@ -236,9 +236,9 @@ class e107Email extends PHPMailer
 			}
 		}
 
-		if(strpos($overrides['smtp_server'],':')!== false)
+		if(strpos((string) $overrides['smtp_server'],':')!== false)
 		{
-			list($smtpServer,$smtpPort) = explode(":", $overrides['smtp_server']);
+			list($smtpServer,$smtpPort) = explode(":", (string) $overrides['smtp_server']);
 			$overrides['smtp_server'] = $smtpServer;
 		}
 		else
@@ -251,7 +251,7 @@ class e107Email extends PHPMailer
 		$this->pause_time =  varset($pref['mail_pausetime'], 1);
 		$this->allow_html = varset($pref['mail_sendstyle'],'textonly') == 'texthtml' ? true : 1;
 
-		if (vartrue($pref['mail_options'])) $this->general_opts = explode(',',$pref['mail_options'],'');
+		if (vartrue($pref['mail_options'])) $this->general_opts = explode(',',(string) $pref['mail_options'],'');
 		
 		if ($this->debug)
 		{
@@ -260,7 +260,7 @@ class e107Email extends PHPMailer
 		
 		foreach ($this->general_opts as $k => $v) 
 		{
-			$v = trim($v);
+			$v = trim((string) $v);
 			$this->general_opts[$k] = $v;
 			if (strpos($v,'hostname') === 0)
 			{
@@ -270,13 +270,13 @@ class e107Email extends PHPMailer
 			}
 		}
 
-		list($this->logEnable,$this->add_email) = explode(',',varset($pref['mail_log_options'],'0,0'));
+		list($this->logEnable,$this->add_email) = explode(',',(string) varset($pref['mail_log_options'],'0,0'));
 
 		switch ($overrides['mailer'])
 		{
 			case 'smtp' :
 				$smtp_options = array();
-				$temp_opts = explode(',',varset($pref['smtp_options'],''));
+				$temp_opts = explode(',',(string) varset($pref['smtp_options'],''));
 				if (vartrue($overrides ['smtp_pop3auth'])) $temp_opts[] = 'pop3auth';		// Legacy option - remove later
 				if (vartrue($pref['smtp_keepalive'])) $temp_opts[] = 'keepalive';	// Legacy option - remove later
 				foreach ($temp_opts as $k=>$v) 
@@ -630,22 +630,22 @@ class e107Email extends PHPMailer
 			//  !preg_match('/<(table|div|font|br|a|img|b)/i', $message)
 			if ($this->legacyBody && e107::getParser()->isHtml($message) != true) // Assume html if it includes one of these tags
 			{	// Otherwise assume its a plain text message which needs some conversion to render in HTML
-			
+
 				if($this->debug == true)
 				{
 					echo 'Running legacyBody mode<br />';	
 				}
-			
+
 				$message = htmlspecialchars($message,ENT_QUOTES,$this->CharSet);
 				$message = preg_replace('%(http|ftp|https)(://\S+)%', '<a href="\1\2">\1\2</a>', $message);
-				$message = preg_replace('/([[:space:]()[{}])(www.[-a-zA-Z0-9@:%_\+.~#?&\/=]+)/i', '\\1<a href="http://\\2">\\2</a>', $message);
-				$message = preg_replace('/([_\.0-9a-z-]+@([0-9a-z][0-9a-z-]+\.)+[a-z]{2,3})/i', '<a href="mailto:\\1">\\1</a>', $message);
+				$message = preg_replace('/([[:space:]()[{}])(www.[-a-zA-Z0-9@:%_\+.~#?&\/=]+)/i', '\\1<a href="http://\\2">\\2</a>', (string) $message);
+				$message = preg_replace('/([_\.0-9a-z-]+@([0-9a-z][0-9a-z-]+\.)+[a-z]{2,3})/i', '<a href="mailto:\\1">\\1</a>', (string) $message);
 				$message = str_replace("\r\n","\n",$message);		// Handle alternative newline characters
 				$message = str_replace("\n\r","\n",$message);		// Handle alternative newline characters
 				$message = str_replace("\r","\n",$message);			// Handle alternative newline characters
 				$message = str_replace("\n", "<br />\n", $message);
 			}
-			
+
 
 			$this->MsgHTML($message);		// Theoretically this should do everything, including handling of inline images.
 
@@ -664,7 +664,7 @@ class e107Email extends PHPMailer
 
 			$text = str_replace('<br />', "\n", $text);
 			$text = strip_tags(str_replace('<br>', "\n", $text));
-			
+
 			// TODO: strip bbcodes here
 
 			$this->Body = $text;
@@ -691,7 +691,7 @@ class e107Email extends PHPMailer
 
 		foreach($attachments as $attach)
 		{
-			$tempName = basename($attach);
+			$tempName = basename((string) $attach);
 			if(is_readable($attach) && $tempName) // First parameter is complete path + filename; second parameter is 'name' of file to send
 			{	
 				if($this->previewMode === true)
@@ -812,11 +812,11 @@ class e107Email extends PHPMailer
 
 		$mediaParms = array();
 
-		if(strpos($eml['templateHTML']['body'], '{MEDIA') !==false )
+		if(strpos((string) $eml['templateHTML']['body'], '{MEDIA') !==false )
 		{
 			// check for media sizing.
 
-			if(preg_match_all('/\{MEDIA([\d]): w=([\d]*)\}/', $eml['templateHTML']['body'], $match))
+			if(preg_match_all('/\{MEDIA([\d]): w=([\d]*)\}/', (string) $eml['templateHTML']['body'], $match))
 			{
 
 				foreach($match[1] as $k=>$num)
@@ -890,18 +890,18 @@ class e107Email extends PHPMailer
 	{
 		$tp = e107::getParser();
 		$tmpl = null;
-		
+
 		// Cleanup legacy key names. ie. remove 'email_' prefix. 		
 		foreach($eml as $k=>$v)
 		{
-			if(substr($k,0,6) == 'email_')
+			if(substr((string) $k,0,6) == 'email_')
 			{
-				$nkey = substr($k,6);
+				$nkey = substr((string) $k,6);
 				$eml[$nkey] = $v;	
 				unset($eml[$k]);
 			}		
 		}
-		
+
 
 
 		if(!empty($eml['template'])) // @see e107_core/templates/email_template.php
@@ -933,11 +933,11 @@ class e107Email extends PHPMailer
 					$eml['shortcodes']['_WRAPPER_'] = 'email/'.$eml['template'];
 				}
 				$emailBody = varset($tmpl['header']). str_replace('{BODY}', $eml['body'], $tmpl['body']) . varset($tmpl['footer']);
-				
+
 				$eml['body'] = $tp->parseTemplate($emailBody, true, $eml['shortcodes']);
-				
+
 			//	$eml['body'] = ($tp->toEmail($tmpl['header']). str_replace('{BODY}', $eml['body'], $tmpl['body']). $tp->toEmail($tmpl['footer']));
-				
+
 				if($this->debug)
 				{
 				//	echo "<h4>e107Email::arraySet() - line ".__LINE__."</h4>";
@@ -946,9 +946,9 @@ class e107Email extends PHPMailer
 					var_dump($this->Subject);
 				//	print_a($tmpl);
 				}
-				
+
 				unset($eml['add_html_header']); // disable other headers when template is used. 
-				
+
 				$this->Subject = $tp->parseTemplate(varset($tmpl['subject'],'{SUBJECT}'), true, varset($eml['shortcodes'],null));
 
 				if($this->debug)
@@ -963,11 +963,11 @@ class e107Email extends PHPMailer
 					echo "<h4>Couldn't find email template: ".print_r($eml['template'],true)."</h4>";
 				}
 			//	$emailBody = $eml['body'];
-				
+
 				if (vartrue($eml['subject'])) $this->Subject = $tp->parseTemplate($eml['subject'], true, varset($eml['shortcodes'],null)); 	
 				e107::getMessage()->addDebug("Couldn't find email template: ".$eml['template']);	
 			}
-			
+
 		}
 		else
 		{
@@ -1022,7 +1022,7 @@ class e107Email extends PHPMailer
 			$this->Sender = $eml['bouncepath'];				// Bounce path
 			$this->save_bouncepath = $eml['bouncepath'];		// Bounce path
 		}
-			
+
 		if (!empty($eml['extra_header'])) 
 		{
 			if (is_array($eml['extra_header']))
@@ -1110,10 +1110,10 @@ class e107Email extends PHPMailer
 
 		}
 
-		if (($bulkmail == true) && $this->localUseVerp && $this->save_bouncepath && (strpos($this->save_bouncepath,'@') !== false))
+		if (($bulkmail == true) && $this->localUseVerp && $this->save_bouncepath && (strpos((string) $this->save_bouncepath,'@') !== false))
 		{
 			// Format where sender is owner@origin, target is user@domain is: owner+user=domain@origin
-			list($our_sender,$our_domain) = explode('@', $this->save_bouncepath,2);
+			list($our_sender,$our_domain) = explode('@', (string) $this->save_bouncepath,2);
 			if ($our_sender && $our_domain)
 			{
 				$this->Sender = $our_sender.'+'.str_replace($send_to,'@','=').'@'.$our_domain; 
@@ -1268,7 +1268,7 @@ class e107Email extends PHPMailer
 
 		$message = $tp->toEmail($message, false, 'rawtext');
 
-		preg_match_all("/(src|background)=([\"\'])(.*)\\2/Ui", $message, $images);			// Modified to accept single quotes as well
+		preg_match_all("/(src|background)=([\"\'])(.*)\\2/Ui", (string) $message, $images);			// Modified to accept single quotes as well
 		if(isset($images[3]) && ($this->previewMode === false)) 
 		{
 			
@@ -1342,7 +1342,7 @@ class e107Email extends PHPMailer
 					try
 					{
 						$this->addEmbeddedImage($basedir.$directory.$filename, md5($filename), $filename, 'base64',$mimeType);
-						$message = preg_replace("/".$images[1][$i]."=".$delim.preg_quote($images[3][$i], '/').$delim."/Ui", $images[1][$i]."=".$delim.$cid.$delim, $message);
+						$message = preg_replace("/".$images[1][$i]."=".$delim.preg_quote($images[3][$i], '/').$delim."/Ui", $images[1][$i]."=".$delim.$cid.$delim, (string) $message);
 					}
 					catch (Exception $e)
 					{

--- a/e107_handlers/mail_manager_class.php
+++ b/e107_handlers/mail_manager_class.php
@@ -1726,7 +1726,7 @@ class e107MailManager
 		}
 		if ($sortOrder)
 		{
-			$sortOrder = strtoupper($sortOrder);
+			$sortOrder = strtoupper((string) $sortOrder);
 			$query .= ($sortOrder == 'DESC') ? ' DESC' : ' ASC';
 		}
 		if ($count)
@@ -1804,7 +1804,7 @@ class e107MailManager
 		}
 		if ($sortOrder)
 		{
-			$sortOrder = strtoupper($sortOrder);
+			$sortOrder = strtoupper((string) $sortOrder);
 			$query .= ($sortOrder == 'DESC') ? ' DESC' : ' ASC';
 		}
 		if ($count)
@@ -1932,14 +1932,14 @@ class e107MailManager
 			$templateName = varset($emailData['mail_send_style'], 'textonly');        // Safest default if nothing specified
 		}
 
-		$templateName = trim($templateName);
+		$templateName = trim((string) $templateName);
 		if ($templateName == '')
 		{
 			return false;
 		}
 
 		$this->currentMailBody = $emailData['mail_body'];            // In case we send immediately
-		$this->currentTextBody = strip_tags($emailData['mail_body']);
+		$this->currentTextBody = strip_tags((string) $emailData['mail_body']);
 
 		//		$emailData['mail_body_templated'] 	= $ourTemplate->mainBodyText;
 		//		$emailData['mail_body_alt'] 		= $ourTemplate->altBodyText;

--- a/e107_handlers/mail_template_class.php
+++ b/e107_handlers/mail_template_class.php
@@ -92,7 +92,7 @@ class e107MailTemplate
 	public function loadTemplateInfo($templateName, $extraFile = FALSE)
 	{
 		static $requiredFields = array ('email_overrides', 'email_header', 'email_body', 'email_footer', 'email_plainText');
-		
+
 		if (is_array($this->lastTemplateData))
 		{
 			if ($this->lastTemplateData['template_name'] == $templateName)
@@ -106,7 +106,7 @@ class e107MailTemplate
 		if (!in_array($templateName, array('textonly', 'texthtml', 'texttheme')))
 		{
 			$found = 0;		// Count number of field definitions we've found
-			
+
 			$fileList = array(THEME.'templates/email_template.php');
 			if ($extraFile)
 			{
@@ -151,7 +151,7 @@ class e107MailTemplate
 			{
 				foreach ($requiredFields as $k)
 				{
-					$override = strtoupper($k);
+					$override = strtoupper((string) $k);
 					if (!$ret[$k] && isset($$override))
 					{
 						$ret[$k] = $$override;

--- a/e107_handlers/mail_validation_class.php
+++ b/e107_handlers/mail_validation_class.php
@@ -37,20 +37,20 @@ class email_validation_class
 	 */
 	Function Tokenize($string, $separator="")
 	{
-		if(!strcmp($separator,""))
+		if(!strcmp((string) $separator,""))
 		{
 			$separator=$string;
 			$string=$this->next_token;
 		}
-		for($character=0, $characterMax = strlen($separator); $character< $characterMax; $character++)
+		for($character=0, $characterMax = strlen((string) $separator); $character< $characterMax; $character++)
 		{
-			if(GetType($position=strpos($string,$separator[$character]))=="integer")
+			if(GetType($position=strpos((string) $string,(string) $separator[$character]))=="integer")
 				$found=(IsSet($found) ? min($found,$position) : $position);
 		}
 		if(IsSet($found))
 		{
-			$this->next_token=substr($string,$found+1);
-			return(substr($string,0,$found));
+			$this->next_token=substr((string) $string,$found+1);
+			return(substr((string) $string,0,$found));
 		}
 		else
 		{
@@ -116,14 +116,14 @@ class email_validation_class
 		if(IsSet($this->preg))
 		{
 			if(strlen($this->preg))
-				return(preg_match($this->preg,$email));
+				return(preg_match($this->preg,(string) $email));
 		}
 		else
 		{
 			$this->preg=(function_exists("preg_match") ? "/".str_replace("/", "\\/", $this->email_regular_expression)."/" : "");
 			return($this->ValidateEmailAddress($email));
 		}
-		return(preg_match("/".str_replace("/", "\\/", $this->email_regular_expression)."/i", $email)/*!=0*/);
+		return(preg_match("/".str_replace("/", "\\/", $this->email_regular_expression)."/i", (string) $email)/*!=0*/);
 	}
 
 	/**
@@ -151,8 +151,8 @@ class email_validation_class
 		}
 		else
 		{
-			if(strcmp($ip=@gethostbyname($domain),$domain)
-			&& (strlen($this->exclude_address)==0
+			if(strcmp($ip=@gethostbyname($domain),(string) $domain)
+			&& (strlen((string) $this->exclude_address)==0
 			|| strcmp(@gethostbyname($this->exclude_address),$ip)))
 				$hosts[]=$domain;
 		}
@@ -169,9 +169,9 @@ class email_validation_class
 		while(($line=$this->GetLine($connection)))
 		{
 			$this->last_code=$this->Tokenize($line," -");
-			if(strcmp($this->last_code,$code))
+			if(strcmp((string) $this->last_code,(string) $code))
 				return(0);
-			if(!strcmp(substr($line, strlen($this->last_code), 1)," "))
+			if(!strcmp(substr((string) $line, strlen((string) $this->last_code), 1)," "))
 				return(1);
 		}
 		return(-1);
@@ -185,32 +185,32 @@ class email_validation_class
 	{
 		if(!$this->ValidateEmailHost($email,$hosts))
 			return(0);
-		if(!strcmp($localhost=$this->localhost,"")
+		if(!strcmp((string) $localhost=$this->localhost,"")
 		&& !strcmp($localhost=getenv("SERVER_NAME"),"")
 		&& !strcmp($localhost=getenv("HOST"),""))
 		   $localhost="localhost";
-		if(!strcmp($localuser=$this->localuser,"")
+		if(!strcmp((string) $localuser=$this->localuser,"")
 		&& !strcmp($localuser=getenv("USERNAME"),"")
 		&& !strcmp($localuser=getenv("USER"),""))
 		   $localuser="root";
 		for($host=0, $hostMax = count($hosts); $host< $hostMax; $host++)
 		{
 			$domain=$hosts[$host];
-			if(preg_match('/^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$/',$domain))
+			if(preg_match('/^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$/',(string) $domain))
 				$ip=$domain;
 			else
 			{
 				if($this->debug)
 					$this->OutputDebug("Resolving host name \"".$hosts[$host]."\"...");
-				if(!strcmp($ip=@gethostbyname($domain),$domain))
+				if(!strcmp($ip=@gethostbyname($domain),(string) $domain))
 				{
 					if($this->debug)
 						$this->OutputDebug("Could not resolve host name \"".$hosts[$host]."\".");
 					continue;
 				}
 			}
-			if(strlen($this->exclude_address)
-			&& !strcmp(@gethostbyname($this->exclude_address),$ip))
+			if(strlen((string) $this->exclude_address)
+			&& !strcmp(@gethostbyname($this->exclude_address),(string) $ip))
 			{
 				if($this->debug)
 					$this->OutputDebug("Host address of \"".$hosts[$host]."\" is the exclude address");
@@ -241,8 +241,8 @@ class email_validation_class
 					}
 					else
 					{
-						if(strlen($this->last_code)
-						&& !strcmp($this->last_code[0],"4"))
+						if(strlen((string) $this->last_code)
+						&& !strcmp((string) $this->last_code[0],"4"))
 							$result=-1;
 					}
 					if($this->debug)

--- a/e107_handlers/mailout_admin_class.php
+++ b/e107_handlers/mailout_admin_class.php
@@ -338,7 +338,7 @@ class mailoutAdminClass extends e107MailManager
 		}
 		if (isset($_GET['asc']))
 		{
-			$temp = strtolower(e107::getParser()->toDB($_GET['asc']));
+			$temp = strtolower((string) e107::getParser()->toDB($_GET['asc']));
 			if (($temp == 'asc') || ($temp == 'desc'))
 			{
 				$this->sortOrder = $temp;
@@ -571,7 +571,7 @@ class mailoutAdminClass extends e107MailManager
 		$ret = 0;
 		$toLoad = explode(',', $options);
 
-		$active_mailers = explode(',', varset($pref['mailout_enabled'], 'user'));
+		$active_mailers = explode(',', (string) varset($pref['mailout_enabled'], 'user'));
 
 		//if((in_array('core', $toLoad) || ($options == 'all')) && in_array('core', $active_mailers))
 		//	{
@@ -799,7 +799,7 @@ class mailoutAdminClass extends e107MailManager
 			{
 				$value = 'ue.user_' . $fd['user_extended_struct_name'];
 				$selected = ($value == $curval) ? " selected='selected'" : '';
-				$ret .= "<option value='" . $value . "' {$selected}>" . ucfirst($fd['user_extended_struct_name']) . "</option>\n";
+				$ret .= "<option value='" . $value . "' {$selected}>" . ucfirst((string) $fd['user_extended_struct_name']) . "</option>\n";
 			}
 		}
 		$ret .= "</select>\n";
@@ -826,7 +826,7 @@ class mailoutAdminClass extends e107MailManager
 			'mail_sender_name'    => $_POST['email_from_name'],
 			'mail_copy_to'        => $_POST['email_cc'],
 			'mail_bcopy_to'       => $_POST['email_bcc'],
-			'mail_attach'         => trim($_POST['email_attachment']),
+			'mail_attach'         => trim((string) $_POST['email_attachment']),
 			'mail_send_style'     => varset($_POST['email_send_style'], 'textonly'),
 			'mail_include_images' => (isset($_POST['email_include_images']) ? 1 : 0)
 		);
@@ -865,23 +865,23 @@ class mailoutAdminClass extends e107MailManager
 
 			return $errList;
 		}
-		if (!trim($email['mail_subject']))
+		if (!trim((string) $email['mail_subject']))
 		{
 			$errList[] = LAN_MAILOUT_200;
 		}
-		if (!trim($email['mail_body']))
+		if (!trim((string) $email['mail_body']))
 		{
 			$errList[] = LAN_MAILOUT_202;
 		}
-		if (!trim($email['mail_sender_name']))
+		if (!trim((string) $email['mail_sender_name']))
 		{
 			$errList[] = LAN_MAILOUT_203;
 		}
-		if (!trim($email['mail_sender_email']))
+		if (!trim((string) $email['mail_sender_email']))
 		{
 			$errList[] = LAN_MAILOUT_204;
 		}
-		if (strlen($email['mail_send_style']) == 0)
+		if (strlen((string) $email['mail_send_style']) == 0)
 		{
 			// Can be a template name now
 			$errList[] = LAN_MAILOUT_205;
@@ -976,7 +976,7 @@ class mailoutAdminClass extends e107MailManager
 						break;
 					case 'chars':
 						// Show generated html as is
-						$text .= htmlspecialchars($val, ENT_COMPAT, 'UTF-8');
+						$text .= htmlspecialchars((string) $val, ENT_COMPAT, 'UTF-8');
 						break;
 					case 'contentstatus':
 						$text .= $this->statusToText($val);
@@ -2200,7 +2200,7 @@ class mailoutAdminClass extends e107MailManager
 
 		$mailers = array('php' => 'php', 'smtp' => 'smtp', 'sendmail' => 'sendmail');
 
-		$smtp_opts = explode(',', varset($pref['smtp_options'], ''));
+		$smtp_opts = explode(',', (string) varset($pref['smtp_options'], ''));
 		$smtpdisp = ($pref[$id] != 'smtp') ? "style='display:none;'" : '';
 
 		$text = $frm->select($id, $mailers, $pref[$id]) . "

--- a/e107_handlers/mailout_class.php
+++ b/e107_handlers/mailout_class.php
@@ -154,9 +154,9 @@ class core_mailout
 		{
 			foreach(array(':', '-', ',') as $sep)
 			{
-				if (strpos($selectVals['last_visit_date'], ':'))
+				if (strpos((string) $selectVals['last_visit_date'], ':'))
 				{
-					$tmp = explode($sep, $selectVals['last_visit_date']);
+					$tmp = explode($sep, (string) $selectVals['last_visit_date']);
 					break;
 				}
 			}

--- a/e107_handlers/media_class.php
+++ b/e107_handlers/media_class.php
@@ -832,7 +832,7 @@ class e_media
 
 		foreach($images as $im)
 		{
-			list($dbWidth,$dbHeight) = explode(" x ",$im['media_dimensions']);
+			list($dbWidth,$dbHeight) = explode(" x ",(string) $im['media_dimensions']);
 			unset($dbHeight);
 				
 			$w = ($dbWidth > $defaultResizeWidth) ? $defaultResizeWidth : intval($dbWidth);
@@ -1127,7 +1127,7 @@ class e_media
 		elseif(!empty($pattern) && !empty($path))
 		{
 			$pattern = '/'.$pattern.'/';
-			if(strpos($path, 'http') === 0)
+			if(strpos((string) $path, 'http') === 0)
 			{
 				$subject = e107::getFile()->getRemoteContent($path);
 			}
@@ -1142,7 +1142,7 @@ class e_media
 		}
 
 
-		$prefixLength = !empty($prefix) ? strlen($prefix) : 3;
+		$prefixLength = !empty($prefix) ? strlen((string) $prefix) : 3;
 
 		if(!empty($pattern) && !empty($subject))
 		{
@@ -1498,7 +1498,7 @@ class e_media
 
 		$len = strlen($ext);
 
-		if($ext && (substr($path,- $len) != $ext))
+		if($ext && (substr((string) $path,- $len) != $ext))
 		{
 			return $path.$ext;
 		}
@@ -1535,7 +1535,7 @@ class e_media
 
 		$style  = varset($data['style']);
 		$class  = varset($data['class']);
-		$dataPreview = !empty($data['previewHtml']) ? base64_encode($data['previewHtml']) : '';
+		$dataPreview = !empty($data['previewHtml']) ? base64_encode((string) $data['previewHtml']) : '';
 
 		return "<a data-toggle='context' data-bs-toggle='context' class='e-media-select ".$select." ".$class."' ".$close." data-id='".$data['id']."' data-width='".$data['width']."' data-height='".$data['height']."' data-src='".$data['previewUrl']."' data-type='".$data['type']."' data-bbcode='".$data['bbcode']."' data-target='".$data['tagid']."' data-path='".$data['saveValue']."' data-preview='".$data['previewUrl']."'  data-preview-html='".$dataPreview."' title=\"".$data['title']."\" style='".$style."' href='#' >";
 
@@ -1725,7 +1725,7 @@ class e_media
 	 */
 	function getThumb($id)
 	{
-		$id = trim($id);
+		$id = trim((string) $id);
 		$filename = 'temp/thumb-'.md5($id).".jpg";
 		$filepath = e_MEDIA.$filename;
 
@@ -2137,7 +2137,7 @@ class e_media
 
 
 		// Clean the fileName for security reasons
-		$fileName = preg_replace('/[^\w\._]+/', '_', $fileName);
+		$fileName = preg_replace('/[^\w\._]+/', '_', (string) $fileName);
 
 		//	$array = array("jsonrpc" => "2.0", "error" => array('code'=>$_FILES['file']['error'], 'message'=>'Failed to move file'), "id" => "id",  'data'=>$_FILES );
 
@@ -2204,7 +2204,7 @@ class e_media
 		}
 
 		// Handle non multipart uploads older WebKit versions didn't support multipart in HTML5
-		if(strpos($contentType, "multipart") !== false)
+		if(strpos((string) $contentType, "multipart") !== false)
 		{
 			if(isset($_FILES['file']['tmp_name']) && is_uploaded_file($_FILES['file']['tmp_name']))
 			{
@@ -2377,7 +2377,7 @@ class e_media
 
 		if(!empty($request['rename']))
 		{
-			$newPath = $targetDir.basename($request['rename']);
+			$newPath = $targetDir.basename((string) $request['rename']);
 			if(!rename($filePath, $newPath))
 			{
 				return '{"jsonrpc" : "2.0", "error" : {"code": 105, "message": "Unable to rename '.$filePath.' to '.$newPath.'"}, "id" : "id"}';

--- a/e107_handlers/menu_class.php
+++ b/e107_handlers/menu_class.php
@@ -88,7 +88,7 @@ class e_menu
 				$converted = $this->convertMenuTable();
 				e107::getConfig()->set('menu_layouts', $converted)->save();
 			}
-			
+
 			$eMenuArea = $this->getData(THEME_LAYOUT);
 			//print_a($eMenuArea);
 		}
@@ -279,10 +279,10 @@ class e_menu
 		$model->load($id, true);
 
 		$menu_path = $model->get('menu_path');
-		$menu_path = rtrim($menu_path, '/');
+		$menu_path = rtrim((string) $menu_path, '/');
 
 		$menu_name = $model->get('menu_name');
-		$menu_name = substr($menu_name,0,-5);
+		$menu_name = substr((string) $menu_name,0,-5);
 
 		if(!$obj = e107::getAddon($menu_path,'e_menu'))
 		{
@@ -504,7 +504,7 @@ class e_menu
 		$tp = e107::getParser();
 		if($row['menu_pages'])
 		{
-			list ($listtype, $listpages) = explode("-", $row['menu_pages'], 2);
+			list ($listtype, $listpages) = explode("-", (string) $row['menu_pages'], 2);
 			$pagelist = explode("|", $listpages);
 			// TODO - check against REQUEST_URI, see what would get broken
 			$check_url = $url ? $url : ($_SERVER['REQUEST_URI'] ? SITEURLBASE.$_SERVER['REQUEST_URI'] : e_SELF.(e_QUERY ? "?".e_QUERY : ''));
@@ -526,13 +526,13 @@ class e_menu
 						if(substr($p, -1)==='!')
 						{
 							$p = substr($p, 0, -1);
-							if(substr($check_url, strlen($p)*-1) == $p)
+							if(substr((string) $check_url, strlen($p)*-1) == $p)
 							{
 								$show_menu = true;
 								break 2;
 							}
 						}
-						elseif(strpos($check_url, $p) !== false)
+						elseif(strpos((string) $check_url, $p) !== false)
 						{
 							$show_menu = true;
 							break 2;
@@ -554,13 +554,13 @@ class e_menu
 						if(substr($p, -1) === '!')
 						{
 							$p = substr($p, 0, -1);
-							if(substr($check_url, strlen($p)*-1) == $p)
+							if(substr((string) $check_url, strlen($p)*-1) == $p)
 							{
 								$show_menu = false;
 								break 2;
 							}
 						}
-						elseif(strpos($check_url, $p) !== false)
+						elseif(strpos((string) $check_url, $p) !== false)
 						{
 							$show_menu = false;
 							break 2;

--- a/e107_handlers/menumanager_class.php
+++ b/e107_handlers/menumanager_class.php
@@ -271,7 +271,7 @@ class e_menuManager
 			$FOOTER = array();
 			foreach($LAYOUT as $key=>$template)
 			{
-				$tmp = explode("{---}",$template);
+				$tmp = explode("{---}",(string) $template);
 				$hd = varset($tmp[0]);
 				$ft = varset($tmp[1]);
 
@@ -280,7 +280,7 @@ class e_menuManager
 			}	
 			unset($hd,$ft);
 		}
-			
+
       	if(($this->curLayout == 'legacyCustom' || $this->curLayout=='legacyDefault') && (isset($CUSTOMHEADER) || isset($CUSTOMFOOTER)) )  // 0.6 themes.
 		{
 		 	if($this->curLayout == 'legacyCustom')
@@ -333,7 +333,7 @@ class e_menuManager
 			return;
 		}
 
-		$file = urldecode($_GET['path']).".php";
+		$file = urldecode((string) $_GET['path']).".php";
 		$file = e107::getParser()->filter($file);
 		$newurl = e_PLUGIN_ABS.$file."?id=".intval($_GET['id']).'&iframe=1';
 
@@ -365,7 +365,7 @@ class e_menuManager
 			{
 				foreach($_POST['menuAct'] as $k => $v)
 				{
-					if(trim($v))
+					if(trim((string) $v))
 					{
 						$value = $tp->filter($_POST['menuAct'][$k]);
 						$this->menuId = intval($k);
@@ -615,7 +615,7 @@ class e_menuManager
 		$sql->select("menus", "*", "menu_path NOT REGEXP('[0-9]+') ");
 		while(list($menu_id, $menu_name, $menu_location, $menu_order) = $sql->fetch('num'))
 		{
-			if(stripos($menustr, $menu_name) === false)
+			if(stripos((string) $menustr, (string) $menu_name) === false)
 			{
 				$sql2->delete("menus", "menu_name='$menu_name'");
 				$message .= MENLAN_11 . " - " . $menu_name . "<br />";
@@ -725,7 +725,7 @@ class e_menuManager
 
 		if(file_exists(e_PLUGIN.$row['menu_path']."e_menu.php")) // v2.x new e_menu.php
 		{
-			$plug = rtrim($row['menu_path'],'/');
+			$plug = rtrim((string) $row['menu_path'],'/');
 			$obj = e107::getAddon($plug,'e_menu');
 
 
@@ -737,7 +737,7 @@ class e_menuManager
 			}
 			else
 			{
-				$menuName = substr($row['menu_name'],0,-5);
+				$menuName = substr((string) $row['menu_name'],0,-5);
 			}
 
 			$menuName = varset($menuName);
@@ -845,19 +845,19 @@ class e_menuManager
 		$frm = e107::getForm();
 		$tp = e107::getParser();
 
-		
+
 		require_once(e_HANDLER."userclass_class.php");
-		
+
 		if(!$sql->select("menus", "*", "menu_id=".intval($_GET['vis'])))
 		{
         	$this->menuAddMessage(MENLAN_48,E_MESSAGE_ERROR);
             return;
 		}
-		
+
 		$row = $sql->fetch();
-		
-		$listtype 	= substr($row['menu_pages'], 0, 1);
-		$menu_pages = substr($row['menu_pages'], 2);
+
+		$listtype 	= substr((string) $row['menu_pages'], 0, 1);
+		$menu_pages = substr((string) $row['menu_pages'], 2);
 		$menu_pages = str_replace("|", "\n", $menu_pages);
 
 		$text = "<div>
@@ -875,45 +875,45 @@ class e_menuManager
 			<tr><td><div class='radio'>
 		";
 		$checked = ($listtype == 1) ? " checked='checked' " : "";
-		
+
 		$text .= $frm->radio('listtype', 1, $checked, array('label'=>$tp->toHTML(MENLAN_26,true), 'class'=> 'e-save'));
 		$text .= "<br />";
 	//	$text .= "<input type='radio' class='e-save' {$checked} name='listtype' value='1' /> ".MENLAN_26."<br />";
 		$checked = ($listtype == 2) ? " checked='checked' " : "";
-		
+
 		$text .= $frm->radio('listtype', 2, $checked, array('label'=> $tp->toHTML(MENLAN_27,true), 'class'=> 'e-save'));
-		
-		
+
+
 		// $text .= "<input type='radio' class='e-save' {$checked} name='listtype' value='2' /> ".MENLAN_27."<br />";
-		
+
 		$text .= "</div>
 		<div class='row' style='padding:10px'>
-			
+
 			<div class='pull-left span3' >
-		
+
 				<textarea name='pagelist' class='e-save span3 tbox' cols='60' rows='8'>" . $menu_pages . "</textarea>
 			</div>
 			<div class='  span4 col-md-4'><small>".MENLAN_28."</small></div>
 		</div></td></tr>
 		</table>";
-		
+
 		$text .= $frm->hidden('mode','visibility'); 
 		$text .= $frm->hidden('menu_id',intval($_GET['vis'])); // "<input type='hidden' name='menu_id' value='".intval($_GET['vis'])."' />";
-		
+
 		/*
 		$text .= "
 		<div class='buttons-bar center'>";
         $text .= $frm->admin_button('class_submit', MENLAN_6, 'update');
 
-		
+
 		</div>";
 		 */ 
 		$text .= "
 		</fieldset>
 		</form>
 		</div>";
-	
-		
+
+
 		return $text;
 		//$caption = MENLAN_7." ".$row['menu_name'];
 		//$ns->tablerender($caption, $text);
@@ -982,7 +982,7 @@ class e_menuManager
 	{
 		$pref = e107::getPref();
 		$key = key($array);
-		$pref['sitetheme_custompages'][$key] = array_filter(explode(" ",$array[$key]));
+		$pref['sitetheme_custompages'][$key] = array_filter(explode(" ",(string) $array[$key]));
 		save_prefs();
 	}
 
@@ -1127,7 +1127,7 @@ class e_menuManager
 		if($sql->update("menus", "menu_class='".intval($_POST['menu_class'])."', menu_pages='{$pageparms}' WHERE menu_id=".intval($_POST['menu_id'])))
 		{
 			e107::getLog()->add('MENU_02',$_POST['menu_class'].'[!br!]'.$pageparms.'[!br!]'.$this->menuId,E_LOG_INFORMATIVE,'');
-						
+
 			return array('msg'=>LAN_UPDATED, 'error'=> false);
 			//$this->menuAddMessage($message,E_MESSAGE_SUCCESS);
 		}
@@ -1253,7 +1253,7 @@ class e_menuManager
 			else
 			{
 				$menuPreset = varset($menuPreset);
-				$row['menu_name'] = preg_replace("#_menu$#i", "", $row['menu_name']);
+				$row['menu_name'] = preg_replace("#_menu$#i", "", (string) $row['menu_name']);
 	            if($pnum = $this->checkMenuPreset($menuPreset,$row['menu_name'].'_menu'))
 				{
 		        	$pdeta = MENLAN_39."  {$pnum}";
@@ -1262,7 +1262,7 @@ class e_menuManager
 
 	        if(!$this->dragDrop)
 			{
-				$menuInf = (!is_numeric($row['menu_path'])) ? ' ('.substr($row['menu_path'],0,-1).')' : " ( #".$row['menu_path']." )";
+				$menuInf = (!is_numeric($row['menu_path'])) ? ' ('.substr((string) $row['menu_path'],0,-1).')' : " ( #".$row['menu_path']." )";
 	    	//	$menuInf = $row['menu_path'];
 	    		
 	    		$text .= "<tr style='background-color:$color;color:black'>
@@ -1301,7 +1301,7 @@ class e_menuManager
 
 	//	echo "<div id='portal'>";
 		$this->parseheader($HEADER);  // $layouts_str;
-		
+
 		$layout = ($this->curLayout);
 		$menuPreset = $this->getMenuPreset();
 
@@ -1315,8 +1315,8 @@ class e_menuManager
 		<td style='color:#2F2F2F;width:50%;padding-bottom:8px;text-align:center'>...".MENLAN_37."</td></tr>";
 		$text .= "<tr><td  style='width:35%;vertical-align:top;text-align:center'>";
 
-	 
-		
+
+
 
 
 
@@ -1337,7 +1337,7 @@ class e_menuManager
 		$pluginMenu = array();
 
 		$done = array();
-		
+
 		$sql->select("menus", "menu_name, menu_id, menu_pages, menu_path", "1 ORDER BY menu_name ASC");
 		while ($row = $sql->fetch())
 		{
@@ -1357,7 +1357,7 @@ class e_menuManager
 			{
 				$pluginMenu[] = $row;	
 			}
-						
+
 		}
 
 		$text .= "<tr><th colspan='2'>".MENLAN_49."</th></tr>";
@@ -1366,7 +1366,7 @@ class e_menuManager
 		{	
 			$text .= $this->renderOptionRow($row);	
 		}
-		
+
 		$text .= "<tr><th colspan='2' >".MENLAN_50."</th></tr>";
 		foreach($pluginMenu as $row)
 		{	
@@ -1379,7 +1379,7 @@ class e_menuManager
 		$text .= "</td><td id='menu-manage-actions' ><br />";
 		foreach ($this->menu_areas as $menu_act)
 		{
-			$text .= "<input type='submit' class='menu-btn' id='menuActivate_".trim($menu_act)."' name='menuActivate[".trim($menu_act)."]' value='".MENLAN_13." ".trim($menu_act)."' /><br /><br />\n";
+			$text .= "<input type='submit' class='menu-btn' id='menuActivate_".trim((string) $menu_act)."' name='menuActivate[".trim((string) $menu_act)."]' value='".MENLAN_13." ".trim((string) $menu_act)."' /><br /><br />\n";
 		}
 
 
@@ -1401,13 +1401,13 @@ class e_menuManager
 		{
 			$text = "<div class='alert alert-block alert-warning text-left'>";
 			$text .= MENLAN_51."<br />";
-			
+
 			if(isset($this->customMenu) && count($this->customMenu))
 			{
 				$text .= "<p>".MENLAN_52."<ul ><li>".implode("</li><li>",$this->customMenu)."</li></ul></p>";	
 				$text .= "<p><a href='".e_ADMIN."cpage.php?mode=menu&action=list&tab=2' class='button btn btn-primary'>".MENLAN_53."</a></p>";
 			}
-			
+
 			$text .= "</div>";
 		}
 	//	$ns -> tablerender(MENLAN_22.'blabla', $text);
@@ -1493,7 +1493,7 @@ class e_menuManager
 	//	}
 
 		// Split up using the same function as the shortcode handler
-		$tmp = preg_split('#(\{\S[^\x02]*?\S\})#', $LAYOUT, -1, PREG_SPLIT_NO_EMPTY | PREG_SPLIT_DELIM_CAPTURE);
+		$tmp = preg_split('#(\{\S[^\x02]*?\S\})#', (string) $LAYOUT, -1, PREG_SPLIT_NO_EMPTY | PREG_SPLIT_DELIM_CAPTURE);
 		$str = array();
 		for($c = 0, $cMax = count($tmp); $c < $cMax; $c++)
 		{
@@ -1582,9 +1582,9 @@ class e_menuManager
 	//	{
 	//		echo $tp->parseTemplate("{LOGO}");
 	//	}
-		if(strpos($str, "SETSTYLE") !== false)
+		if(strpos((string) $str, "SETSTYLE") !== false)
 		{
-			$style = preg_replace("/\{SETSTYLE=(.*?)\}/si", "\\1", $str);
+			$style = preg_replace("/\{SETSTYLE=(.*?)\}/si", "\\1", (string) $str);
 
 			$this->style = $style;
 			$ns->setStyle($style);
@@ -1608,14 +1608,14 @@ class e_menuManager
 	//		$tp->parseTemplate("{NAVIGATION".$cust."}",true);
 		//	echo "<span class='label label-info'>Navigation Area</span>";
 	//	}
-		elseif(strpos($str, '{---MODAL---}') !== false)
+		elseif(strpos((string) $str, '{---MODAL---}') !== false)
 		{
 			//echo "\n<!-- Modal would appear here --> \n";
 			echo '<div id="uiAlert" class="notifications center"><!-- empty --></div>';
 
 			//TODO Store in a central area - currently used in header.php, header_default.php and here.
 			echo '
-       
+
 	         <div id="uiModal" class="modal  fade" tabindex="-1" role="dialog"  aria-hidden="true">
 	            <div class="modal-dialog modal-lg">
 					<div class="modal-content">
@@ -1623,11 +1623,11 @@ class e_menuManager
 	                        <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
 	                        <h4 class="modal-caption">&nbsp;</h4>
 	                     </div>
-	
+
 	                    <div class="modal-body">
 	                        <p>Loading…</p>
 	                    </div>
-	
+
 	                    <div class="modal-footer">
 	                        <a href="#" data-dismiss="modal" class="btn btn-primary">Close</a>
 	                    </div>
@@ -1637,31 +1637,31 @@ class e_menuManager
 
 			//echo getModal();
 		}
-		elseif(strpos($str, '{---CAPTION---}') !== false)
+		elseif(strpos((string) $str, '{---CAPTION---}') !== false)
 		{
 			echo LAN_CAPTION;
 		}
-		elseif(strpos($str, '{LAYOUT_ID}') !== false)
+		elseif(strpos((string) $str, '{LAYOUT_ID}') !== false)
 		{
 			echo 'layout-'.e107::getForm()->name2id($this->curLayout);
 		}
-		elseif(strpos($str, "ALERT") !== false)
+		elseif(strpos((string) $str, "ALERT") !== false)
 		{
 			echo '';
 			//echo "[Navigation Area]";
 		}
-		elseif(strpos($str, "LANGUAGELINKS") !== false)
+		elseif(strpos((string) $str, "LANGUAGELINKS") !== false)
 		{
 			echo "<div class=text style='padding: 2px; text-align: center'>[".defset('ADLAN_132', "Language")."]</div>";
 		}
-		elseif(strpos($str, "CUSTOM") !== false)
+		elseif(strpos((string) $str, "CUSTOM") !== false)
 		{
-			$cust = preg_replace("/\W*\{CUSTOM=(.*?)(\+.*)?\}\W*/si", "\\1", $str);
+			$cust = preg_replace("/\W*\{CUSTOM=(.*?)(\+.*)?\}\W*/si", "\\1", (string) $str);
 			echo "<div style='padding: 2px'>[" . $cust . "]</div>";
 		}
-		elseif(strpos($str, "CMENU") !== false)
+		elseif(strpos((string) $str, "CMENU") !== false)
 		{
-			$cust = preg_replace("/\W*\{CMENU=(.*?)(\+.*)?\}\W*/si", "\\1", $str);
+			$cust = preg_replace("/\W*\{CMENU=(.*?)(\+.*)?\}\W*/si", "\\1", (string) $str);
 			if(isset($this->customMenu))
 			{
 				$this->customMenu[] = $cust;
@@ -1669,9 +1669,9 @@ class e_menuManager
 			echo $tp->parseTemplate("{CMENU=".$cust."}",true);
 		//	echo $this->renderPanel('Embedded Custom Menu',$cust);
 		}
-		elseif(strpos($str, "SETIMAGE") !== false)
+		elseif(strpos((string) $str, "SETIMAGE") !== false)
 		{
-			$cust = preg_replace("/\W*\{SETIMAGE(.*?)(\+.*)?\}\W*/si", "\\1", $str);
+			$cust = preg_replace("/\W*\{SETIMAGE(.*?)(\+.*)?\}\W*/si", "\\1", (string) $str);
 			echo $tp->parseTemplate("{SETIMAGE".$cust."}",true);
 		//	echo $this->renderPanel('Embedded Custom Menu',$cust);
 		}
@@ -1680,26 +1680,26 @@ class e_menuManager
 			echo "<div class=text style='padding: 30px; text-align: center'>[Welcome Message Area]</div>";
 		//	echo $this->renderPanel('Embedded Custom Menu',$cust);
 		}*/
-		elseif(strpos($str, "{FEATUREBOX") !== false)
+		elseif(strpos((string) $str, "{FEATUREBOX") !== false)
 		{
 			echo "<div class=text style='padding: 80px; text-align: center'>[".LAN_PLUGIN_FEATUREBOX_NAME."]</div>";
 		//	echo $this->renderPanel('Embedded Custom Menu',$cust);
 		}
 		// Display embedded Plugin information.
-		else if(strpos($str, "PLUGIN") !== false)
+		else if(strpos((string) $str, "PLUGIN") !== false)
 		{
-			$plug = preg_replace("/\{PLUGIN=(.*?)\}/si", "\\1", $str);
+			$plug = preg_replace("/\{PLUGIN=(.*?)\}/si", "\\1", (string) $str);
 			$plug = trim($plug);
 			if(file_exists((e_PLUGIN . "{$plug}/{$plug}_config.php")))
 			{
 				$link = e_PLUGIN . "{$plug}/{$plug}_config.php";
 			}
-			
+
 			if(file_exists((e_PLUGIN . $plug . "/config.php")))
 			{
 				$link = e_PLUGIN . $plug . "/config.php";
 			}
-			
+
 		//	$plugtext = "<div class='menu-panel'>";
 		//	$plugtext .= "<div class='menu-panel-header' title=\"".MENLAN_34."\">".$plug."</div>";
 			$plugtext = (varset($link)) ? "(" . MENLAN_34 . ":<a href='$link btn-menu' title='" . LAN_CONFIGURE . "'>" . LAN_CONFIGURE . "</a>)" : "";
@@ -1708,18 +1708,18 @@ class e_menuManager
 			echo $this->renderPanel($plug, $plugtext);
 			// $ns->tablerender($plug, $plugtext);
 		}
-		else if(strpos($str, "MENU") !== false)
+		else if(strpos((string) $str, "MENU") !== false)
 		{
 
 			$matches = array();
-			if(preg_match_all("/\{(?:MENU|MENUAREA)=([\d]{1,3})(:[\w\d]*)?\}/", $str, $matches)) //
+			if(preg_match_all("/\{(?:MENU|MENUAREA)=([\d]{1,3})(:[\w\d]*)?\}/", (string) $str, $matches)) //
 			{
 
 				$menuText = "";
 				foreach($matches[1] as $menu)
 				{
-					$menu = preg_replace("/\{(?:MENU|MENUAREA)=(.*?)(:.*?)?\}/si", "\\1", $str);
-					if(isset($sc_style['MENU']['pre']) && strpos($str, 'ret') !== false)
+					$menu = preg_replace("/\{(?:MENU|MENUAREA)=(.*?)(:.*?)?\}/si", "\\1", (string) $str);
+					if(isset($sc_style['MENU']['pre']) && strpos((string) $str, 'ret') !== false)
 					{
 						$menuText .= $sc_style['MENU']['pre'];
 					}
@@ -1738,7 +1738,7 @@ class e_menuManager
 					{
 						unset($text);
 						$menuText .= $rs->form_open("post", e_SELF . "?configure=" . $this->curLayout, "frm_menu_" . intval($menu));
-						
+
 					//	$rows = $sql9->retrieve("menus", "*", "menu_location='$menu' AND menu_layout='" . $this->dbLayout . "' ORDER BY menu_order",true);
 						$rows = $this->menuData[$menu];
 					//	$menu_count = $sql9->db_Rows();
@@ -1751,24 +1751,24 @@ class e_menuManager
 						}
 
 						$cl = ($this->dragDrop) ? "'portlet" : "regularMenu";
-						
+
 						$menuText .= "\n<div class='column' id='area-".$menu."'>\n\n";
 					//	while($row = $sql9->fetch())
 						foreach($rows as $row)
 						{
 							$menuText .= "\n\n\n <!-- Menu Start ".$row['menu_name']. "-->\n";
 							$menuText .= "<div class='{$cl}' id='block-".$row['menu_id']."-".$menu."'>\n";
-		
+
 						//	echo "<div class='ggportal'>";
-							
+
 						//	$menuText .= "hi there";
 							$menuText .= $this->menuRenderMenu($row, $menu_count);
-							
+
 						//	echo "\n</div>";
 							$menuText .= "\n</div>\n";
 							$menuText .= "<!-- Menu end -->\n\n\n";
 							// echo "<div><br /></div>";
-						
+
 						}
 						$menuText .= "\n\n</div>\n\n"; // End Column 
 						$menuText .= $rs->form_close();
@@ -1777,18 +1777,18 @@ class e_menuManager
 					{	// placeholder
 						$menuText .=  "<div class='column' id='area-" . $menu . "'><!-- --></div>";
 					}
-					
+
 					$menuText .= "</div><!-- END OF AREA -->\n\n";
-					
+
 					// ---------------
-					
-					
-					if(isset($sc_style['MENU']['post']) && strpos($str, 'ret') !== false)
+
+
+					if(isset($sc_style['MENU']['post']) && strpos((string) $str, 'ret') !== false)
 					{
 						$menuText .= $sc_style['MENU']['post'];
 					}
-					
-					
+
+
 				}
 
 				echo $menuText;
@@ -1831,15 +1831,15 @@ class e_menuManager
 		if(empty($menu_id)){ return; }
 
 		$menu_name = varset($menu_name);
-		$menu_name = preg_replace("#_menu#i", "", $menu_name);
+		$menu_name = preg_replace("#_menu#i", "", (string) $menu_name);
 		//TODO we need a CSS class for this
-		$vis = (varset($menu_class) || strlen(varset($menu_pages)) > 1) ? " <span class='required'><i class='e-mm-icon-search'></i></span> " : "";
+		$vis = (varset($menu_class) || strlen((string) varset($menu_pages)) > 1) ? " <span class='required'><i class='e-mm-icon-search'></i></span> " : "";
 		//DEBUG div not allowed in final tags 	$caption = "<div style='text-align:center'>{$menu_name}{$vis}</div>";
 		// use theme render style instead
 		
 		// Undocumented special parameter 'admin_title'
 		$menuParms = array();
-		if(!empty($row['menu_parms'])) parse_str($row['menu_parms'], $menuParms);
+		if(!empty($row['menu_parms'])) parse_str((string) $row['menu_parms'], $menuParms);
 		if(isset($menuParms['admin_title']) && $menuParms['admin_title'])
 		{
 			$caption = deftrue($menuParms['admin_title'], $menuParms['admin_title']).$vis;
@@ -1936,10 +1936,10 @@ class e_menuManager
 		
 		if(!$this->dragDrop)
 		{
-				
+
 			return "<span class='muted'>".$caption."</span><br />". $text;
 		//	return;
-	
+
 
 		//	return $ns->tablerender($caption, $text,'', true); Theme style too unpredictable. 
 			
@@ -1963,34 +1963,34 @@ class e_menuManager
 	 */
 	function menuSaveAjax($mode = null)
 	{
-		
-		
+
+
 		if($mode == 'visibility')
 		{
-		
+
 			$ret = $this->menuSaveVisibility();	
 		//	echo json_encode($ret);
 			return null;
 		}		
-		
+
 		if($mode == 'delete')
 		{
-			list($tmp,$area) = explode("-",$_POST['area']);
-		
+			list($tmp,$area) = explode("-",(string) $_POST['area']);
+
 			if($_POST['area'] == 'remove')
 			{
-				list($tmp,$deleteID) = explode("-",$_POST['removeid']);	
+				list($tmp,$deleteID) = explode("-",(string) $_POST['removeid']);	
 				$this->menuId = $deleteID;
 
 				$ret = $this->menuDeactivate();	
 			//	echo json_encode($ret);
-				
+
 				return null;
 			}	
-			
+
 		}
-		
-		
+
+
 		if($mode == 'parms') 
 		{
 			$ret = $this->menuSaveParameters();
@@ -2000,53 +2000,53 @@ class e_menuManager
 			}
 			return null;
 		}
-		
-		
-		
+
+
+
     // 	print_r($_POST);
 		return;
-	 
-	 
+
+
 		$this->debug = TRUE;
-		
+
 		$sql = e107::getDb();
 
 
-		
+
 
 		// Allow deletion by ajax, but not the rest when drag/drop disabled.  
 
 		if(!$this->dragDrop){ return; }
 
 		$this -> dbLayout = $_POST['layout'];
-		list($tmp,$insertID) = explode("-",$_POST['insert']);	
+		list($tmp,$insertID) = explode("-",(string) $_POST['insert']);	
 		$insert[] = $insertID;
 
-		
+
 
 		if($_POST['mode'] == 'insert'  && count($insert) && $area) // clear out everything before rewriting everything to db. 
 		{
 		 	$this->menuActivateLoc = $area;  // location
 			$this->menuActivateIds = $insert;  // array of ids, in order.
 			$this->menuActivate(); 
-			
+
 		}
 		elseif($_POST['mode'] == 'update')
 		{
 			$sql->update("menus","menu_location = ".intval($area)." WHERE menu_id = ".intval($insertID)."",$this->debug);
 		}
-		
+
 		$c = 0;
-		
+
 		if(count($_POST['list'])<2)
 		{
 			return;
 		}
-		
+
 		// resort the menus in this 'Area"
 		foreach($_POST['list'] as $val)
 		{
-			list($b,$id) = explode("-",$val);
+			list($b,$id) = explode("-",(string) $val);
 			$order[] = $id;
 			$sql->update("menus","menu_order = ".$c." WHERE menu_id = ".intval($id)."",$this->debug);
        		$c++;
@@ -2076,7 +2076,7 @@ class e_menuManager
 			{
 				$link = "";
 
-				$id = substr($row['menu_path'],0,-1);
+				$id = substr((string) $row['menu_path'],0,-1);
 
 				if (file_exists(e_PLUGIN."{$row['menu_path']}{$row['menu_name']}_menu_config.php"))
 				{
@@ -2158,7 +2158,7 @@ class e_mm_layout
 
 			if(vartrue($_GET['enc']))
 			{
-				$string = base64_decode($_GET['enc']);
+				$string = base64_decode((string) $_GET['enc']);
 				parse_str($string,$_GET);
 			}
 
@@ -2239,7 +2239,7 @@ class e_mm_layout
 		{
 			e107::css('inline',"
 				.menuOption { display: none }
-			
+
 			");
 
 
@@ -2345,8 +2345,8 @@ class e_mm_layout
 
 		$tp = e107::getParser();
 
-		$head = preg_replace_callback("/\{MENU=([\d]{1,3})(:[\w\d]*)?\}/", array($this, 'renderMenuArea'), $HEADER[THEME_LAYOUT]);
-		$foot = preg_replace_callback("/\{MENU=([\d]{1,3})(:[\w\d]*)?\}/", array($this, 'renderMenuArea'), $FOOTER[THEME_LAYOUT]);
+		$head = preg_replace_callback("/\{MENU=([\d]{1,3})(:[\w\d]*)?\}/", array($this, 'renderMenuArea'), (string) $HEADER[THEME_LAYOUT]);
+		$foot = preg_replace_callback("/\{MENU=([\d]{1,3})(:[\w\d]*)?\}/", array($this, 'renderMenuArea'), (string) $FOOTER[THEME_LAYOUT]);
 
 		global $style;
 
@@ -2399,7 +2399,7 @@ class e_mm_layout
 
 		foreach($pageMenu as $row)
 		{
-			$menuInf = (!is_numeric($row['menu_path'])) ? ' (' . substr($row['menu_path'], 0, -1) . ')' : " (#" . $row['menu_path'] . ")";
+			$menuInf = (!is_numeric($row['menu_path'])) ? ' (' . substr((string) $row['menu_path'], 0, -1) . ')' : " (#" . $row['menu_path'] . ")";
 			$tab1 .= "<li>" . $frm->checkbox('menuselect[]', $row['menu_id'], '', array('label' => "<span>" . $row['menu_name'] . "<small>" . $menuInf . "</small></span>")) . "</li>";
 		}
 
@@ -2408,7 +2408,7 @@ class e_mm_layout
 		$tab2 = '<div class="menu-selector"><ul class=" list-unstyled">';
 		foreach($pluginMenu as $row)
 		{
-			$menuInf = (!is_numeric($row['menu_path'])) ? ' (' . substr($row['menu_path'], 0, -1) . ')' : " (#" . $row['menu_path'] . ")";
+			$menuInf = (!is_numeric($row['menu_path'])) ? ' (' . substr((string) $row['menu_path'], 0, -1) . ')' : " (#" . $row['menu_path'] . ")";
 			$tab2 .= "<li>" . $frm->checkbox('menuselect[]', $row['menu_id'], '', array('label' => "<span>" . $row['menu_name'] . "<small>" . $menuInf . "</small></span>")) . "</li>";
 		}
 
@@ -2449,7 +2449,7 @@ class e_mm_layout
 
 			foreach($areas as $menu_act)
 			{
-				$text .= "<input type='submit' class='btn btn-sm btn-primary col-xs-6'  name='menuActivate[" . trim($menu_act) . "]' value=\"" . $tp->lanVars($menuButtonLabel, trim($menu_act)) . "\" />\n";
+				$text .= "<input type='submit' class='btn btn-sm btn-primary col-xs-6'  name='menuActivate[" . trim((string) $menu_act) . "]' value=\"" . $tp->lanVars($menuButtonLabel, trim((string) $menu_act)) . "\" />\n";
 			}
 
 			$text .= '</div></li></ul>';
@@ -2542,10 +2542,10 @@ class e_mm_layout
 			$themeFileContent = preg_replace("/e107::lan\(['|\"]theme.*\);/","e107::themeLan(null, '".$theme."');", $themeFileContent);
 		//	$themeFileContent = preg_replace("/define\(['|\"]BOOTSTRAP['|\"].*;/", '', $themeFileContent);
 		//	$themeFileContent = preg_replace("/define\(['|\"]FONTAWESOME['|\"].*;/", '', $themeFileContent);
-			$themeFileContent = preg_replace("/LAN_[\w]*/", '""', $themeFileContent);
-			$themeFileContent = preg_replace("/include_lan\(.*;/", '', $themeFileContent);
+			$themeFileContent = preg_replace("/LAN_[\w]*/", '""', (string) $themeFileContent);
+			$themeFileContent = preg_replace("/include_lan\(.*;/", '', (string) $themeFileContent);
 
-			$themeFileContent = preg_replace("/define\(.*;/", '', $themeFileContent);
+			$themeFileContent = preg_replace("/define\(.*;/", '', (string) $themeFileContent);
 
 			$themeFileContent = preg_replace('/\(\s?THEME\s?\./', '( e_THEME. "' . $theme . '/" .', str_replace($srch, '', $themeFileContent));
 
@@ -2616,9 +2616,9 @@ class e_mm_layout
 					continue;
 				}
 
-				if(strpos($template, '{---}') !== false)
+				if(strpos((string) $template, '{---}') !== false)
 				{
-					list($hd, $ft) = explode("{---}", $template);
+					list($hd, $ft) = explode("{---}", (string) $template);
 					$head[$key] = isset($LAYOUT['_header_']) ? $LAYOUT['_header_'] . $hd : $hd;
 					$foot[$key] = isset($LAYOUT['_footer_']) ? $ft . $LAYOUT['_footer_'] : $ft;
 				}
@@ -2705,14 +2705,14 @@ class e_mm_layout
 	private static function countMenus($template, $name)
 	{
 
-		if(preg_match_all("/\{(?:MENU|MENUAREA)=([\d]{1,3})(:[\w\d]*)?\}/", $template, $matches))
+		if(preg_match_all("/\{(?:MENU|MENUAREA)=([\d]{1,3})(:[\w\d]*)?\}/", (string) $template, $matches))
 		{
 			sort($matches[1]);
 
 			return $matches[1];
 		}
 
-		e107::getDebug()->log("No Menus Found in Template:" . $name . " with strlen: " . strlen($template));
+		e107::getDebug()->log("No Menus Found in Template:" . $name . " with strlen: " . strlen((string) $template));
 
 		return array();
 	}
@@ -2952,8 +2952,8 @@ class e_mm_layout
 	*/
 
 
-		$listtype 	= substr($_GET['pages'], 0, 1);
-		$menu_pages = substr($_GET['pages'], 2);
+		$listtype 	= substr((string) $_GET['pages'], 0, 1);
+		$menu_pages = substr((string) $_GET['pages'], 2);
 		$menu_pages = str_replace("|", "\n", $menu_pages);
 
 		$text = "<div>
@@ -2984,9 +2984,9 @@ class e_mm_layout
 
 		$text .= "</div>
 		<div class='row' style='padding:10px'>
-			
+
 			<div class='pull-left span3' >
-		
+
 				<textarea name='pagelist' class='e-save span3' cols='60' rows='8' class='tbox'>".$menu_pages."</textarea>
 			</div>
 			<div class='  span4 col-md-4'><small>".MENLAN_28."</small></div>
@@ -3096,7 +3096,7 @@ class e_mm_layout
 					cursor: "move",
 					iframeFix: true,
 			        refreshPositions: true
-			       
+
 				});
 		 })'
 		 );

--- a/e107_handlers/message_handler.php
+++ b/e107_handlers/message_handler.php
@@ -1149,7 +1149,7 @@ $SYSTEM_DIRECTORY    = "e107_system/";</pre>
 				$emailLogFile = e_LOG.'criticalErrorEmail'.date('Ymd').'.log';
 				if(!file_exists($emailLogFile))
 				{
-					@mail(e_EMAIL_CRITICAL, $subject, $date."\t\t". strip_tags($message));
+					@mail((string) e_EMAIL_CRITICAL, $subject, $date."\t\t". strip_tags($message));
 					@file_put_contents(e_LOG.'criticalErrorEmail'.date('Ymd').'.log', 'Critical Error email sent to '.e_EMAIL_CRITICAL);
 				}
 				$message = LAN_ERROR_11; // "Check log for details";

--- a/e107_handlers/model_class.php
+++ b/e107_handlers/model_class.php
@@ -1553,7 +1553,7 @@ class e_model extends e_object
 			$res = $sql->select(
 				$this->getModelTable(),
 				$this->getParam('db_fields', '*'),
-				$this->getFieldIdName().'='.$id.' '.trim($this->getParam('db_where', '')),
+				$this->getFieldIdName().'='.$id.' '.trim((string) $this->getParam('db_where', '')),
 				'default',
 				($this->getParam('db_debug') ? true : false)
 			);
@@ -2696,7 +2696,7 @@ class e_front_model extends e_model
 		// FIXME make this more accurate - commonly used field names could conflict. @see e_front_modelTest::testSanitize()
 		foreach($this->_data_fields as $k=>$var)
 		{
-			if(strpos($k,'/') !== false && strpos($k, $key) !== false)
+			if(strpos((string) $k,'/') !== false && strpos((string) $k, (string) $key) !== false)
 			{
 				return $this->_data_fields[$k];
 			}
@@ -3369,7 +3369,7 @@ class e_tree_model extends e_front_model
 				:
 					$this->getParam('db_query');
 
-			return $this->setCacheString($this->getCacheString().'_'.md5($str));
+			return $this->setCacheString($this->getCacheString().'_'.md5((string) $str));
 		}
 
 		return parent::setCacheString($str);
@@ -3744,7 +3744,7 @@ class e_tree_model extends e_front_model
 			}
 
 			return "";
-		}, $db_query);
+		}, (string) $db_query);
 		$this->setParam('db_query', $db_query);
 	}
 
@@ -3783,7 +3783,7 @@ class e_tree_model extends e_front_model
 					);
 
 				return "";
-			}, $db_query)
+			}, (string) $db_query)
 			// Optimization goes with e_tree_model::moveRowsToTreeNodes()
 			. " ORDER BY " . $this->getParam('sort_parent') . "," . $this->getParam('primary_field');
 		$this->setParam('db_query', $db_query);
@@ -4126,7 +4126,7 @@ class e_admin_tree_model extends e_front_tree_model
 
 		if(!is_array($ids))
 		{
-			$ids = explode(',', $ids);
+			$ids = explode(',', (string) $ids);
 		}
 
 		$tp = e107::getParser();
@@ -4171,7 +4171,7 @@ class e_admin_tree_model extends e_front_tree_model
 					$this->getNode($id)->clearCache()->setMessages($session_messages);
 					if($destroy)
 					{
-						call_user_func(array($this->getNode(trim($id)), 'destroy')); // first call model destroy method if any
+						call_user_func(array($this->getNode(trim((string) $id)), 'destroy')); // first call model destroy method if any
 						$this->setNode($id, null);
 					}
 				}

--- a/e107_handlers/mysql_class.php
+++ b/e107_handlers/mysql_class.php
@@ -392,7 +392,7 @@ class e_db_mysql implements e_db
 		{
 			$this->dbg->log($query);
 		}
-		if ($debug !== FALSE || strpos($_SERVER['QUERY_STRING'], 'showsql') !== false)
+		if ($debug !== FALSE || strpos((string) $_SERVER['QUERY_STRING'], 'showsql') !== false)
 		{
 			$debugQry = is_array($query) ? print_a($query,true) : $query;
 			$queryinfo[] = "<b>{$qry_from}</b>: ".$debugQry;
@@ -1464,7 +1464,7 @@ class e_db_mysql implements e_db
 		}
 		elseif ($this->mySQLresult === TRUE)
 		{	// Successful query which may return a row count (because it operated on a number of rows without returning a result set)
-			if(preg_match('#^(DELETE|INSERT|REPLACE|UPDATE)#',$query, $matches))
+			if(preg_match('#^(DELETE|INSERT|REPLACE|UPDATE)#',(string) $query, $matches))
 			{	// Need to check mysqli_affected_rows() - to return number of rows actually updated
 				$tmp = mysqli_affected_rows($this->mySQLaccess);
 				$this->dbError('db_Select_gen');
@@ -1502,7 +1502,7 @@ class e_db_mysql implements e_db
 			$this->tabset = true;
 		}
 
-		return " ".$this->mySQLPrefix.$table.substr($matches[0],-1);
+		return " ".$this->mySQLPrefix.$table.substr((string) $matches[0],-1);
 	}
 
 	/**
@@ -1547,9 +1547,9 @@ class e_db_mysql implements e_db
 			foreach($this->mySQLtableList as $tab)
 			{
 
- 				if(strpos($tab, "lan_") === 0)
+ 				if(strpos((string) $tab, "lan_") === 0)
 				{
-					list($tmp,$lng,$tableName) = explode("_",$tab,3);
+					list($tmp,$lng,$tableName) = explode("_",(string) $tab,3);
 
                     foreach($table as $t)
 					{
@@ -1804,7 +1804,7 @@ class e_db_mysql implements e_db
 
       	foreach($tmp as $val)
 		{
-   			if(strpos($val,$this->mySQLPrefix) !== false) // search for table names references using the mprefix
+   			if(strpos($val,(string) $this->mySQLPrefix) !== false) // search for table names references using the mprefix
 			{
     			$table[] = str_replace(array($this->mySQLPrefix,"`"),"", $val);
 				$search[] = str_replace("`","",$val);
@@ -2142,9 +2142,9 @@ class e_db_mysql implements e_db
 		$database = !empty($this->mySQLdefaultdb) ? "FROM  `".$this->mySQLdefaultdb."`" : "";
 		$prefix = $this->mySQLPrefix;
 
-		if(strpos($prefix, ".") !== false) // eg. `my_database`.$prefix
+		if(strpos((string) $prefix, ".") !== false) // eg. `my_database`.$prefix
 		{
-			$tmp = explode(".",$prefix);
+			$tmp = explode(".",(string) $prefix);
 			$prefix = $tmp[1];
 		}
 
@@ -2153,7 +2153,7 @@ class e_db_mysql implements e_db
 			if(!isset($this->mySQLtableListLanguage[$language]))
 			{
 				$table = array();
-				if($res = $this->db_Query("SHOW TABLES ".$database." LIKE '".$prefix."lan_".strtolower($language)."%' "))
+				if($res = $this->db_Query("SHOW TABLES ".$database." LIKE '".$prefix."lan_".strtolower((string) $language)."%' "))
 				{
 					while($rows = $this->fetch('num'))
 					{
@@ -2175,10 +2175,10 @@ class e_db_mysql implements e_db
 
 			if($res = $this->db_Query("SHOW TABLES ".$database." LIKE '".$prefix."%' "))
 			{
-				$length = strlen($prefix);
+				$length = strlen((string) $prefix);
 				while($rows = $this->fetch('num'))
 				{
-					$table[] = substr($rows[0],$length);
+					$table[] = substr((string) $rows[0],$length);
 				}
 			}
 			return $table;
@@ -2235,7 +2235,7 @@ class e_db_mysql implements e_db
 			$ret = array();
 			foreach($this->mySQLtableList as $table)
 			{
-				if(substr($table,-4) != '_log' && $table != 'download_requests')
+				if(substr((string) $table,-4) != '_log' && $table != 'download_requests')
 				{
 					$ret[] = $table;
 				}
@@ -2258,7 +2258,7 @@ class e_db_mysql implements e_db
 
 			foreach($this->mySQLtableList as $tab)
 			{
-				if(strpos($tab,'lan_') === 0)
+				if(strpos((string) $tab,'lan_') === 0)
 				{
 					$lan[] = $tab;
 				}
@@ -2317,8 +2317,8 @@ class e_db_mysql implements e_db
 	 */
 	function db_CopyTable($oldtable, $newtable, $drop = FALSE, $data = FALSE)
 	{
-		$old = $this->mySQLPrefix.strtolower($oldtable);
-		$new = $this->mySQLPrefix.strtolower($newtable);
+		$old = $this->mySQLPrefix.strtolower((string) $oldtable);
+		$new = $this->mySQLPrefix.strtolower((string) $newtable);
 
 		if ($drop)
 		{
@@ -2334,7 +2334,7 @@ class e_db_mysql implements e_db
 			$row = $this->fetch('num');
 			$qry = $row[1];
 			//        $qry = str_replace($old, $new, $qry);
-			$qry = preg_replace("#CREATE\sTABLE\s`?".$old."`?\s#", "CREATE TABLE {$new} ", $qry, 1); // More selective search
+			$qry = preg_replace("#CREATE\sTABLE\s`?".$old."`?\s#", "CREATE TABLE {$new} ", (string) $qry, 1); // More selective search
 		}
 		else
 		{
@@ -2480,7 +2480,7 @@ class e_db_mysql implements e_db
 			else
 			{
 				// Check if MySQL version is utf8 compatible
-				preg_match('/^(.*?)($|-)/', $this->mySqlServerInfo, $mysql_version);
+				preg_match('/^(.*?)($|-)/', (string) $this->mySqlServerInfo, $mysql_version);
 				if (version_compare($mysql_version[1], '4.1.2', '<'))
 				{
 					// reset utf8

--- a/e107_handlers/news_class.php
+++ b/e107_handlers/news_class.php
@@ -613,12 +613,12 @@ class e_news_item extends e_front_model
 	 */
 	public function sc_news_field($parm = null)
 	{
-		$tmp = explode('|', $parm, 2);
+		$tmp = explode('|', (string) $parm, 2);
 		$field = $tmp[0];
 
 		if(!is_array($parm))
 		{
-			parse_str(varset($tmp[1]), $parm);
+			parse_str((string) varset($tmp[1]), $parm);
 		}
 		$val = $this->field($field, '');
 
@@ -631,7 +631,7 @@ class e_news_item extends e_front_model
 				case 'html':
 					$method = 'toHTML';
 					$callback = e107::getParser();
-					$parm['arg'] = explode(',', varset($parm['arg']));
+					$parm['arg'] = explode(',', (string) varset($parm['arg']));
 					$parm['arg'][0] = vartrue($parm['arg'][0]) ? true : false; //to boolean
 					$params = array($val); //value is always the first callback argument
 					$params += $parm['arg'];
@@ -1034,7 +1034,7 @@ class e_news_category_item extends e_front_model
 		{
 			return '';
 		}
-		if(strpos($this->cat('icon'), '{') === 0)
+		if(strpos((string) $this->cat('icon'), '{') === 0)
 		{
 			$src = e107::getParser()->replaceConstants($this->cat('icon'));
 		}

--- a/e107_handlers/notify_class.php
+++ b/e107_handlers/notify_class.php
@@ -150,9 +150,9 @@ class notify
 		$blockOriginator = FALSE;		// TODO: set this using a pref
 		$recipients = array();
 
-		if(strpos($notifyTarget, '::') !== false) // custom router @see e107_plugins/_blank/e_notify.php
+		if(strpos((string) $notifyTarget, '::') !== false) // custom router @see e107_plugins/_blank/e_notify.php
 		{
-			list($class,$method) = explode('::', $notifyTarget);
+			list($class,$method) = explode('::', (string) $notifyTarget);
 
 			if($cls = e107::getAddon($class,'e_notify'))
 			{
@@ -289,7 +289,7 @@ class notify
 					$mailData['mail_media'][$k] = array('path'=>$v);
 				}
 			}
-			
+
 			$mailer->sendEmails('notify', $mailData, $recipients);
 
 			e107::getLog()->addEvent(10,-1,'NOTIFY',$subject,$message,FALSE,LOG_TO_ROLLING);
@@ -495,7 +495,7 @@ class notify
 			'NEWS_AUTHOR'   => $tp->toHTML($author)
 		);
 
-		$img = explode(",",$data['news_thumbnail']);
+		$img = explode(",",(string) $data['news_thumbnail']);
 
 		$message = $tp->simpleParse($template, $shortcodes);
 

--- a/e107_handlers/online_class.php
+++ b/e107_handlers/online_class.php
@@ -99,7 +99,7 @@ class e_online
 
 		$online_timeout = 300;
 
-		list($ban_access_guest,$ban_access_member) = explode(',',e107::getPref('ban_max_online_access', '100,200'));
+		list($ban_access_guest,$ban_access_member) = explode(',',(string) e107::getPref('ban_max_online_access', '100,200'));
 		$online_bancount = max($ban_access_guest,50);					// Safety net for incorrect values
 		if ($user->isUser())
 		{
@@ -333,7 +333,7 @@ class e_online
 					{
 
 						$row['online_bot'] = $this->isBot($row['online_agent']);
-				
+
 						// Sort into usable format and add bot field. 
 						$user = array(
 							'user_location'		=> $row['online_location'],
@@ -348,10 +348,10 @@ class e_online
 							'online_user_id'	=> $row['online_user_id'],
 							'user_language'     => $row['online_language']
 						);	
-		
+
 						if($row['online_user_id'] != 0 )
 						{
-							$vals = explode('.', $row['online_user_id'], 2);
+							$vals = explode('.', (string) $row['online_user_id'], 2);
 							$user['user_id'] = $vals[0];
 							$user['user_name'] = $vals[1];
 							$member_list .= "<a href='".SITEURL."user.php?id.{$vals[0]}'>{$vals[1]}</a> ";
@@ -367,8 +367,8 @@ class e_online
 							$user['user_name'] = 'guest';		// Maybe should just be an empty string?
 							$this->guests[] = $user;	
 						}
-						
-						
+
+
 					}
 				}
 				if(!defined('TOTAL_ONLINE'))

--- a/e107_handlers/pclerror.lib.php
+++ b/e107_handlers/pclerror.lib.php
@@ -126,7 +126,7 @@ if (!defined("PCLERROR_LIB"))
   {
     global $g_pcl_error_string;
     global $g_pcl_error_code;
-    
+
     return($g_pcl_error_code);
   }
   // --------------------------------------------------------------------------------

--- a/e107_handlers/pcltar.lib.php
+++ b/e107_handlers/pcltar.lib.php
@@ -60,7 +60,7 @@ if (!defined("PCL_TAR"))
   $g_pcltar_version = "1.3";
 
   // ----- Extract extension type (.php3/.php/...)
-  $g_pcltar_extension = substr(strrchr(basename($PATH_TRANSLATED), '.'), 1);
+  $g_pcltar_extension = substr(strrchr(basename((string) $PATH_TRANSLATED), '.'), 1);
 
   // ----- Include other libraries
   // This library should be called by each script before the include of PhpZip
@@ -1469,7 +1469,7 @@ if (!defined("PCL_TAR"))
       }
 
       // ----- Check the path length
-      if (strlen($p_filename) > 99)
+      if (strlen((string) $p_filename) > 99)
       {
         // ----- Error log
         PclErrorLog(-5, "File name is too long (max. 99) : '$p_filename'");
@@ -1600,26 +1600,26 @@ if (!defined("PCL_TAR"))
     $v_stored_filename = $p_filename;
     if ($p_remove_dir != "")
     {
-      if (substr($p_remove_dir, -1) != '/')
+      if (substr((string) $p_remove_dir, -1) != '/')
         $p_remove_dir .= "/";
 
-      if ((substr($p_filename, 0, 2) == "./") || (substr($p_remove_dir, 0, 2) == "./"))
+      if ((substr((string) $p_filename, 0, 2) == "./") || (substr((string) $p_remove_dir, 0, 2) == "./"))
       {
-        if ((substr($p_filename, 0, 2) == "./") && (substr($p_remove_dir, 0, 2) != "./"))
+        if ((substr((string) $p_filename, 0, 2) == "./") && (substr((string) $p_remove_dir, 0, 2) != "./"))
           $p_remove_dir = "./".$p_remove_dir;
-        if ((substr($p_filename, 0, 2) != "./") && (substr($p_remove_dir, 0, 2) == "./"))
-          $p_remove_dir = substr($p_remove_dir, 2);
+        if ((substr((string) $p_filename, 0, 2) != "./") && (substr((string) $p_remove_dir, 0, 2) == "./"))
+          $p_remove_dir = substr((string) $p_remove_dir, 2);
       }
 
-      if (substr($p_filename, 0, strlen($p_remove_dir)) == $p_remove_dir)
+      if (substr((string) $p_filename, 0, strlen((string) $p_remove_dir)) == $p_remove_dir)
       {
-        $v_stored_filename = substr($p_filename, strlen($p_remove_dir));
+        $v_stored_filename = substr((string) $p_filename, strlen((string) $p_remove_dir));
         TrFctMessage(__FILE__, __LINE__, 3, "Remove path '$p_remove_dir' in file '$p_filename' = '$v_stored_filename'");
       }
     }
     if ($p_add_dir != "")
     {
-      if (substr($p_add_dir, -1) == "/")
+      if (substr((string) $p_add_dir, -1) == "/")
         $v_stored_filename = $p_add_dir.$v_stored_filename;
       else
         $v_stored_filename = $p_add_dir."/".$v_stored_filename;
@@ -1627,7 +1627,7 @@ if (!defined("PCL_TAR"))
     }
 
     // ----- Check the path length
-    if (strlen($v_stored_filename) > 99)
+    if (strlen((string) $v_stored_filename) > 99)
     {
       // ----- Error log
       PclErrorLog(-5, "Stored file name is too long (max. 99) : '$v_stored_filename'");
@@ -1935,15 +1935,15 @@ if (!defined("PCL_TAR"))
     $v_listing = FALSE;
 
     // ----- Check the path
-    if (($p_path == "") || ((substr($p_path, 0, 1) != "/") && (substr($p_path, 0, 3) != "../")))
+    if (($p_path == "") || ((substr((string) $p_path, 0, 1) != "/") && (substr((string) $p_path, 0, 3) != "../")))
       $p_path = "./".$p_path;
 
     // ----- Look for path to remove format (should end by /)
-    if (($p_remove_path != "") && (substr($p_remove_path, -1) != '/'))
+    if (($p_remove_path != "") && (substr((string) $p_remove_path, -1) != '/'))
     {
       $p_remove_path .= '/';
     }
-    $p_remove_path_size = strlen($p_remove_path);
+    $p_remove_path_size = strlen((string) $p_remove_path);
 
     // ----- Study the mode
     switch ($p_mode) {
@@ -2049,12 +2049,12 @@ if (!defined("PCL_TAR"))
           TrFctMessage(__FILE__, __LINE__, 2, "Compare archived file '$v_header[filename]' from asked list file '".$p_file_list[$i]."'");
 
           // ----- Look if it is a directory
-          if (substr($p_file_list[$i], -1) == "/")
+          if (substr((string) $p_file_list[$i], -1) == "/")
           {
             TrFctMessage(__FILE__, __LINE__, 3, "Compare file '$v_header[filename]' with directory '$p_file_list[$i]'");
 
             // ----- Look if the directory is in the filename path
-            if ((strlen($v_header[filename]) > strlen($p_file_list[$i])) && (substr($v_header[filename], 0, strlen($p_file_list[$i])) == $p_file_list[$i]))
+            if ((strlen((string) $v_header[filename]) > strlen((string) $p_file_list[$i])) && (substr((string) $v_header[filename], 0, strlen((string) $p_file_list[$i])) == $p_file_list[$i]))
             {
               // ----- The file is in the directory, so extract it
               TrFctMessage(__FILE__, __LINE__, 2, "File '$v_header[filename]' is in directory '$p_file_list[$i]' : extract it");
@@ -2094,11 +2094,11 @@ if (!defined("PCL_TAR"))
       {
         // ----- Look for path to remove
         if (($p_remove_path != "")
-            && (substr($v_header[filename], 0, $p_remove_path_size) == $p_remove_path))
+            && (substr((string) $v_header[filename], 0, $p_remove_path_size) == $p_remove_path))
         {
           TrFctMessage(__FILE__, __LINE__, 3, "Found path '$p_remove_path' to remove in file '$v_header[filename]'");
           // ----- Remove the path
-          $v_header[filename] = substr($v_header[filename], $p_remove_path_size);
+          $v_header[filename] = substr((string) $v_header[filename], $p_remove_path_size);
           TrFctMessage(__FILE__, __LINE__, 3, "Reslting file is '$v_header[filename]'");
         }
 
@@ -2106,15 +2106,15 @@ if (!defined("PCL_TAR"))
         if (($p_path != "./") && ($p_path != "/"))
         {
           // ----- Look for the path end '/'
-          while (substr($p_path, -1) == "/")
+          while (substr((string) $p_path, -1) == "/")
           {
             TrFctMessage(__FILE__, __LINE__, 3, "Destination path [$p_path] ends by '/'");
-            $p_path = substr($p_path, 0, -1);
+            $p_path = substr((string) $p_path, 0, -1);
             TrFctMessage(__FILE__, __LINE__, 3, "Modified to [$p_path]");
           }
 
           // ----- Add the path
-          if (substr($v_header[filename], 0, 1) == "/")
+          if (substr((string) $v_header[filename], 0, 1) == "/")
               $v_header[filename] = $p_path.$v_header[filename];
           else
             $v_header[filename] = $p_path."/".$v_header[filename];
@@ -2171,10 +2171,10 @@ if (!defined("PCL_TAR"))
         {
           if ($v_header[typeflag]=="5")
             $v_dir_to_check = $v_header[filename];
-          else if (strpos($v_header[filename], "/") === false)
+          else if (strpos((string) $v_header[filename], "/") === false)
             $v_dir_to_check = "";
           else
-            $v_dir_to_check = dirname($v_header[filename]);
+            $v_dir_to_check = dirname((string) $v_header[filename]);
 
           if (($v_result = PclTarHandlerDirCheck($v_dir_to_check)) != 1)
           {
@@ -2302,9 +2302,9 @@ if (!defined("PCL_TAR"))
         TrFctMessage(__FILE__, __LINE__, 2, "Memorize info about file '$v_header[filename]'");
 
         // ----- Log extracted files
-        if (($v_file_dir = dirname($v_header[filename])) == $v_header[filename])
+        if (($v_file_dir = dirname((string) $v_header[filename])) == $v_header[filename])
           $v_file_dir = "";
-        if ((substr($v_header[filename], 0, 1) == "/") && ($v_file_dir == ""))
+        if ((substr((string) $v_header[filename], 0, 1) == "/") && ($v_file_dir == ""))
           $v_file_dir = "/";
 
         // ----- Add the array describing the file into the list
@@ -2358,15 +2358,15 @@ if (!defined("PCL_TAR"))
     // ----- TBC : I should check the string by a regexp
 
     // ----- Check the path
-    if (($p_path == "") || ((substr($p_path, 0, 1) != "/") && (substr($p_path, 0, 3) != "../") && (substr($p_path, 0, 2) != "./")))
+    if (($p_path == "") || ((substr((string) $p_path, 0, 1) != "/") && (substr((string) $p_path, 0, 3) != "../") && (substr((string) $p_path, 0, 2) != "./")))
       $p_path = "./".$p_path;
 
     // ----- Look for path to remove format (should end by /)
-    if (($p_remove_path != "") && (substr($p_remove_path, -1) != '/'))
+    if (($p_remove_path != "") && (substr((string) $p_remove_path, -1) != '/'))
     {
       $p_remove_path .= '/';
     }
-    $p_remove_path_size = strlen($p_remove_path);
+    $p_remove_path_size = strlen((string) $p_remove_path);
 
     // ----- Open the tar file
     if ($p_tar_mode == "tar")
@@ -2392,7 +2392,7 @@ if (!defined("PCL_TAR"))
     }
 
     // ----- Manipulate the index list
-    $v_list = explode(",", $p_index_string);
+    $v_list = explode(",", (string) $p_index_string);
     sort($v_list);
 
     // ----- Loop on the index list
@@ -2553,9 +2553,9 @@ if (!defined("PCL_TAR"))
         TrFctMessage(__FILE__, __LINE__, 2, "Memorize info about file '$v_header[filename]'");
 
         // ----- Log extracted files
-        if (($v_file_dir = dirname($v_header[filename])) == $v_header[filename])
+        if (($v_file_dir = dirname((string) $v_header[filename])) == $v_header[filename])
           $v_file_dir = "";
-        if ((substr($v_header[filename], 0, 1) == "/") && ($v_file_dir == ""))
+        if ((substr((string) $v_header[filename], 0, 1) == "/") && ($v_file_dir == ""))
           $v_file_dir = "/";
 
         // ----- Add the array describing the file into the list
@@ -2598,15 +2598,15 @@ if (!defined("PCL_TAR"))
     $v_tar = $p_tar;
     $v_extract_file = 1;
 
-    $p_remove_path_size = strlen($p_remove_path);
+    $p_remove_path_size = strlen((string) $p_remove_path);
 
         // ----- Look for path to remove
         if (($p_remove_path != "")
-            && (substr($v_header[filename], 0, $p_remove_path_size) == $p_remove_path))
+            && (substr((string) $v_header[filename], 0, $p_remove_path_size) == $p_remove_path))
         {
           TrFctMessage(__FILE__, __LINE__, 3, "Found path '$p_remove_path' to remove in file '$v_header[filename]'");
           // ----- Remove the path
-          $v_header[filename] = substr($v_header[filename], $p_remove_path_size);
+          $v_header[filename] = substr((string) $v_header[filename], $p_remove_path_size);
           TrFctMessage(__FILE__, __LINE__, 3, "Resulting file is '$v_header[filename]'");
         }
 
@@ -2614,15 +2614,15 @@ if (!defined("PCL_TAR"))
         if (($p_path != "./") && ($p_path != "/"))
         {
           // ----- Look for the path end '/'
-          while (substr($p_path, -1) == "/")
+          while (substr((string) $p_path, -1) == "/")
           {
             TrFctMessage(__FILE__, __LINE__, 3, "Destination path [$p_path] ends by '/'");
-            $p_path = substr($p_path, 0, -1);
+            $p_path = substr((string) $p_path, 0, -1);
             TrFctMessage(__FILE__, __LINE__, 3, "Modified to [$p_path]");
           }
 
           // ----- Add the path
-          if (substr($v_header[filename], 0, 1) == "/")
+          if (substr((string) $v_header[filename], 0, 1) == "/")
               $v_header[filename] = $p_path.$v_header[filename];
           else
             $v_header[filename] = $p_path."/".$v_header[filename];
@@ -2679,10 +2679,10 @@ if (!defined("PCL_TAR"))
         {
           if ($v_header[typeflag]=="5")
             $v_dir_to_check = $v_header[filename];
-          else if (strpos($v_header[filename], "/") === false)
+          else if (strpos((string) $v_header[filename], "/") === false)
             $v_dir_to_check = "";
           else
-            $v_dir_to_check = dirname($v_header[filename]);
+            $v_dir_to_check = dirname((string) $v_header[filename]);
 
           if (($v_result = PclTarHandlerDirCheck($v_dir_to_check)) != 1)
           {
@@ -2916,7 +2916,7 @@ if (!defined("PCL_TAR"))
       {
         // ----- Compare the file names
 //        if ($p_file_list[$i] == $v_header[filename])
-        if (($v_len = strcmp($p_file_list[$i], $v_header[filename])) <= 0)
+        if (($v_len = strcmp((string) $p_file_list[$i], (string) $v_header[filename])) <= 0)
         {
           if ($v_len==0)
           {
@@ -2926,7 +2926,7 @@ if (!defined("PCL_TAR"))
           else
           {
             TrFctMessage(__FILE__, __LINE__, 3, "Look if '$v_header[filename]' is a file in $p_file_list[$i]");
-            if (substr($v_header[filename], strlen($p_file_list[$i]), 1) == "/")
+            if (substr((string) $v_header[filename], strlen((string) $p_file_list[$i]), 1) == "/")
             {
               TrFctMessage(__FILE__, __LINE__, 3, "'$v_header[filename]' is a file in $p_file_list[$i]");
               $v_delete_file = TRUE;
@@ -3137,18 +3137,18 @@ if (!defined("PCL_TAR"))
     $v_stored_list[$i] = $p_file_list[$i];
     if ($p_remove_dir != "")
     {
-      if (substr($p_file_list[$i], -1) != '/')
+      if (substr((string) $p_file_list[$i], -1) != '/')
         $p_remove_dir .= "/";
 
-      if (substr($p_file_list[$i], 0, strlen($p_remove_dir)) == $p_remove_dir)
+      if (substr((string) $p_file_list[$i], 0, strlen((string) $p_remove_dir)) == $p_remove_dir)
       {
-        $v_stored_list[$i] = substr($p_file_list[$i], strlen($p_remove_dir));
+        $v_stored_list[$i] = substr((string) $p_file_list[$i], strlen((string) $p_remove_dir));
         TrFctMessage(__FILE__, __LINE__, 3, "Remove path '$p_remove_dir' in file '$p_file_list[$i]' = '$v_stored_list[$i]'");
       }
     }
     if ($p_add_dir != "")
     {
-      if (substr($p_add_dir, -1) == "/")
+      if (substr((string) $p_add_dir, -1) == "/")
         $v_stored_list[$i] = $p_add_dir.$v_stored_list[$i];
       else
         $v_stored_list[$i] = $p_add_dir."/".$v_stored_list[$i];
@@ -3453,7 +3453,7 @@ if (!defined("PCL_TAR"))
     */
 
     // ----- Look for no more block
-    if (strlen($v_binary_data)==0)
+    if (strlen((string) $v_binary_data)==0)
     {
       $v_header[filename] = "";
       $v_header[status] = "empty";
@@ -3464,14 +3464,14 @@ if (!defined("PCL_TAR"))
     }
 
     // ----- Look for invalid block size
-    if (strlen($v_binary_data) != 512)
+    if (strlen((string) $v_binary_data) != 512)
     {
       $v_header[filename] = "";
       $v_header[status] = "invalid_header";
-      TrFctMessage(__FILE__, __LINE__, 2, "Invalid block size : ".strlen($v_binary_data));
+      TrFctMessage(__FILE__, __LINE__, 2, "Invalid block size : ".strlen((string) $v_binary_data));
 
       // ----- Error log
-      PclErrorLog(-10, "Invalid block size : ".strlen($v_binary_data));
+      PclErrorLog(-10, "Invalid block size : ".strlen((string) $v_binary_data));
 
       // ----- Return
       TrFctEnd(__FILE__, __LINE__, PclErrorCode(), PclErrorString());
@@ -3483,7 +3483,7 @@ if (!defined("PCL_TAR"))
     // ..... First part of the header
     for ($i=0; $i<148; $i++)
     {
-      $v_checksum+=ord(substr($v_binary_data,$i,1));
+      $v_checksum+=ord(substr((string) $v_binary_data,$i,1));
     }
     // ..... Ignore the checksum value and replace it by ' ' (space)
     for ($i=148; $i<156; $i++)
@@ -3493,16 +3493,16 @@ if (!defined("PCL_TAR"))
     // ..... Last part of the header
     for ($i=156; $i<512; $i++)
     {
-      $v_checksum+=ord(substr($v_binary_data,$i,1));
+      $v_checksum+=ord(substr((string) $v_binary_data,$i,1));
     }
     TrFctMessage(__FILE__, __LINE__, 3, "Calculated checksum : $v_checksum");
 
     // ----- Extract the values
     TrFctMessage(__FILE__, __LINE__, 2, "Header : '$v_binary_data'");
-    $v_data = unpack("a100filename/a8mode/a8uid/a8gid/a12size/a12mtime/a8checksum/a1typeflag/a100link/a6magic/a2version/a32uname/a32gname/a8devmajor/a8devminor", $v_binary_data);
+    $v_data = unpack("a100filename/a8mode/a8uid/a8gid/a12size/a12mtime/a8checksum/a1typeflag/a100link/a6magic/a2version/a32uname/a32gname/a8devmajor/a8devminor", (string) $v_binary_data);
 
     // ----- Extract the checksum for check
-    $v_header[checksum] = OctDec(trim($v_data[checksum]));
+    $v_header[checksum] = OctDec(trim((string) $v_data[checksum]));
     TrFctMessage(__FILE__, __LINE__, 3, "File checksum : $v_header[checksum]");
     if ($v_header[checksum] != $v_checksum)
     {
@@ -3530,17 +3530,17 @@ if (!defined("PCL_TAR"))
     TrFctMessage(__FILE__, __LINE__, 2, "File checksum is valid ($v_checksum)");
 
     // ----- Extract the properties
-    $v_header[filename] = trim($v_data[filename]);
+    $v_header[filename] = trim((string) $v_data[filename]);
     TrFctMessage(__FILE__, __LINE__, 2, "Name : '$v_header[filename]'");
-    $v_header[mode] = OctDec(trim($v_data[mode]));
+    $v_header[mode] = OctDec(trim((string) $v_data[mode]));
     TrFctMessage(__FILE__, __LINE__, 2, "Mode : '".DecOct($v_header[mode])."'");
-    $v_header[uid] = OctDec(trim($v_data[uid]));
+    $v_header[uid] = OctDec(trim((string) $v_data[uid]));
     TrFctMessage(__FILE__, __LINE__, 2, "Uid : '$v_header[uid]'");
-    $v_header[gid] = OctDec(trim($v_data[gid]));
+    $v_header[gid] = OctDec(trim((string) $v_data[gid]));
     TrFctMessage(__FILE__, __LINE__, 2, "Gid : '$v_header[gid]'");
-    $v_header[size] = OctDec(trim($v_data[size]));
+    $v_header[size] = OctDec(trim((string) $v_data[size]));
     TrFctMessage(__FILE__, __LINE__, 2, "Size : '$v_header[size]'");
-    $v_header[mtime] = OctDec(trim($v_data[mtime]));
+    $v_header[mtime] = OctDec(trim((string) $v_data[mtime]));
     TrFctMessage(__FILE__, __LINE__, 2, "Date : ".date("l dS of F Y h:i:s A", $v_header[mtime]));
     if (($v_header[typeflag] = $v_data[typeflag]) == "5")
     {
@@ -3612,7 +3612,7 @@ if (!defined("PCL_TAR"))
     */
 
     // ----- Extract parent directory
-    $p_parent_dir = dirname($p_dir);
+    $p_parent_dir = dirname((string) $p_dir);
     TrFctMessage(__FILE__, __LINE__, 3, "Parent directory is '$p_parent_dir'");
 
     // ----- Just a check
@@ -3662,12 +3662,12 @@ if (!defined("PCL_TAR"))
     TrFctStart(__FILE__, __LINE__, "PclTarHandleExtension", "tar=$p_tarname");
 
     // ----- Look for file extension
-    if ((substr($p_tarname, -7) == ".tar.gz") || (substr($p_tarname, -4) == ".tgz"))
+    if ((substr((string) $p_tarname, -7) == ".tar.gz") || (substr((string) $p_tarname, -4) == ".tgz"))
     {
       TrFctMessage(__FILE__, __LINE__, 2, "Archive is a gzip tar");
       $v_tar_mode = "tgz";
     }
-    else if (substr($p_tarname, -4) == ".tar")
+    else if (substr((string) $p_tarname, -4) == ".tar")
     {
       TrFctMessage(__FILE__, __LINE__, 2, "Archive is a tar");
       $v_tar_mode = "tar";
@@ -3708,7 +3708,7 @@ if (!defined("PCL_TAR"))
     if ($p_dir != "")
     {
       // ----- Explode path by directory names
-      $v_list = explode("/", $p_dir);
+      $v_list = explode("/", (string) $p_dir);
 
       // ----- Study directories from last to first
       for ($i=count($v_list)-1; $i>=0; $i--)

--- a/e107_handlers/pcltrace.lib.php
+++ b/e107_handlers/pcltrace.lib.php
@@ -241,14 +241,14 @@ if (!defined("PCLTRACE_LIB"))
 
     // ----- Extract the function name in the list
     // ----- Remove the function name in the list
-    if (!($v_name = strrchr($g_pcl_trace_name, ",")))
+    if (!($v_name = strrchr((string) $g_pcl_trace_name, ",")))
     {
       $v_name = $g_pcl_trace_name;
       $g_pcl_trace_name = "";
     }
     else
     {
-      $g_pcl_trace_name = substr($g_pcl_trace_name, 0, strlen($g_pcl_trace_name)-strlen($v_name));
+      $g_pcl_trace_name = substr((string) $g_pcl_trace_name, 0, strlen((string) $g_pcl_trace_name)-strlen($v_name));
       $v_name = substr($v_name, -strlen($v_name)+1);
     }
 
@@ -444,7 +444,7 @@ if (!defined("PCLTRACE_LIB"))
       }
       echo "</tr></table></td>";
       echo "<td width=5></td>";
-      echo "<td><font size=1 face=$v_font>".basename($g_pcl_trace_entries[$i][file])."</font></td>";
+      echo "<td><font size=1 face=$v_font>".basename((string) $g_pcl_trace_entries[$i][file])."</font></td>";
       echo "<td width=5></td>";
       echo "<td><font size=1 face=$v_font>".$g_pcl_trace_entries[$i][line]."</font></td>";
       echo "</tr>";

--- a/e107_handlers/pclzip.lib.php
+++ b/e107_handlers/pclzip.lib.php
@@ -1689,7 +1689,7 @@ class PclZip
                     $v_sort_value = 0;
                     for ($j = 0, $jMax = count($v_work_list); $j < $jMax; $j++) {
                         // ----- Explode the item
-                        $v_item_list      = explode("-", $v_work_list[$j]);
+                        $v_item_list      = explode("-", (string) $v_work_list[$j]);
                         $v_size_item_list = count($v_item_list);
 
                         // ----- TBC : Here we might check that each item is a
@@ -2608,7 +2608,7 @@ class PclZip
         $p_header['compression']       = 0;
         $p_header['crc']               = 0;
         $p_header['compressed_size']   = 0;
-        $p_header['filename_len']      = strlen($p_filename);
+        $p_header['filename_len']      = strlen((string) $p_filename);
         $p_header['extra_len']         = 0;
         $p_header['disk']              = 0;
         $p_header['internal']          = 0;
@@ -2634,7 +2634,7 @@ class PclZip
         // ----- Look for virtual file
         } elseif ($p_filedescr['type'] == 'virtual_file') {
             $p_header['external'] = 0x00000000;
-            $p_header['size']     = strlen($p_filedescr['content']);
+            $p_header['size']     = strlen((string) $p_filedescr['content']);
         }
 
         // ----- Look for filetime
@@ -2686,7 +2686,7 @@ class PclZip
         }
 
         // ----- Check the path length
-        if (strlen($p_header['stored_filename']) > 0xFF) {
+        if (strlen((string) $p_header['stored_filename']) > 0xFF) {
             $p_header['status'] = 'filename_too_long';
         }
 
@@ -2755,7 +2755,7 @@ class PclZip
                 $v_content = $p_filedescr['content'];
 
                 // ----- Calculate the CRC
-                $p_header['crc'] = @crc32($v_content);
+                $p_header['crc'] = @crc32((string) $v_content);
 
                 // ----- Look for no compression
                 if ($p_options[PCLZIP_OPT_NO_COMPRESSION]) {
@@ -2766,7 +2766,7 @@ class PclZip
                 // ----- Look for normal compression
                 } else {
                     // ----- Compress the content
-                    $v_content = @gzdeflate($v_content);
+                    $v_content = @gzdeflate((string) $v_content);
 
                     // ----- Set header parameters
                     $p_header['compressed_size'] = strlen($v_content);
@@ -2781,12 +2781,12 @@ class PclZip
                 }
 
                 // ----- Write the compressed (or not) content
-                @fwrite($this->zip_fd, $v_content, $p_header['compressed_size']);
+                @fwrite($this->zip_fd, (string) $v_content, $p_header['compressed_size']);
 
             // ----- Look for a directory
             } elseif ($p_filedescr['type'] == 'folder') {
                 // ----- Look for directory last '/'
-                if (@substr($p_header['stored_filename'], -1) != '/') {
+                if (@substr((string) $p_header['stored_filename'], -1) != '/') {
                     $p_header['stored_filename'] .= '/';
                 }
 
@@ -2896,7 +2896,7 @@ class PclZip
         $v_data_header = unpack('a1id1/a1id2/a1cm/a1flag/Vmtime/a1xfl/a1os', $v_binary_data);
 
         // ----- Check some parameters
-        $v_data_header['os'] = bin2hex($v_data_header['os']);
+        $v_data_header['os'] = bin2hex((string) $v_data_header['os']);
 
         // ----- Read the gzip file footer
         @fseek($v_file_compressed, filesize($v_gzip_temp_name) - 8);
@@ -2992,7 +2992,7 @@ class PclZip
             // ----- Look for short name change
             // Its when we cahnge just the filename but not the path
             if (isset($p_filedescr['new_short_name'])) {
-                $v_path_info = pathinfo($p_filename);
+                $v_path_info = pathinfo((string) $p_filename);
                 $v_dir       = '';
                 if ($v_path_info['dirname'] != '') {
                     $v_dir = $v_path_info['dirname'] . '/';
@@ -3005,21 +3005,21 @@ class PclZip
 
             // ----- Look for all path to remove
             if ($p_remove_all_dir) {
-                $v_stored_filename = basename($p_filename);
+                $v_stored_filename = basename((string) $p_filename);
 
             // ----- Look for partial path remove
             } elseif ($p_remove_dir != "") {
-                if (substr($p_remove_dir, -1) != '/') {
+                if (substr((string) $p_remove_dir, -1) != '/') {
                     $p_remove_dir .= "/";
                 }
 
-                if ((substr($p_filename, 0, 2) == "./") || (substr($p_remove_dir, 0, 2) == "./")) {
+                if ((substr((string) $p_filename, 0, 2) == "./") || (substr((string) $p_remove_dir, 0, 2) == "./")) {
 
-                    if ((substr($p_filename, 0, 2) == "./") && (substr($p_remove_dir, 0, 2) != "./")) {
+                    if ((substr((string) $p_filename, 0, 2) == "./") && (substr((string) $p_remove_dir, 0, 2) != "./")) {
                         $p_remove_dir = "./" . $p_remove_dir;
                     }
-                    if ((substr($p_filename, 0, 2) != "./") && (substr($p_remove_dir, 0, 2) == "./")) {
-                        $p_remove_dir = substr($p_remove_dir, 2);
+                    if ((substr((string) $p_filename, 0, 2) != "./") && (substr((string) $p_remove_dir, 0, 2) == "./")) {
+                        $p_remove_dir = substr((string) $p_remove_dir, 2);
                     }
                 }
 
@@ -3028,7 +3028,7 @@ class PclZip
                     if ($v_compare == 2) {
                         $v_stored_filename = "";
                     } else {
-                        $v_stored_filename = substr($v_stored_filename, strlen($p_remove_dir));
+                        $v_stored_filename = substr((string) $v_stored_filename, strlen((string) $p_remove_dir));
                     }
                 }
             }
@@ -3038,7 +3038,7 @@ class PclZip
 
             // ----- Look for path to add
             if ($p_add_dir != "") {
-                if (substr($p_add_dir, -1) == "/") {
+                if (substr((string) $p_add_dir, -1) == "/") {
                     $v_stored_filename = $p_add_dir . $v_stored_filename;
                 } else {
                     $v_stored_filename = $p_add_dir . "/" . $v_stored_filename;
@@ -3078,17 +3078,17 @@ class PclZip
         $v_mdate = (($v_date['year'] - 1980) << 9) + ($v_date['mon'] << 5) + $v_date['mday'];
 
         // ----- Packed data
-        $v_binary_data = pack("VvvvvvVVVvv", 0x04034b50, $p_header['version_extracted'], $p_header['flag'], $p_header['compression'], $v_mtime, $v_mdate, $p_header['crc'], $p_header['compressed_size'], $p_header['size'], strlen($p_header['stored_filename']), $p_header['extra_len']);
+        $v_binary_data = pack("VvvvvvVVVvv", 0x04034b50, $p_header['version_extracted'], $p_header['flag'], $p_header['compression'], $v_mtime, $v_mdate, $p_header['crc'], $p_header['compressed_size'], $p_header['size'], strlen((string) $p_header['stored_filename']), $p_header['extra_len']);
 
         // ----- Write the first 148 bytes of the header in the archive
         fwrite($this->zip_fd, $v_binary_data, 30);
 
         // ----- Write the variable fields
-        if (strlen($p_header['stored_filename']) != 0) {
-            fwrite($this->zip_fd, $p_header['stored_filename'], strlen($p_header['stored_filename']));
+        if (strlen((string) $p_header['stored_filename']) != 0) {
+            fwrite($this->zip_fd, (string) $p_header['stored_filename'], strlen((string) $p_header['stored_filename']));
         }
         if ($p_header['extra_len'] != 0) {
-            fwrite($this->zip_fd, $p_header['extra'], $p_header['extra_len']);
+            fwrite($this->zip_fd, (string) $p_header['extra'], $p_header['extra_len']);
         }
 
         // ----- Return
@@ -3120,20 +3120,20 @@ class PclZip
         $v_mdate = (($v_date['year'] - 1980) << 9) + ($v_date['mon'] << 5) + $v_date['mday'];
 
         // ----- Packed data
-        $v_binary_data = pack("VvvvvvvVVVvvvvvVV", 0x02014b50, $p_header['version'], $p_header['version_extracted'], $p_header['flag'], $p_header['compression'], $v_mtime, $v_mdate, $p_header['crc'], $p_header['compressed_size'], $p_header['size'], strlen($p_header['stored_filename']), $p_header['extra_len'], $p_header['comment_len'], $p_header['disk'], $p_header['internal'], $p_header['external'], $p_header['offset']);
+        $v_binary_data = pack("VvvvvvvVVVvvvvvVV", 0x02014b50, $p_header['version'], $p_header['version_extracted'], $p_header['flag'], $p_header['compression'], $v_mtime, $v_mdate, $p_header['crc'], $p_header['compressed_size'], $p_header['size'], strlen((string) $p_header['stored_filename']), $p_header['extra_len'], $p_header['comment_len'], $p_header['disk'], $p_header['internal'], $p_header['external'], $p_header['offset']);
 
         // ----- Write the 42 bytes of the header in the zip file
         fwrite($this->zip_fd, $v_binary_data, 46);
 
         // ----- Write the variable fields
-        if (strlen($p_header['stored_filename']) != 0) {
-            fwrite($this->zip_fd, $p_header['stored_filename'], strlen($p_header['stored_filename']));
+        if (strlen((string) $p_header['stored_filename']) != 0) {
+            fwrite($this->zip_fd, (string) $p_header['stored_filename'], strlen((string) $p_header['stored_filename']));
         }
         if ($p_header['extra_len'] != 0) {
-            fwrite($this->zip_fd, $p_header['extra'], $p_header['extra_len']);
+            fwrite($this->zip_fd, (string) $p_header['extra'], $p_header['extra_len']);
         }
         if ($p_header['comment_len'] != 0) {
-            fwrite($this->zip_fd, $p_header['comment'], $p_header['comment_len']);
+            fwrite($this->zip_fd, (string) $p_header['comment'], $p_header['comment_len']);
         }
 
         // ----- Return
@@ -3159,14 +3159,14 @@ class PclZip
         $v_result = 1;
 
         // ----- Packed data
-        $v_binary_data = pack("VvvvvVVv", 0x06054b50, 0, 0, $p_nb_entries, $p_nb_entries, $p_size, $p_offset, strlen($p_comment));
+        $v_binary_data = pack("VvvvvVVv", 0x06054b50, 0, 0, $p_nb_entries, $p_nb_entries, $p_size, $p_offset, strlen((string) $p_comment));
 
         // ----- Write the 22 bytes of the header in the zip file
         fwrite($this->zip_fd, $v_binary_data, 22);
 
         // ----- Write the variable fields
-        if (strlen($p_comment) != 0) {
-            fwrite($this->zip_fd, $p_comment, strlen($p_comment));
+        if (strlen((string) $p_comment) != 0) {
+            fwrite($this->zip_fd, (string) $p_comment, strlen((string) $p_comment));
         }
 
         // ----- Return
@@ -3328,23 +3328,23 @@ class PclZip
         $this->privDisableMagicQuotes();
 
         // ----- Check the path
-        if (($p_path == "") || ((substr($p_path, 0, 1) != "/") && (substr($p_path, 0, 3) != "../") && (substr($p_path, 1, 2) != ":/"))) {
+        if (($p_path == "") || ((substr((string) $p_path, 0, 1) != "/") && (substr((string) $p_path, 0, 3) != "../") && (substr((string) $p_path, 1, 2) != ":/"))) {
             $p_path = "./" . $p_path;
         }
 
         // ----- Reduce the path last (and duplicated) '/'
         if (($p_path != "./") && ($p_path != "/")) {
             // ----- Look for the path end '/'
-            while (substr($p_path, -1) == "/") {
-                $p_path = substr($p_path, 0, -1);
+            while (substr((string) $p_path, -1) == "/") {
+                $p_path = substr((string) $p_path, 0, -1);
             }
         }
 
         // ----- Look for path to remove format (should end by /)
-        if (($p_remove_path != "") && (substr($p_remove_path, -1) != '/')) {
+        if (($p_remove_path != "") && (substr((string) $p_remove_path, -1) != '/')) {
             $p_remove_path .= '/';
         }
-        $p_remove_path_size = strlen($p_remove_path);
+        $p_remove_path_size = strlen((string) $p_remove_path);
 
         // ----- Open the zip file
         if (($v_result = $this->privOpenFd('rb')) != 1) {
@@ -3410,10 +3410,10 @@ class PclZip
                 for ($j = 0; ($j < count($p_options[PCLZIP_OPT_BY_NAME])) && (!$v_extract); $j++) {
 
                     // ----- Look for a directory
-                    if (substr($p_options[PCLZIP_OPT_BY_NAME][$j], -1) == "/") {
+                    if (substr((string) $p_options[PCLZIP_OPT_BY_NAME][$j], -1) == "/") {
 
                         // ----- Look if the directory is in the filename path
-                        if ((strlen($v_header['stored_filename']) > strlen($p_options[PCLZIP_OPT_BY_NAME][$j])) && (substr($v_header['stored_filename'], 0, strlen($p_options[PCLZIP_OPT_BY_NAME][$j])) == $p_options[PCLZIP_OPT_BY_NAME][$j])) {
+                        if ((strlen((string) $v_header['stored_filename']) > strlen((string) $p_options[PCLZIP_OPT_BY_NAME][$j])) && (substr((string) $v_header['stored_filename'], 0, strlen((string) $p_options[PCLZIP_OPT_BY_NAME][$j])) == $p_options[PCLZIP_OPT_BY_NAME][$j])) {
                             $v_extract = true;
                         }
 
@@ -3437,7 +3437,7 @@ class PclZip
             // ----- Look for extract by preg rule
             } elseif ((isset($p_options[PCLZIP_OPT_BY_PREG])) && ($p_options[PCLZIP_OPT_BY_PREG] != "")) {
 
-                if (preg_match($p_options[PCLZIP_OPT_BY_PREG], $v_header['stored_filename'])) {
+                if (preg_match($p_options[PCLZIP_OPT_BY_PREG], (string) $v_header['stored_filename'])) {
                     $v_extract = true;
                 }
 
@@ -3663,7 +3663,7 @@ class PclZip
             }
 
             // ----- Get the basename of the path
-            $p_entry['filename'] = basename($p_entry['filename']);
+            $p_entry['filename'] = basename((string) $p_entry['filename']);
 
         // ----- Look for path to remove
         } elseif ($p_remove_path != "") {
@@ -3676,11 +3676,11 @@ class PclZip
                 return $v_result;
             }
 
-            $p_remove_path_size = strlen($p_remove_path);
-            if (substr($p_entry['filename'], 0, $p_remove_path_size) == $p_remove_path) {
+            $p_remove_path_size = strlen((string) $p_remove_path);
+            if (substr((string) $p_entry['filename'], 0, $p_remove_path_size) == $p_remove_path) {
 
                 // ----- Remove the path
-                $p_entry['filename'] = substr($p_entry['filename'], $p_remove_path_size);
+                $p_entry['filename'] = substr((string) $p_entry['filename'], $p_remove_path_size);
 
             }
         }
@@ -3791,12 +3791,12 @@ class PclZip
 
             // ----- Check the directory availability and create it if necessary
             } else {
-                if ((($p_entry['external'] & 0x00000010) == 0x00000010) || (substr($p_entry['filename'], -1) == '/')) {
+                if ((($p_entry['external'] & 0x00000010) == 0x00000010) || (substr((string) $p_entry['filename'], -1) == '/')) {
                     $v_dir_to_check = $p_entry['filename'];
-                } elseif (strpos($p_entry['filename'], "/") === false) {
+                } elseif (strpos((string) $p_entry['filename'], "/") === false) {
                     $v_dir_to_check = "";
                 } else {
-                    $v_dir_to_check = dirname($p_entry['filename']);
+                    $v_dir_to_check = dirname((string) $p_entry['filename']);
                 }
 
                 if (($v_result = $this->privDirCheck($v_dir_to_check, (($p_entry['external'] & 0x00000010) == 0x00000010))) != 1) {
@@ -4740,10 +4740,10 @@ class PclZip
                 for ($j = 0; ($j < count($p_options[PCLZIP_OPT_BY_NAME])) && (!$v_found); $j++) {
 
                     // ----- Look for a directory
-                    if (substr($p_options[PCLZIP_OPT_BY_NAME][$j], -1) == "/") {
+                    if (substr((string) $p_options[PCLZIP_OPT_BY_NAME][$j], -1) == "/") {
 
                         // ----- Look if the directory is in the filename path
-                        if ((strlen($v_header_list[$v_nb_extracted]['stored_filename']) > strlen($p_options[PCLZIP_OPT_BY_NAME][$j])) && (substr($v_header_list[$v_nb_extracted]['stored_filename'], 0, strlen($p_options[PCLZIP_OPT_BY_NAME][$j])) == $p_options[PCLZIP_OPT_BY_NAME][$j])) {
+                        if ((strlen((string) $v_header_list[$v_nb_extracted]['stored_filename']) > strlen((string) $p_options[PCLZIP_OPT_BY_NAME][$j])) && (substr((string) $v_header_list[$v_nb_extracted]['stored_filename'], 0, strlen((string) $p_options[PCLZIP_OPT_BY_NAME][$j])) == $p_options[PCLZIP_OPT_BY_NAME][$j])) {
                             $v_found = true;
                         } elseif ((($v_header_list[$v_nb_extracted]['external'] & 0x00000010) == 0x00000010) /* Indicates a folder */ && ($v_header_list[$v_nb_extracted]['stored_filename'] . '/' == $p_options[PCLZIP_OPT_BY_NAME][$j])) {
                             $v_found = true;
@@ -4770,7 +4770,7 @@ class PclZip
             // ----- Look for extract by preg rule
             } elseif ((isset($p_options[PCLZIP_OPT_BY_PREG])) && ($p_options[PCLZIP_OPT_BY_PREG] != "")) {
 
-                if (preg_match($p_options[PCLZIP_OPT_BY_PREG], $v_header_list[$v_nb_extracted]['stored_filename'])) {
+                if (preg_match($p_options[PCLZIP_OPT_BY_PREG], (string) $v_header_list[$v_nb_extracted]['stored_filename'])) {
                     $v_found = true;
                 }
 
@@ -4976,8 +4976,8 @@ class PclZip
         $v_result = 1;
 
         // ----- Remove the final '/'
-        if (($p_is_dir) && (substr($p_dir, -1) == '/')) {
-            $p_dir = substr($p_dir, 0, -1);
+        if (($p_is_dir) && (substr((string) $p_dir, -1) == '/')) {
+            $p_dir = substr((string) $p_dir, 0, -1);
         }
 
         // ----- Check the directory availability
@@ -4986,7 +4986,7 @@ class PclZip
         }
 
         // ----- Extract parent directory
-        $p_parent_dir = dirname($p_dir);
+        $p_parent_dir = dirname((string) $p_dir);
 
         // ----- Just a check
         if ($p_parent_dir != $p_dir) {
@@ -5382,7 +5382,7 @@ function PclZipUtilPathReduction($p_dir)
     // ----- Look for not empty path
     if ($p_dir != "") {
         // ----- Explode path by directory names
-        $v_list = explode("/", $p_dir);
+        $v_list = explode("/", (string) $p_dir);
 
         // ----- Study directories from last to first
         $v_skip = 0;
@@ -5462,17 +5462,17 @@ function PclZipUtilPathInclusion($p_dir, $p_path)
     $v_result = 1;
 
     // ----- Look for path beginning by ./
-    if (($p_dir == '.') || ((strlen($p_dir) >= 2) && (substr($p_dir, 0, 2) == './'))) {
-        $p_dir = PclZipUtilTranslateWinPath(getcwd(), false) . '/' . substr($p_dir, 1);
+    if (($p_dir == '.') || ((strlen((string) $p_dir) >= 2) && (substr((string) $p_dir, 0, 2) == './'))) {
+        $p_dir = PclZipUtilTranslateWinPath(getcwd(), false) . '/' . substr((string) $p_dir, 1);
     }
-    if (($p_path == '.') || ((strlen($p_path) >= 2) && (substr($p_path, 0, 2) == './'))) {
-        $p_path = PclZipUtilTranslateWinPath(getcwd(), false) . '/' . substr($p_path, 1);
+    if (($p_path == '.') || ((strlen((string) $p_path) >= 2) && (substr((string) $p_path, 0, 2) == './'))) {
+        $p_path = PclZipUtilTranslateWinPath(getcwd(), false) . '/' . substr((string) $p_path, 1);
     }
 
     // ----- Explode dir and path by directory separator
-    $v_list_dir       = explode("/", $p_dir);
+    $v_list_dir       = explode("/", (string) $p_dir);
     $v_list_dir_size  = count($v_list_dir);
-    $v_list_path      = explode("/", $p_path);
+    $v_list_path      = explode("/", (string) $p_path);
     $v_list_path_size = count($v_list_path);
 
     // ----- Study directories paths
@@ -5668,11 +5668,11 @@ function PclZipUtilTranslateWinPath($p_path, $p_remove_disk_letter = true)
 {
     if (stripos(php_uname(), 'windows') !== false) {
         // ----- Look for potential disk letter
-        if (($p_remove_disk_letter) && (($v_position = strpos($p_path, ':')) != false)) {
-            $p_path = substr($p_path, $v_position + 1);
+        if (($p_remove_disk_letter) && (($v_position = strpos((string) $p_path, ':')) != false)) {
+            $p_path = substr((string) $p_path, $v_position + 1);
         }
         // ----- Change potential windows directory separator
-        if ((strpos($p_path, '\\') > 0) || (substr($p_path, 0, 1) == '\\')) {
+        if ((strpos((string) $p_path, '\\') > 0) || (substr((string) $p_path, 0, 1) == '\\')) {
             $p_path = strtr($p_path, '\\', '/');
         }
     }

--- a/e107_handlers/plugin_class.php
+++ b/e107_handlers/plugin_class.php
@@ -491,7 +491,7 @@ class e_plugin
 	public function getAddonErrors($e_xxx)
 	{
 
-		if(substr($e_xxx, -3) === '.sc')
+		if(substr((string) $e_xxx, -3) === '.sc')
 		{
 			$filename =  $e_xxx;
 			$sc = true;
@@ -511,7 +511,7 @@ class e_plugin
 			return 2;
 		}
 
-		if(substr($e_xxx, - 4, 4) == '_sql')
+		if(substr((string) $e_xxx, - 4, 4) == '_sql')
 		{
 
 			if(strpos($content,'INSERT INTO')!==false)
@@ -559,12 +559,12 @@ class e_plugin
 	 */
 	public function isValidAddonMarkup($content='')
     {
-       if ((strpos($content, '<' . '?php') !== 0))
+       if ((strpos((string) $content, '<' . '?php') !== 0))
        {
             return false;
        }
 
-      if ((substr($content, -2, 2) != '?'.'>') && (strrpos(substr($content, -20, 20), '?'.'>') !== false))
+      if ((substr((string) $content, -2, 2) != '?'.'>') && (strrpos(substr((string) $content, -20, 20), '?'.'>') !== false))
       {
 			return false;
       }
@@ -642,7 +642,7 @@ class e_plugin
 					}
 				}
 
-				$this->_addons[$path] = !empty($row['plugin_addons']) ? explode(',',$row['plugin_addons']) : null;// $path;
+				$this->_addons[$path] = !empty($row['plugin_addons']) ? explode(',',(string) $row['plugin_addons']) : null;// $path;
 			}
 
 			if($save)
@@ -690,7 +690,7 @@ class e_plugin
 				else
 				{
 					$this->_ids[$path] = (int) $id;
-					$this->_addons[$path] = !empty($row['plugin_addons']) ? explode(',',$row['plugin_addons']) : null;
+					$this->_addons[$path] = !empty($row['plugin_addons']) ? explode(',',(string) $row['plugin_addons']) : null;
 					$runUpdate = true;
 
 					e107::getDebug()->log("Inserting plugin data into table".print_a($row,true));
@@ -773,23 +773,23 @@ class e_plugin
 		foreach($allFiles as $file)
 		{
 
-			if(substr($file, -8) === "_sql.php")
+			if(substr((string) $file, -8) === "_sql.php")
 			{
 				$addons[] = str_replace(".php", '', $file);
 			}
 
-			if(substr($file, -3) === ".bb")
+			if(substr((string) $file, -3) === ".bb")
 			{
 				$addons[] = $file;
 			}
 
 
-			if(substr($file, -3) === ".sc")
+			if(substr((string) $file, -3) === ".sc")
 			{
 				$addons[] = $file;
 			}
 
-			if(preg_match('/^bb_(.*)\.php$/',$file))
+			if(preg_match('/^bb_(.*)\.php$/',(string) $file))
 			{
 				$addons[] = $file;
 			}
@@ -1741,7 +1741,7 @@ class e107plugin
 
 		foreach ($plugList as $num => $val) // Remove Duplicates caused by having both plugin.php AND plugin.xml.
 		{
-			$key = basename($val['path']);
+			$key = basename((string) $val['path']);
 			$pluginList[$key] = $val;
 		}
 
@@ -1759,14 +1759,14 @@ class e107plugin
 				$mes->addWarning("Folder error: <i>{$p['path']}</i>.  'e107_' is not permitted within plugin folder names.");
 				continue;
 			}
-			
+
 			if(in_array($plugin_path, $this->disAllowed))
 			{
 				$mes->addWarning("Folder error: <i>{$p['path']}</i> is not permitted as an acceptable folder name.");
 				continue;	
 			}
-			
-			
+
+
 			$plug['plug_action'] = 'scan'; // Make sure plugin.php knows what we're up to
 
 			if (!$this->parse_plugin($p['path']))
@@ -1778,14 +1778,14 @@ class e107plugin
 
 			$plug_info = $this->plug_vars;
 			$eplug_addons = $this->getAddons($plugin_path);
-			
+
 			//Ensure the plugin path lives in the same folder as is configured in the plugin.php/plugin.xml - no longer relevant. 
 			if ($plugin_path == $plug_info['folder'])
 			{
 				if (array_key_exists($plugin_path, $pluginDBList))
 				{ // Update the addons needed by the plugin
 					$pluginDBList[$plugin_path]['status'] = 'exists';
-					
+
 						// Check for name (lan) changes
 					if (vartrue($plug_info['@attributes']['lan']) && $pluginDBList[$plugin_path]['plugin_name'] != $plug_info['@attributes']['lan'])
 					{
@@ -1795,7 +1795,7 @@ class e107plugin
 						$this->plugFolder = $plugin_path;
 						$this->XmlLanguageFiles('upgrade');
 					}
-					
+
 					if ($mode == 'refresh')
 					{
 						if ($this->XmlLanguageFileCheck('_log', 'lan_log_list', 'refresh', $pluginDBList[$plugin_path]['plugin_installflag'], FALSE, $plugin_path)) $sp = TRUE;
@@ -1846,10 +1846,10 @@ class e107plugin
 					if ($plug_info['@attributes']['name'])
 					{					
 						$pName = vartrue($plug_info['@attributes']['lan']) ? $plug_info['@attributes']['lan'] : $plug_info['@attributes']['name'] ;
-						
+
 						$_installed = ($plug_info['@attributes']['installRequired'] == 'true' || $plug_info['@attributes']['installRequired'] == 1 ? 0 : 1);
-						
-						
+
+
 						$pInsert = array(
 							'plugin_id' 			=> 0,
 							'plugin_name'			=> $tp->toDB($pName, true),
@@ -1859,7 +1859,7 @@ class e107plugin
 							'plugin_addons'			=> $eplug_addons,
 							'plugin_category'		=> $this->manage_category($plug_info['category'])
 						);
-						
+
 					//		if (e107::getDb()->db_Insert("plugin", "0, '".$tp->toDB($pName, true)."', '".$tp->toDB($plug_info['@attributes']['version'], true)."', '".$tp->toDB($plugin_path, true)."',{$_installed}, '{$eplug_addons}', '".$this->manage_category($plug_info['category'])."' "))
 							if (e107::getDb()->insert("plugin", $pInsert))
 							{
@@ -1869,7 +1869,7 @@ class e107plugin
 							{
 								$log->addDebug("Failed to add ".$tp->toHTML($pName,false,"defs")." to the plugin table.");
 							}
-							
+
 							$log->flushMessages("Updated Plugins table");
 						}
 					}
@@ -1990,7 +1990,7 @@ class e107plugin
 
 				foreach($iconTypes as $key)
 				{
-					if(!empty($attrib[$key]) && str_ends_with($attrib[$key], '.png'))
+					if(!empty($attrib[$key]) && str_ends_with((string) $attrib[$key], '.png'))
 					{
 						$path = e_PLUGIN.$folder."/".$attrib[$key];
 						$file = basename($path);
@@ -2285,7 +2285,7 @@ class e107plugin
 	private function manage_extended_field_sql($action, $field_name)
 	{
 		$this->log("Running ".__FUNCTION__);
-		$f = e_CORE.'sql/extended_'.preg_replace('/[^\w]/', '', $field_name).'.php'; // quick security, always good idea
+		$f = e_CORE.'sql/extended_'.preg_replace('/[^\w]/', '', (string) $field_name).'.php'; // quick security, always good idea
 		
 		if(!is_readable($f)) return false;
 		
@@ -2360,7 +2360,7 @@ class e107plugin
 			$e107->user_class = new user_class_admin; // We need the extra methods of the admin extension
 		}
 
-		$class_name = strip_tags(strtoupper($class_name));
+		$class_name = strip_tags(strtoupper((string) $class_name));
 		if ($action == 'add')
 		{
 			if ($e107->user_class->ucGetClassIDFromName($class_name) !== FALSE)
@@ -2712,7 +2712,7 @@ class e107plugin
 		$prefvals[] = $varArray;
 		//			$prefvals[] = $plugin_folder;
 		//		}
-		$curvals = explode(',', $pref[$prefname]);
+		$curvals = explode(',', (string) $pref[$prefname]);
 
 		if ($action == 'add')
 		{
@@ -2995,7 +2995,7 @@ class e107plugin
 		
 		$this->unInstallOpts = $options;
 
-		$addons = explode(',', $plug['plugin_addons']);
+		$addons = explode(',', (string) $plug['plugin_addons']);
 		$sql_list = array();
 		foreach ($addons as $addon)
 		{
@@ -3387,9 +3387,9 @@ class e107plugin
 				continue;
 			}
 
-			if(substr($file,-9) === '_menu.php')
+			if(substr((string) $file,-9) === '_menu.php')
 			{
-				$menuFiles[] = basename($file, '.php');
+				$menuFiles[] = basename((string) $file, '.php');
 			}
 
 
@@ -4044,7 +4044,7 @@ class e107plugin
 				{
 					$type = $v['@attributes']['type'];
 					
-					if(strpos($type, 'image') !== 0 && strpos($type, 'file') !== 0 && strpos($type, 'video') !== 0)
+					if(strpos((string) $type, 'image') !== 0 && strpos((string) $type, 'file') !== 0 && strpos((string) $type, 'video') !== 0)
 					{
 						continue; 	
 					}
@@ -4307,7 +4307,7 @@ class e107plugin
 
 		//	$this->log("&nbsp;   Pref:  ".$key." => ".$value);
 			
-			if(strpos($value,"e_UC_") === 0) // Convert Userclass constants.
+			if(strpos((string) $value,"e_UC_") === 0) // Convert Userclass constants.
 			{
 				$value = constant($value);	
 			}
@@ -4377,19 +4377,19 @@ class e107plugin
 	function execute_function($path = null, $what = '', $when = '', $callbackData = null)
 	{
 		$mes = e107::getMessage();
-		
+
 		if($path == null)
 		{
 			$path = $this->plugFolder;	
 		}
-		
+
 		$class_name = $path."_setup"; // was using $this->pluginFolder; 
 		$method_name = $what."_".$when;
-		
-		
+
+
 			// {PLUGIN}_setup.php should ALWAYS be the name of the file.. 
-			
-			
+
+
 	//	if (varset($this->plug_vars['@attributes']['setupFile']))
 	//	{
 	//		$setup_file = e_PLUGIN.$this->plugFolder.'/'.$this->plug_vars['@attributes']['setupFile'];
@@ -4401,7 +4401,7 @@ class e107plugin
 
 
 
-		if(!is_readable($setup_file) && substr($path,-5) == "_menu")
+		if(!is_readable($setup_file) && substr((string) $path,-5) == "_menu")
 		{
 			$setup_file = e_PLUGIN.$path.'/'.str_replace("_menu","",$path).'_setup.php';
 		}
@@ -4417,15 +4417,15 @@ class e107plugin
 			{
 				$mes->addDebug("Found setup file <b>".$path."_setup.php</b> ");
 			}
-			
+
 			include_once($setup_file);
-			
+
 
 			if (class_exists($class_name))
 			{
 				$obj = new $class_name;
 			//	$obj->version_from = $this; // Not used?
-				
+
 				if (method_exists($obj, $method_name))
 				{
 					if(e_PAGE == 'e107_update.php' && E107_DBG_INCLUDES)
@@ -4965,7 +4965,7 @@ class e107plugin
 			while ($row = $sql->fetch())
 			{
 				$is_installed = ($row['plugin_installflag'] == 1);
-				$tmp = explode(",", $row['plugin_addons']);
+				$tmp = explode(",", (string) $row['plugin_addons']);
 				$path = $row['plugin_path'];
 				
 				if ($is_installed)
@@ -5219,7 +5219,7 @@ class e107plugin
 			return 2;
 		}
 	
-		if(substr($e_xxx, - 4, 4) == '_sql')
+		if(substr((string) $e_xxx, - 4, 4) == '_sql')
 		{
 			
 			if(strpos($content,'INSERT INTO')!==false)

--- a/e107_handlers/pop3_class.php
+++ b/e107_handlers/pop3_class.php
@@ -74,17 +74,17 @@ class receiveMail
 		$mail_header=imap_header($this->marubox,$mid);
 		$sender=$mail_header->from[0];
 		$sender_replyto=$mail_header->reply_to[0];
-		$stat = !(strtolower($sender->mailbox) != 'mailer-daemon' && strtolower($sender->mailbox) != 'postmaster');
-        if(strpos($mail_header->subject,"delayed")){
+		$stat = !(strtolower((string) $sender->mailbox) != 'mailer-daemon' && strtolower((string) $sender->mailbox) != 'postmaster');
+        if(strpos((string) $mail_header->subject,"delayed")){
            $stat = FALSE;
 		}
 			$mail_details=array(
-					'from'=>strtolower($sender->mailbox).'@'.$sender->host,
+					'from'=>strtolower((string) $sender->mailbox).'@'.$sender->host,
 					'fromName'=>$sender->personal,
-					'toOth'=>strtolower($sender_replyto->mailbox).'@'.$sender_replyto->host,
+					'toOth'=>strtolower((string) $sender_replyto->mailbox).'@'.$sender_replyto->host,
 					'toNameOth'=>$sender_replyto->personal,
 					'subject'=>$mail_header->subject,
-					'to'=>strtolower($mail_header->toaddress),
+					'to'=>strtolower((string) $mail_header->toaddress),
 					'bounce'=>$stat,
 					'date'=>$mail_header->date
 				);

--- a/e107_handlers/pop_bounce_handler.php
+++ b/e107_handlers/pop_bounce_handler.php
@@ -110,18 +110,18 @@ class pop3BounceHandler
 		$mail_header=imap_header($this->mailResource,$mid);
 		$sender=$mail_header->from[0];
 		$sender_replyto=$mail_header->reply_to[0];
-		$stat = !(strtolower($sender->mailbox) != 'mailer-daemon' && strtolower($sender->mailbox) != 'postmaster');
-        if(strpos($mail_header->subject,"delayed"))
+		$stat = !(strtolower((string) $sender->mailbox) != 'mailer-daemon' && strtolower((string) $sender->mailbox) != 'postmaster');
+        if(strpos((string) $mail_header->subject,"delayed"))
 		{
 			$stat = FALSE;
 		}
 			$mail_details=array(
-					'from'=>strtolower($sender->mailbox).'@'.$sender->host,
+					'from'=>strtolower((string) $sender->mailbox).'@'.$sender->host,
 					'fromName'=>$sender->personal,
-					'toOth'=>strtolower($sender_replyto->mailbox).'@'.$sender_replyto->host,
+					'toOth'=>strtolower((string) $sender_replyto->mailbox).'@'.$sender_replyto->host,
 					'toNameOth'=>$sender_replyto->personal,
 					'subject'=>$mail_header->subject,
-					'to'=>strtolower($mail_header->toaddress),
+					'to'=>strtolower((string) $mail_header->toaddress),
 					'bounce'=>$stat,
 					'date'=>$mail_header->date
 				);

--- a/e107_handlers/pref_class.php
+++ b/e107_handlers/pref_class.php
@@ -1234,7 +1234,7 @@ class prefs
 				break;
 			}
 		}
-		$val = addslashes($val);
+		$val = addslashes((string) $val);
 
 		switch ($table )
 		{
@@ -1273,7 +1273,7 @@ class prefs
 	{
 		$tp = e107::getParser();
 
-		if (!strlen($name))
+		if (!strlen((string) $name))
 		{
 			switch ($table)
 			{

--- a/e107_handlers/rate_class.php
+++ b/e107_handlers/rate_class.php
@@ -106,7 +106,7 @@ class rater
 		$TEMPLATE['RATE']   = "<div class='e-rate e-rate-{$table}' id='{$identifier}'  data-hint=\"{$datahint}\" data-readonly='{$readonly}' data-score='{$score}' data-url='".e_HTTP."rate.php' data-path='{$path}'>".$label."</div>";
 		$TEMPLATE['VOTES']  = "<div class='muted e-rate-votes e-rate-votes-{$table}' id='e-rate-votes-{$identifier}'><small>".$this->renderVotes($votes,$score)."</small></div>";
 
-		$tmp = explode("|",$template);
+		$tmp = explode("|",(string) $template);
 		
 		$text = "";
 		foreach($tmp as $k)
@@ -155,7 +155,7 @@ class rater
 	{
 		//$mode	: if mode is set, no urljump will be used (used in combined comments+rating system)
 
-		$table = preg_replace('/\W/', '', $table);
+		$table = preg_replace('/\W/', '', (string) $table);
 		$id = intval($id);
 		
 	//	return $this->render($text,$table,$id,$mode);
@@ -198,7 +198,7 @@ class rater
 	 */
 	function rateradio($table, $id) {
 
-		$table = preg_replace('/\W/', '', $table);
+		$table = preg_replace('/\W/', '', (string) $table);
 		$id = intval($id);
 
 		$str = "
@@ -222,7 +222,7 @@ class rater
 	 */
 	function checkrated($table, $id) {
 		
-		$table = preg_replace('/\W/', '', $table);
+		$table = preg_replace('/\W/', '', (string) $table);
 		$id = intval($id);
 
 		$sql = new db;
@@ -235,12 +235,12 @@ class rater
 		{
 			$row = $sql->fetch();
 
-			if(preg_match("/\." . USERID . "\./", $row['rate_voters']))
+			if(preg_match("/\." . USERID . "\./", (string) $row['rate_voters']))
 			{
 				return true;
 				//added option to split an individual users rating
 			}
-			elseif(preg_match("/\." . USERID . chr(1) . "([0-9]{1,2})\./", $row['rate_voters']))
+			elseif(preg_match("/\." . USERID . chr(1) . "([0-9]{1,2})\./", (string) $row['rate_voters']))
 			{
 				return true;
 			}
@@ -265,7 +265,7 @@ class rater
 
 
 
-		$table = preg_replace('/\W/', '', $table);
+		$table = preg_replace('/\W/', '', (string) $table);
 		$id = intval($id);
 		
 		if($id == 0)
@@ -334,7 +334,7 @@ class rater
 		{
 			$rating = array();
 
-			$rateusers = explode(".", $rowgr['rate_voters']);
+			$rateusers = explode(".", (string) $rowgr['rate_voters']);
 			for($i = 0, $iMax = count($rateusers); $i < $iMax; $i++)
 			{
 				if(strpos($rateusers[$i], $sep))
@@ -473,7 +473,7 @@ class rater
 		{
 			$row 		= $sql->fetch();
 			
-			if(preg_match("/\.". USERID."\./",$row['rate_voters'])) // already voted. 
+			if(preg_match("/\.". USERID."\./",(string) $row['rate_voters'])) // already voted. 
 			{		
 				return false;
 			}
@@ -570,7 +570,7 @@ class rater
 		$sql = e107::getDb();
 		$tp = e107::getParser();
 
-		$qs = explode("^", $rateindex);
+		$qs = explode("^", (string) $rateindex);
 
 		if (!$qs[0] || USER == FALSE || $qs[3] > 10 || $qs[3] < 1)
 		{
@@ -607,9 +607,9 @@ class rater
 			$stat = ($new_rating /$new_votes)/2;
 			$statR = round($stat,1);
 			
-			if(strpos($row['rate_voters'], ".".$voter.".") == true || strpos($row['rate_voters'], ".".USERID.".") == true)
+			if(strpos((string) $row['rate_voters'], ".".$voter.".") == true || strpos((string) $row['rate_voters'], ".".USERID.".") == true)
 			{
-				
+
 				return RATELAN_9."|".$this->renderVotes($new_votes,$statR); // " newvotes = ".($statR). " =".$new_votes;
 			}
 			

--- a/e107_handlers/redirection_class.php
+++ b/e107_handlers/redirection_class.php
@@ -226,7 +226,7 @@ class redirection
 	public function checkMaintenance()
 	{
 		// prevent looping.
-		if(strpos(defset('e_SELF'), 'admin.php') !== FALSE || strpos(defset('e_SELF'), 'sitedown.php') !== FALSE)
+		if(strpos((string) defset('e_SELF'), 'admin.php') !== FALSE || strpos((string) defset('e_SELF'), 'sitedown.php') !== FALSE)
 		{
 			return;
 		}
@@ -283,7 +283,7 @@ class redirection
 		{
 			return;
 		}
-		if(strpos(defset('e_PAGE'), 'admin') !== false)
+		if(strpos((string) defset('e_PAGE'), 'admin') !== false)
 		{
 			return;
 		}
@@ -297,7 +297,7 @@ class redirection
 		}
 		foreach (e107::getPref('membersonly_exceptions') as $val)
 		{
-			$srch = trim($val);
+			$srch = trim((string) $val);
 			if(!empty($srch) && strpos(e_SELF, $srch) !== false)
 			{
 				return;
@@ -405,10 +405,10 @@ class redirection
 		$hostMismatch = (strcasecmp($urlbase, $PrefSiteBase) !==0); // -- base domain does not match (case-insensitive)
 		$portMismatch = ($urlport !== $PrefSitePort); 	 // -- ports do not match (http <==> https)
 
-		if(($portMismatch || $hostMismatch) && strpos($server['PHP_SELF'], $adminDir) === false)
+		if(($portMismatch || $hostMismatch) && strpos((string) $server['PHP_SELF'], $adminDir) === false)
 		{
 			// Reconstruct the redirect URL
-			$aeSELF = explode('/', $server['PHP_SELF'], 4);
+			$aeSELF = explode('/', (string) $server['PHP_SELF'], 4);
 			$aeSELF[0] = $aPrefURL['scheme'] . ':'; // Correct scheme (http/https)
 			$aeSELF[1] = ''; // Defensive code: ensure http:// not http:/<garbage>/
 			$aeSELF[2] = $PrefRoot; // Correct domain and port if needed
@@ -512,7 +512,7 @@ class redirection
 			return false;
 		}
 
-		$tmp = explode('.',$this->domain);
+		$tmp = explode('.',(string) $this->domain);
 
 		if(!empty($tmp[0]) && strpos($tmp[0], 'static') !== false)
 		{

--- a/e107_handlers/ren_help.php
+++ b/e107_handlers/ren_help.php
@@ -31,15 +31,15 @@ function ren_help($mode = 1, $addtextfunc = "addtext", $helpfunc = "help")
  */
 function display_help($tagid="helpb", $mode = 1, $addtextfunc = "addtext", $helpfunc = "help", $helpsize = '')
 {
-	
+
 	$options = array('trigger' => $addtextfunc );
-	
+
 	return e107::getBB()->renderButtons($mode,'data',$options); // guessing the name of the textarea as 'data' no indicator unfortunately. 
 	// may cause pre-image and pre-file selector issues. 
-	
-		
+
+
   //  if(defsettrue('e_WYSIWYG')) { return; }
-	
+
 	/*
 	global $tp, $pref, $eplug_bb, $bbcode_func, $register_bb, $bbcode_help, $bbcode_helpactive, $bbcode_helptag, $bbcode_helpsize;
 	$bbcode_helpsize = $helpsize;
@@ -47,7 +47,7 @@ function display_help($tagid="helpb", $mode = 1, $addtextfunc = "addtext", $help
 	$bbcode_func = $addtextfunc;
  	$bbcode_help = $helpfunc;
     $bbcode_helptag = $tagid;
-	
+
 	// $arr = get_defined_vars();
 	// print_a($arr);
 
@@ -98,14 +98,14 @@ function display_help($tagid="helpb", $mode = 1, $addtextfunc = "addtext", $help
 
     if(is_readable(e_CORE."shortcodes/batch/bbcode_shortcodes.php"))
 	{
-		
+
 		$sc = e107::getScBatch('bbcode');
-		
+
 		if($tagid == 'data') // BC fix. 
 		{
 			$tagid = 'data_';	
 		}
-		
+
 		$data = array(
 			'tagid'			=> $tagid,
 			'template'		=> $mode,
@@ -114,9 +114,9 @@ function display_help($tagid="helpb", $mode = 1, $addtextfunc = "addtext", $help
 			'hint_active'	=> $bbcode_helpactive,
 			'size'			=> $helpsize
 		);
-				
+
 		$sc->setVars($data);	
-		
+
   		return "<div id='bbcode-panel-".$tagid."' class='mceToolbar bbcode-panel' {$visible}>".$tp->parseTemplate($BBCODE_TEMPLATE)."</div>";
 	}
 	else
@@ -305,7 +305,7 @@ function PreFile_Select($formid='prefile_selector')
 			}
 			else
 			{
-				$text .= "<option value=\"[file={e_BASE}request.php?".htmlspecialchars($file['url'])."{$ucinfo}]".htmlspecialchars($file['name'])."[/file]\">".htmlspecialchars($file['name'])." - {$ucname}</option>\n";
+				$text .= "<option value=\"[file={e_BASE}request.php?".htmlspecialchars((string) $file['url'])."{$ucinfo}]".htmlspecialchars((string) $file['name'])."[/file]\">".htmlspecialchars((string) $file['name'])." - {$ucname}</option>\n";
 			}
 
 		}

--- a/e107_handlers/resize_handler.php
+++ b/e107_handlers/resize_handler.php
@@ -23,7 +23,7 @@ if (!defined('e107_INIT')) { exit; }
  */
 function mimeFromFilename($fileName)
 {
-	$fileExt = strtolower(substr(strrchr($fileName, "."), 1));
+	$fileExt = strtolower(substr(strrchr((string) $fileName, "."), 1));
 	$mimeTypes = array(
 		'jpg' 	=> 'jpeg',
 		'gif' 	=> 'gif',

--- a/e107_handlers/search/comments_download.php
+++ b/e107_handlers/search/comments_download.php
@@ -32,7 +32,7 @@ function com_search_2($row)
 	$res['pre_title'] = !empty($row['download_name']) ? defset('LAN_SEARCH_70') . ": " : "";
 	$res['title'] = !empty($row['download_name']) ? $row['download_name'] : defset('LAN_SEARCH_9');
 	$res['summary'] = $row['comment_comment'];
-	preg_match("/([0-9]+)\.(.*)/", $row['comment_author'], $user);
+	preg_match("/([0-9]+)\.(.*)/", (string) $row['comment_author'], $user);
 	$res['detail'] = defset('LAN_SEARCH_7') . "<a href='user.php?id." . $user[1] . "'>" . $user[2] . "</a>" . defset('LAN_SEARCH_8') . $datestamp;
 
 	return $res;

--- a/e107_handlers/search/comments_news.php
+++ b/e107_handlers/search/comments_news.php
@@ -27,7 +27,7 @@ $comments_table['news'] = "LEFT JOIN #news AS n ON c.comment_type=0 AND n.news_i
 	$res['pre_title'] = $row['news_title'] ? defset('LAN_SEARCH_71').": " : "";
 	$res['title'] = $row['news_title'] ? $row['news_title'] : defset('LAN_SEARCH_9');
 	$res['summary'] = $row['comment_comment'];
-	preg_match("/([0-9]+)\.(.*)/", $row['comment_author'], $user);
+	preg_match("/([0-9]+)\.(.*)/", (string) $row['comment_author'], $user);
 	$res['detail'] = defset('LAN_SEARCH_7')."<a href='user.php?id.".$user[1]."'>".$user[2]."</a>".defset('LAN_SEARCH_8').$datestamp;
 	return $res;
 }

--- a/e107_handlers/search/comments_page.php
+++ b/e107_handlers/search/comments_page.php
@@ -31,7 +31,7 @@ $comments_table['page'] = "LEFT JOIN #page AS cp ON c.comment_type='page' AND cp
 	$res['pre_title'] = LAN_SEARCH_76.": ";
 	$res['title'] = $row['page_title'];
 	$res['summary'] = $row['comment_comment'];
-	preg_match("/([0-9]+)\.(.*)/", $row['comment_author'], $user);
+	preg_match("/([0-9]+)\.(.*)/", (string) $row['comment_author'], $user);
 	$res['detail'] = LAN_SEARCH_7."<a href='user.php?id.".$user[1]."'>".$user[2]."</a>".LAN_SEARCH_8.$datestamp;
 	return $res;
 }

--- a/e107_handlers/search/comments_user.php
+++ b/e107_handlers/search/comments_user.php
@@ -25,7 +25,7 @@ $comments_table['user'] = "LEFT JOIN #user AS u ON c.comment_type='profile' AND 
 	$res['pre_title'] = LAN_SEARCH_77.": ";
 	$res['title'] = $row['user_name'];
 	$res['summary'] = $row['comment_comment'];
-	preg_match("/([0-9]+)\.(.*)/", $row['comment_author'], $user);
+	preg_match("/([0-9]+)\.(.*)/", (string) $row['comment_author'], $user);
 	$res['detail'] = LAN_SEARCH_7."<a href='user.php?id.".$user[1]."'>".$user[2]."</a>".LAN_SEARCH_8.$datestamp;
 	return $res;
 }

--- a/e107_handlers/search_class.php
+++ b/e107_handlers/search_class.php
@@ -234,7 +234,7 @@ class e_search
 
 			$keycount = !empty($this->keywords['split']) ? count($this->keywords['split']) : 0;
 
-			if(!empty($keycount) && (strpos($query, '"') === false) && (!isset($no_exact)))
+			if(!empty($keycount) && (strpos((string) $query, '"') === false) && (!isset($no_exact)))
 			{
 				$exact_query[] = $query;
 				$this->keywords['split'] = array_merge($exact_query, $this->keywords['split']);
@@ -288,7 +288,7 @@ class e_search
 				$x = 0;
 				foreach ($search_fields as $field_key => $field)
 				{
-					$crop_fields[] = preg_replace('/(.*?)\./', '', $field);
+					$crop_fields[] = preg_replace('/(.*?)\./', '', (string) $field);
 				}
 
 				while ($row = $sql->fetch())
@@ -299,7 +299,7 @@ class e_search
 						$this -> text = $row[$field];
 						foreach ($this -> keywords['match'] as $k_key => $this -> query) 
 						{
-							if (stripos($this->text, $this->query) !== false)
+							if (stripos((string) $this->text, (string) $this->query) !== false)
 							{
 								if ($this -> keywords['exact'][$k_key] || $this -> keywords['boolean'][$k_key]) 
 								{
@@ -354,23 +354,23 @@ class e_search
 					$endcrop = FALSE;
 					$output = ''; // <!-- Start Search Block -->';
 					$title = TRUE;
-					
+
 					if(!empty($matches))
 					{
 
 						foreach ($matches as $this -> text) 
 						{
-							$this -> text = nl2br($this -> text);
+							$this -> text = nl2br((string) $this -> text);
 							$t_search = $tp->search;
 							$t_replace = $tp->replace;
 							$s_search = array('<br />', '[', ']');
 							$s_replace = array(' ', '<', '>');
 							$search = array_merge($t_search, $s_search);
 							$replace = array_merge($t_replace, $s_replace);
-							
+
 							$this -> text = strip_tags(str_replace($search, $replace, $this -> text));
-							
-							
+
+
 							if(!empty($this->keywords['match']))
 							{
 
@@ -391,12 +391,12 @@ class e_search
 											$endcrop = TRUE;
 										}
 										$key = $tp->usubstr($this -> text, $this->pos, $tp->ustrlen($this -> query));
-										$this -> text = preg_replace("#(".$boundary.$this -> query.$regex_append."#i", "<mark>\\1</mark>", $this -> text);
+										$this -> text = preg_replace("#(".$boundary.$this -> query.$regex_append."#i", "<mark>\\1</mark>", (string) $this -> text);
 									}
 								}
 							}
-							
-							
+
+
 							if($title) 
 							{
 								if ($pre_title == 0) 
@@ -411,14 +411,14 @@ class e_search
 								{
 									$pre_title_output = $pre_title;
 								}
-								
+
 								$this -> text = $this -> bullet."<h4><a class='title visit' href='".$res['link']."'>".$pre_title_output.$this -> text."</a></h4>{DETAILS}<div>".$res['pre_summary'];
 							} 
 							elseif (!$endcrop) 
 							{
 								$this -> parsesearch_crop();
 							}
-							
+
 							$output .= $this -> text;
 							$title = FALSE;
 						}
@@ -461,7 +461,7 @@ class e_search
 	{
 		global $search_chars;
 		$tp = e107::getParser();
-		if (strlen($this -> text) > $search_chars) {
+		if (strlen((string) $this -> text) > $search_chars) {
 			if ($this -> pos < ($search_chars - $tp->ustrlen($this -> query))) {
 				$this -> text = $tp->usubstr($this -> text, 0, $search_chars)."...";
 			} else if ($this -> pos > ($tp->ustrlen($this -> text) - ($search_chars - $tp->ustrlen($this -> query)))) {

--- a/e107_handlers/secure_img_handler.php
+++ b/e107_handlers/secure_img_handler.php
@@ -450,11 +450,11 @@ class secure_image
 
 		if(!empty($fontFile))
 		{
-			imagettftext($image, $secureimg['size'],$secureimg['angle'], $secureimg['x'], $secureimg['y'], $text_color, $fontFile, $code);
+			imagettftext($image, $secureimg['size'],$secureimg['angle'], $secureimg['x'], $secureimg['y'], $text_color, $fontFile, (string) $code);
 		}
 		else
 		{
-			imagestring ($image, 5, 12, 2, $code, $text_color);
+			imagestring ($image, 5, 12, 2, (string) $code, $text_color);
 		}
 
 		imagesavealpha($image, true);

--- a/e107_handlers/session_handler.php
+++ b/e107_handlers/session_handler.php
@@ -271,10 +271,10 @@ public function get($key, $clear = false)
 
     // Check for keys starting with $key/
     foreach ($this->_data as $dataKey => $value) {
-        if (strpos($dataKey, $key . '/') === 0) {
+        if (strpos((string) $dataKey, $key . '/') === 0) {
             // Normalize multiple slashes to a single slash
-            $subKeyString = preg_replace('#/+#', '/', substr($dataKey, strlen($key . '/')));
-            $subKeys = explode('/', $subKeyString);
+            $subKeyString = preg_replace('#/+#', '/', substr((string) $dataKey, strlen($key . '/')));
+            $subKeys = explode('/', (string) $subKeyString);
             // Remove empty segments
             $subKeys = array_filter($subKeys, function($k) { return $k !== ''; });
             $current = &$result;
@@ -304,7 +304,7 @@ public function get($key, $clear = false)
         $this->clear($key);
         // Clear all related keys
         foreach (array_keys($this->_data) as $dataKey) {
-            if (strpos($dataKey, $key . '/') === 0) {
+            if (strpos((string) $dataKey, $key . '/') === 0) {
                 unset($this->_data[$dataKey]);
             }
         }
@@ -327,8 +327,8 @@ public function getData($key = null, $clear = false)
         $result = [];
         foreach ($this->_data as $dataKey => $value) {
             // Normalize multiple slashes to a single slash
-            $dataKey = preg_replace('#/+#', '/', $dataKey);
-            $keys = explode('/', $dataKey);
+            $dataKey = preg_replace('#/+#', '/', (string) $dataKey);
+            $keys = explode('/', (string) $dataKey);
             // Remove empty segments
             $keys = array_filter($keys, function($k) { return $k !== ''; });
             $current = &$result;
@@ -451,7 +451,7 @@ public function getData($key = null, $clear = false)
 
         // Unset all keys starting with $key/
         foreach (array_keys($this->_data) as $dataKey) {
-            if (strpos($dataKey, $key . '/') === 0) {
+            if (strpos((string) $dataKey, $key . '/') === 0) {
                 unset($this->_data[$dataKey]);
             }
         }
@@ -759,7 +759,7 @@ public function getData($key = null, $clear = false)
             $this->cookieDelete()->destroy();
 
             // TODO event trigger
-            $msg = 'Session validation failed! <a href="'.strip_tags($_SERVER['REQUEST_URI']).'">Go Back</a>';
+            $msg = 'Session validation failed! <a href="'.strip_tags((string) $_SERVER['REQUEST_URI']).'">Go Back</a>';
         }
 
         return $this;
@@ -841,7 +841,7 @@ public function getData($key = null, $clear = false)
                 file_put_contents(__DIR__.'/session.log', $message, FILE_APPEND);
             }
         }
-        return ($in_form ? md5($this->get('__form_token')) : $this->get('__form_token'));
+        return ($in_form ? md5((string) $this->get('__form_token')) : $this->get('__form_token'));
     }
 
     /**
@@ -1248,7 +1248,7 @@ class e_session_db implements SessionHandlerInterface
         if($check)
         {
             $tmp = $this->_db->fetch();
-            $data = base64_decode($tmp['session_data']);
+            $data = base64_decode((string) $tmp['session_data']);
         }
         elseif(false !== $check)
         {

--- a/e107_handlers/shortcode_handler.php
+++ b/e107_handlers/shortcode_handler.php
@@ -192,7 +192,7 @@ class e_parse_shortcode
 		{
 			foreach ($codes as $code)
 			{
-				$code = strtoupper($code);
+				$code = strtoupper((string) $code);
 				if ((!$this->isRegistered($code) || $force == true) && !$this->isOverride($code))
 				{
 					$this->registered_codes[$code] = array('type' => 'class', 'path' => $path, 'class' => $classFunc);
@@ -207,7 +207,7 @@ class e_parse_shortcode
 		}
 		else
 		{
-			$codes = strtoupper($codes);
+			$codes = strtoupper((string) $codes);
 			if ((!$this->isRegistered($codes) || $force == true) && !$this->isOverride($codes))
 			{
 				$this->registered_codes[$codes] = array('type' => 'func', 'path' => $path, 'function' => $classFunc);
@@ -513,7 +513,7 @@ class e_parse_shortcode
 	{
 		if (e107::getPref('sc_override'))
 		{
-			$tmp = explode(',', e107::getPref('sc_override'));
+			$tmp = explode(',', (string) e107::getPref('sc_override'));
 			foreach ($tmp as $code)
 			{
 				$code = strtoupper(trim($code));
@@ -525,7 +525,7 @@ class e_parse_shortcode
 		}
 		if (e107::getPref('sc_batch_override'))
 		{
-			$tmp = explode(',', e107::getPref('sc_batch_override'));
+			$tmp = explode(',', (string) e107::getPref('sc_batch_override'));
 			foreach ($tmp as $code)
 			{
 				//$code = strtoupper(trim($code));
@@ -568,7 +568,7 @@ class e_parse_shortcode
 			{
 				if (!$this->isRegistered($code))
 				{
-					$code = strtoupper($code);
+					$code = strtoupper((string) $code);
 					$this->registered_codes[$code]['type'] = 'theme';
 				}
 			}
@@ -594,7 +594,7 @@ class e_parse_shortcode
 			{
 				foreach ($namearray as $code => $uclass)
 				{
-					$code = strtoupper($code);
+					$code = strtoupper((string) $code);
 					if (!$this->isRegistered($code))
 					{
 						if($this->isOverride($code))
@@ -628,7 +628,7 @@ class e_parse_shortcode
 					}
 					else
 					{
-						$code = strtoupper($code); 
+						$code = strtoupper((string) $code); 
 						if (!$this->isRegistered($code))
 						{
 							$this->registered_codes[$code]['type'] = 'plugin_legacy';
@@ -854,7 +854,7 @@ class e_parse_shortcode
 			$this->addedCodes = &$extraCodes;
 
 		//	e107::getDebug()->log("Codes".print_a($this->addedCodes,true));
-			
+
 			// TEMPLATEID_WRAPPER support - see contact template
 			// must be registered in e_shortcode object (batch) via () method before parsing
 			// Do it only once per parsing cylcle and not on every doCode() loop - performance
@@ -895,34 +895,34 @@ class e_parse_shortcode
 
 						$(this).contentEditable({
 							"placeholder" : "",
-							
+
 							  "onFocusIn" : function(element){
 							    var $input = $("<span id=\"e-editable-front-controls\"><span class=\"e-editable-front-save\" ><i class=\"fa fa-fw fa-save\"></i></span><span class=\"e-editable-front-cancel\" ><i class=\"fa fa-fw fa-ban\"></i></span></span>"); 
 							   $input.appendTo($(box)).hide().fadeIn(300);
 								$(container).addClass("active");
-				             
+
 				            },
 							"onFocusOut" : function(element){
 				            //   $(".e-editable-front-save").remove();
 				            }
-				            
-				          
+
+
 						});
-						
-						
+
+
 						$(box).on("click",".e-editable-front-cancel",function () 
 						{
 					        console.log("Cancelled");
 					        $(container).removeClass("active");
 					        $("#e-editable-front-controls").fadeOut(300, function() { $("#e-editable-front-controls").remove(); });	 
 						}); 
-						
+
 						$(box).on("click",".e-editable-front-save",function () 
 						{
 							$("#e-editable-front-controls").html("<i class=\"fa fa-fw fa-spin fa-spinner\"></i>");
-						
+
 					        $(container).removeClass("active");
-					        
+
 					        var edited_content = $(container).html();
 
 							$.post("'.e_WEB_ABS.'js/inline.php",{ content : edited_content, sc: sc, id: id, token: token }, function (data)
@@ -939,37 +939,37 @@ class e_parse_shortcode
 								}
 
 								console.log(d);
-									 
+
 								if(d.msg)
 								{
-	
+
 									if(d.status == "ok")
 									{
 										$("#e-editable-front-controls").html("<i class=\"fa fa-fw fa-check\"></i>");	
 									}
-											
+
 									if(d.status == "error")
 									{
 										$("#e-editable-front-controls").html("<i class=\"fa fa-fw fa-cross\"></i>");	
 									}			
-										
+
 								}	
 								else
 								{
 									$("#e-editable-front-controls").html("<i class=\"fa fa-fw fa-cross\"></i>");	
 								}
-								
+
 								$("#e-editable-front-controls").fadeOut(2000, function() { $(this).remove(); });	 
-	
+
 							}) 
-					        
+
 						}); 
-										
-						
+
+
 
 					});
-					
-				
+
+
 
 
 
@@ -1013,7 +1013,7 @@ class e_parse_shortcode
 				$this->scList[$sc] = $code;
 			}
 			*/
-			
+
 		//	print_a($this);
 		}
 
@@ -1063,13 +1063,13 @@ class e_parse_shortcode
 				return $this->eVars->$match1;
 			}
 		}
-		if (strpos($matches[1], E_NL) !== false)
+		if (strpos((string) $matches[1], E_NL) !== false)
 		{
 			return $matches[0];
 		}
 
 
-		if(preg_match('/^([A-Z_]*\d?):(.*)/', $matches[1], $newMatch))
+		if(preg_match('/^([A-Z_]*\d?):(.*)/', (string) $matches[1], $newMatch))
 		{
 			$fullShortcodeKey = $newMatch[0];
 			$code = $newMatch[1];
@@ -1080,9 +1080,9 @@ class e_parse_shortcode
 			parse_str($parmStr,$parm);
 			$parmArray = true;
 		}
-		elseif (strpos($matches[1], '='))
+		elseif (strpos((string) $matches[1], '='))
 		{
-			list($code, $parm) = explode('=', $matches[1], 2);
+			list($code, $parm) = explode('=', (string) $matches[1], 2);
 		}
 		else
 		{
@@ -1090,9 +1090,9 @@ class e_parse_shortcode
 			$parm = '';
 		}
 		//look for the $sc_mode
-		if (strpos($code, '|'))
+		if (strpos((string) $code, '|'))
 		{
-			list($code, $sc_mode) = explode("|", $code, 2);
+			list($code, $sc_mode) = explode("|", (string) $code, 2);
 			$code = trim($code);
 			$sc_mode = trim($sc_mode);
 		}
@@ -1120,7 +1120,7 @@ class e_parse_shortcode
 
 		if (E107_DBG_SC && ADMIN)
 		{
-			
+
 			$dbg = "<strong>";
 			$dbg .= '{';
 			$dbg .= $code;
@@ -1136,7 +1136,7 @@ class e_parse_shortcode
 		$scFile = '';
 		$_path = '';
 		$ret = '';
-		$_method = 'sc_'.strtolower($code);
+		$_method = 'sc_'.strtolower((string) $code);
 
 
 		// Display e_shortcode.php override info.
@@ -1186,7 +1186,7 @@ class e_parse_shortcode
 		}
 		elseif (array_key_exists($code, $this->scList)) // Check to see if we've already loaded the .sc file contents
 		{
-			
+
 			$scCode = $this->scList[$code];
 			$_path = "(loaded earlier)"; // debug. 
 		}
@@ -1195,7 +1195,7 @@ class e_parse_shortcode
 			//.sc file not yet loaded, or shortcode is new function type
 			if ($this->parseSCFiles == true)
 			{
-				
+
 				if (array_key_exists($code, $this->registered_codes))
 				{
 					//shortcode is registered, let's proceed.
@@ -1212,7 +1212,7 @@ class e_parse_shortcode
 						case 'class':
 							//It is batch shortcode.  Load the class and call the method
 							$_class 	= $this->registered_codes[$code]['class'];
-							$_method 	= 'sc_'.strtolower($code);
+							$_method 	= 'sc_'.strtolower((string) $code);
 
 							if (!$this->isScClass($_class))
 							{
@@ -1237,7 +1237,7 @@ class e_parse_shortcode
 							$wrapper = $this->callScFunc($_class, 'wrapper', null);
 
 							$ret = $this->callScFuncA($_class, $_method, array($parm, $sc_mode));
-							
+
 							/*if (method_exists($this->scClasses[$_class], $_method))
 							{
 								$ret = $this->scClasses[$_class]->$_method($parm, $sc_mode);
@@ -1248,7 +1248,7 @@ class e_parse_shortcode
 							}*/
 
 							break;
-						
+
 						case 'override':
 						case 'func':
 						case 'plugin':
@@ -1256,10 +1256,10 @@ class e_parse_shortcode
 							$_function = $this->registered_codes[$code]['function'];
 							if (!function_exists($_function) && $this->registered_codes[$code]['path'])
 							{
-								include_once($this->registered_codes[$code]['path'].strtolower($code).'.php');
+								include_once($this->registered_codes[$code]['path'].strtolower((string) $code).'.php');
 
 							}
-							
+
 							if (function_exists($_function))
 							{
 								$ret = call_user_func($_function, $parm, $sc_mode);
@@ -1267,7 +1267,7 @@ class e_parse_shortcode
 							break;
 
 						case 'plugin_legacy':
-							$scFile = e_PLUGIN.strtolower($this->registered_codes[$code]['path']).'/'.strtolower($code).'.sc';
+							$scFile = e_PLUGIN.strtolower((string) $this->registered_codes[$code]['path']).'/'.strtolower((string) $code).'.sc';
 							break;
 
 						// case 'override':
@@ -1275,7 +1275,7 @@ class e_parse_shortcode
 							// break;
 
 						case 'theme':
-							$scFile = THEME.strtolower($code).'.sc';
+							$scFile = THEME.strtolower((string) $code).'.sc';
 							break;
 
 					}
@@ -1284,7 +1284,7 @@ class e_parse_shortcode
 				{
 					// Code is not registered, let's look for .sc or .php file
 					// .php file takes precedence over .sc file
-					$codeLower = strtolower($code);
+					$codeLower = strtolower((string) $code);
 					if (is_readable(e_CORE.'shortcodes/single/'.$codeLower.'.php'))
 					{
 						$_function = $codeLower.'_shortcode';
@@ -1305,7 +1305,7 @@ class e_parse_shortcode
 							{
 								$ret = call_user_func(array($_class, $_function), $parm, $sc_mode);
 							}
-						
+
 						}
 						elseif (function_exists($_function))
 						{
@@ -1386,7 +1386,7 @@ class e_parse_shortcode
 
 		if(E107_DBG_BBSC && !empty($this->wrapper) && $this->wrapperDebugDone[$this->wrapper]==false)
 		{
-			list($wrapTmpl, $wrapID1, $wrapID2) = explode('/',$this->wrapper,3);
+			list($wrapTmpl, $wrapID1, $wrapID2) = explode('/',(string) $this->wrapper,3);
 
 			$wrapActive = strtoupper($wrapTmpl)."_WRAPPER";
 
@@ -1507,11 +1507,11 @@ class e_parse_shortcode
 
 		if(!empty($fullShortcodeKey) && !empty($this->wrappers[$fullShortcodeKey]) ) // eg: $NEWS_WRAPPER['view']['item']['NEWSIMAGE: item=1']
 		{
-			list($pre, $post) = explode("{---}", $this->wrappers[$fullShortcodeKey], 2);
+			list($pre, $post) = explode("{---}", (string) $this->wrappers[$fullShortcodeKey], 2);
 		}
 		elseif(isset($this->wrappers[$code]) && !empty($this->wrappers[$code])) // eg: $NEWS_WRAPPER['view']['item']['NEWSIMAGE']
 		{
-			list($pre, $post) = explode("{---}", $this->wrappers[$code], 2);
+			list($pre, $post) = explode("{---}", (string) $this->wrappers[$code], 2);
 		}
 		else
 		{
@@ -1538,14 +1538,14 @@ class e_parse_shortcode
 				}
 				else // new way - same format as wrapper
 				{
-					list($pre, $post) = explode("{---}", $this->sc_style[$code], 2);
+					list($pre, $post) = explode("{---}", (string) $this->sc_style[$code], 2);
 				}
 
 			}
 
 		}
 
-		if(strpos($pre, '{') !== false) // shortcode found in wrapper
+		if(strpos((string) $pre, '{') !== false) // shortcode found in wrapper
 		{
 			$this->nowrap = $code;
 			$pre = $this->parseCodes($pre, true, $this->addedCodes);
@@ -1636,7 +1636,7 @@ class e_parse_shortcode
 		$cur_shortcodes = array();
 		if ($type == 'file')
 		{
-			$batch_cachefile = 'nomd5_scbatch_'.md5($fname);
+			$batch_cachefile = 'nomd5_scbatch_'.md5((string) $fname);
 			//			$cache_filename = $e107cache->cache_fname("nomd5_{$batchfile_md5}");
 			$sc_cache = e107::getCache()->retrieve_sys($batch_cachefile);
 			if (!$sc_cache)
@@ -1661,7 +1661,7 @@ class e_parse_shortcode
 			$cur_sc = '';
 			foreach ($sc_batch as $line)
 			{
-				if (trim($line) == 'SC_END')
+				if (trim((string) $line) == 'SC_END')
 				{
 					$cur_sc = '';
 				}
@@ -1669,7 +1669,7 @@ class e_parse_shortcode
 				{
 					$cur_shortcodes[$cur_sc] .= $line;
 				}
-				if (preg_match('#^SC_BEGIN (\w*).*#', $line, $matches))
+				if (preg_match('#^SC_BEGIN (\w*).*#', (string) $line, $matches))
 				{
 					$cur_sc = $matches[1];
 					$cur_shortcodes[$cur_sc] = varset($cur_shortcodes[$cur_sc], '');
@@ -1688,11 +1688,11 @@ class e_parse_shortcode
 			{
 				if ($this->registered_codes[$cur_sc]['type'] == 'plugin')
 				{
-					$scFile = e_PLUGIN.strtolower($this->registered_codes[$cur_sc]['path']).'/'.strtolower($cur_sc).'.sc';
+					$scFile = e_PLUGIN.strtolower((string) $this->registered_codes[$cur_sc]['path']).'/'.strtolower((string) $cur_sc).'.sc';
 				}
 				else
 				{
-					$scFile = THEME.strtolower($cur_sc).'.sc';
+					$scFile = THEME.strtolower((string) $cur_sc).'.sc';
 				}
 				if (is_readable($scFile))
 				{

--- a/e107_handlers/sitelinks_class.php
+++ b/e107_handlers/sitelinks_class.php
@@ -59,7 +59,7 @@ class sitelinks
 					if(!empty($row['link_function']))
 					{
 						$parm = false;
-						list($path,$method) = explode("::",$row['link_function']);
+						list($path,$method) = explode("::",(string) $row['link_function']);
 						
 						if(strpos($method,"("))
 						{
@@ -105,7 +105,7 @@ class sitelinks
 		$pref = e107::getPref();
 		$e107cache = e107::getCache();
 
-		$usecache = (!(trim(defset('LINKSTART_HILITE')) != "" || trim(defset('LINKCLASS_HILITE')) != ""));
+		$usecache = (!(trim((string) defset('LINKSTART_HILITE')) != "" || trim((string) defset('LINKCLASS_HILITE')) != ""));
 
 		if($usecache && !strpos(e_SELF, e_ADMIN) && ($data = $e107cache->retrieve('sitelinks_' . $cat . md5($linkstyle . e_PAGE . e_QUERY))))
 		{
@@ -320,12 +320,12 @@ class sitelinks
 		// Start with an empty link
 		$linkstart = $indent = $linkadd = $screentip = $href = $link_append = '';
 		$highlighted = FALSE;
-		
+
 		if(!isset($style['linkstart_hilite'])) // Notice removal
 		{
 			$style['linkstart_hilite'] = "";	
 		}
-		
+
 		if(!isset($style['linkclass_hilite']))
 		{
 			$style['linkclass_hilite'] = "";	
@@ -341,9 +341,9 @@ class sitelinks
 		// If submenu: Fix Name, Add Indentation.
 		if ($submenu == true)
 		{
-			if(strpos($linkInfo['link_name'], 'submenu.') === 0)
+			if(strpos((string) $linkInfo['link_name'], 'submenu.') === 0)
 			{
-				$tmp = explode('.', $linkInfo['link_name'], 3);
+				$tmp = explode('.', (string) $linkInfo['link_name'], 3);
 				$linkInfo['link_name'] = $tmp[2];
 			}
 			$indent = ($style['linkdisplay'] != self::LINK_DISPLAY_OTHER && !empty($style['subindent'])) ? ($style['subindent']) : "";
@@ -352,23 +352,23 @@ class sitelinks
 		// Convert any {e_XXX} to absolute URLs (relative ones sometimes get broken by adding e_HTTP at the front)
 		$linkInfo['link_url'] = $tp -> replaceConstants($linkInfo['link_url'], TRUE, TRUE); // replace {e_xxxx}
 
-		if(strpos($linkInfo['link_url'],"{") !== false)
+		if(strpos((string) $linkInfo['link_url'],"{") !== false)
 		{
 			$linkInfo['link_url'] = $tp->parseTemplate($linkInfo['link_url'], TRUE); // shortcode in URL support - dynamic urls for multilanguage.
 		}
-		elseif($linkInfo['link_url'][0] !== '/' && strpos($linkInfo['link_url'],'http') !== 0)
+		elseif($linkInfo['link_url'][0] !== '/' && strpos((string) $linkInfo['link_url'],'http') !== 0)
 		{
-			$linkInfo['link_url'] = e_HTTP.ltrim($linkInfo['link_url'],'/');
+			$linkInfo['link_url'] = e_HTTP.ltrim((string) $linkInfo['link_url'],'/');
 		}
 		// By default links are not highlighted.
-		
+
 		if (isset($linkInfo['link_expand']) && $linkInfo['link_expand'])
 		{
 			// $href = " href=\"javascript:expandit('sub_".$linkInfo['link_id']."')\"";
 			$css_class .= " e-expandit";
 		}
-		
-		
+
+
 		$linkstart = $style['linkstart'];
 		$linkadd = ($style['linkclass']) ? " class='".$style['linkclass']."'" : "";
 		$linkadd = ($css_class) ? " class='".$style['linkclass'].$css_class."'" : $linkadd;
@@ -421,9 +421,9 @@ class sitelinks
 		// Remove default images if its a button and add new image at the start.
 		if ($linkInfo['link_button'])
 		{
-			$linkstart = preg_replace('/\<img.*\>/si', '', $linkstart);
+			$linkstart = preg_replace('/\<img.*\>/si', '', (string) $linkstart);
 			$linkstart .= $tp->toIcon($linkInfo['link_button'],array('legacy'=> "{e_IMAGE}icons/"));
-			
+
 		/*	if($linkInfo['link_button'][0]=='{')
 			{
 				$linkstart .= "<img src='".$tp->replaceConstants($linkInfo['link_button'],'abs')."' alt='' style='vertical-align:middle' />";	
@@ -505,7 +505,7 @@ class sitelinks
 		// ----------- highlight overriding - set the link matching in the page itself.
 		if(defined('HILITE'))
 		{
-			if(strpos($link,HILITE))
+			if(strpos($link,(string) HILITE))
 			{
 				return TRUE;
 			}
@@ -526,7 +526,7 @@ class sitelinks
 			{
 				if (in_array($fk,$uc_array))
 				{
-					$full_url = ((strpos($fp, 'http') === FALSE) ? SITEURL : '').$fp;
+					$full_url = ((strpos((string) $fp, 'http') === FALSE) ? SITEURL : '').$fp;
 					break;
 				}
 			}
@@ -544,7 +544,7 @@ class sitelinks
 		}
 
 		// --------------- highlighting for plugins. ----------------
-		if(stripos($link, $PLUGINS_DIRECTORY) !== false && stripos($link, "custompages") === false)
+		if(stripos($link, (string) $PLUGINS_DIRECTORY) !== false && stripos($link, "custompages") === false)
 		{
 			if($link_qry)
 			{	// plugin links with queries
@@ -639,7 +639,7 @@ class sitelinks
           	return TRUE;
 		}
 		
-		if($link_pge == basename($_SERVER['REQUEST_URI'])) // mod_rewrite support
+		if($link_pge == basename((string) $_SERVER['REQUEST_URI'])) // mod_rewrite support
 		{
 			return TRUE;
 		}
@@ -689,7 +689,7 @@ class e_navigation
 	 */
 	public static function guessMenuIcon($key)
 	{
-		$tmp = explode('/', $key);
+		$tmp = explode('/', (string) $key);
 		$mode = varset($tmp[0]);
 		$action = varset($tmp[1]);
 
@@ -983,13 +983,13 @@ i.e-cat_users-32{ background-position: -555px 0; width: 32px; height: 32px; }
         }
 
 
-		
+
 		$this->setIconArray();	
-		
-			
+
+
 		if($mode === 'sub')
 		{
-				
+
 				//FIXME  array structure suitable for e_admin_menu - see shortcodes/admin_navigation.php
 				/*
 				 * Info about sublinks array structure
@@ -1008,16 +1008,16 @@ i.e-cat_users-32{ background-position: -555px 0; width: 32px; height: 32px; }
 				$array_sub_functions[17][] = array(e_ADMIN.'newspost.php', LAN_MANAGE, ADLAN_3, 'H', 3, defset('E_16_MANAGE'), defset('E_32_MANAGE'));
 				$array_sub_functions[17][] = array(e_ADMIN.'newspost.php?create', LAN_CREATE, ADLAN_2, 'H', 3, defset('E_16_CREATE'), defset('E_32_CREATE'));
 				$array_sub_functions[17][] = array(e_ADMIN.'newspost.php?pref', LAN_PREFS, LAN_PREFS, 'H', 3, defset('E_16_SETTINGS'), defset('E_32_SETTINGS'));
-				
+
 				return $array_sub_functions;
 		}
-		
-		
+
+
 			//FIXME array structure suitable for e_admin_menu (NOW admin() below) - see shortcodes/admin_navigation.php
 			//TODO find out where is used $array_functions elsewhere, refactor it
-		
+
 			//XXX DO NOT EDIT without first checking perms in user_handler.php !!!!
-			
+
 		$array_functions = $this->adminLinksArray();
 
 		if($mode === 'legacy')
@@ -1029,12 +1029,12 @@ i.e-cat_users-32{ background-position: -555px 0; width: 32px; height: 32px; }
     	$array_functions_assoc = $this->convert_core_icons($newarray);
 
 
-        
+
        if($mode === 'core') // Core links only.
         {          
             return $array_functions_assoc;          
         }
-            
+
         $merged = array_merge($array_functions_assoc, $this->pluginLinks($E_16_PLUGMANAGER, "array"));
         $sorted = multiarray_sort($merged,'title'); // this deleted the e-xxxx and p-xxxxx keys. 
         return $this->restoreKeys($sorted); // we restore the keys with this. 
@@ -1122,7 +1122,7 @@ i.e-cat_users-32{ background-position: -555px 0; width: 32px; height: 32px; }
 		{
 			if(varset($val[0]))
 			{
-				$key = "e-".basename($val[0],".php");
+				$key = "e-".basename((string) $val[0],".php");
                 $val['key'] = $key;
 				$val['icon'] = $val[5];
 				$val['icon_32'] = $val[6];
@@ -1465,7 +1465,7 @@ i.e-cat_users-32{ background-position: -555px 0; width: 32px; height: 32px; }
 				$e107_vars[$act]['image_src'] = self::guessMenuIcon($act.'/'.$act);
 			}
 			
-			if(!empty($e107_vars[$act]['image_src']) && strpos($e107_vars[$act]['image_src'], '.glyph') !== false)
+			if(!empty($e107_vars[$act]['image_src']) && strpos((string) $e107_vars[$act]['image_src'], '.glyph') !== false)
 			{
 				$replace['LINK_IMAGE'] = $tp->toGlyph($e107_vars[$act]['image_src'], array('fw'=>true, 'space'=>'&nbsp;'));
 			}
@@ -1571,7 +1571,7 @@ i.e-cat_users-32{ background-position: -555px 0; width: 32px; height: 32px; }
 		$text = '';
 		if (getperms($perms))
 		{
-			$description = strip_tags($description);
+			$description = strip_tags((string) $description);
 			if ($mode === 'adminb')
 			{
 				$text = "<tr><td class='forumheader3'>
@@ -1841,7 +1841,7 @@ i.e-cat_users-32{ background-position: -555px 0; width: 32px; height: 32px; }
 		{	
 			$parm = false;	
 			
-			list($path,$method) = explode("::",$row['link_function']);
+			list($path,$method) = explode("::",(string) $row['link_function']);
 
 			if($path === 'theme')
 			{
@@ -1897,16 +1897,16 @@ i.e-cat_users-32{ background-position: -555px 0; width: 32px; height: 32px; }
 		### Example of main link: {e_BASE}some/url/#?match/string1^match/string2
 		### It would match http://your.domain/match/string/ or http://your.domain/match/string2?some=vars
 		### '#?' is the alternate active check trigger
-		if(strpos($data['link_url'], '#?') !== false)
+		if(strpos((string) $data['link_url'], '#?') !== false)
 		{
 			if($removeOnly)
 			{
-			    $arr = explode('#?', $data['link_url'], 2);
+			    $arr = explode('#?', (string) $data['link_url'], 2);
 				$data['link_url'] = array_shift($arr);
 				return null;
 			}
 			
-			$_temp = explode('#?', $data['link_url'], 2);
+			$_temp = explode('#?', (string) $data['link_url'], 2);
 			$data['link_url'] = $_temp[0] ? $_temp[0] : '#';
 			$matches = explode('^', $_temp[1]);
 			foreach ($matches as $match) 
@@ -1971,7 +1971,7 @@ i.e-cat_users-32{ background-position: -555px 0; width: 32px; height: 32px; }
 		$manualOverride = e107::getRegistry('core/e107/navigation/active');
 		if(!empty($manualOverride) && empty($data['link_sub']))
 		{
-			if(strpos($dbLink, $manualOverride) !==false)
+			if(strpos($dbLink, (string) $manualOverride) !==false)
 			{
 				return true;
 			}
@@ -1982,7 +1982,7 @@ i.e-cat_users-32{ background-position: -555px 0; width: 32px; height: 32px; }
 		// Set the URL matching in the page itself. see: forum_viewforum.php and forum_viewtopic.php 
 		if(defined("NAVIGATION_ACTIVE") && empty($data['link_sub']))
 		{
-			if(strpos($data['link_url'], NAVIGATION_ACTIVE)!==false)
+			if(strpos((string) $data['link_url'], NAVIGATION_ACTIVE)!==false)
 			{
 				return true;
 			}

--- a/e107_handlers/traffic_class_display.php
+++ b/e107_handlers/traffic_class_display.php
@@ -88,7 +88,7 @@ if (count($this->aTrafficTimed))
 
 	foreach ($this->aTrafficTimed as $key => $aVals)
 	{
-		if (strpos($key, 'TRAF_CAL') === 0)
+		if (strpos((string) $key, 'TRAF_CAL') === 0)
 		{
 			continue;
 		}

--- a/e107_handlers/upload_handler.php
+++ b/e107_handlers/upload_handler.php
@@ -146,7 +146,7 @@ function process_uploaded_files($uploaddir, $fileinfo = FALSE, $options = NULL)
 		{
 	//		e107::getLog()->addEvent(10, __FILE__."|".__FUNCTION__."@".__LINE__, "DEBUG", "Upload Handler test", "Invalid directory: ".$uploaddir, FALSE, FALSE);
 		}
-		
+
 		return FALSE; // Need a valid directory
 	}
 	if (UH_DEBUG)
@@ -205,9 +205,9 @@ function process_uploaded_files($uploaddir, $fileinfo = FALSE, $options = NULL)
 			// FIX handle non-latin file names
 			$name = preg_replace("/[^\w\pL.-]/u", '', str_replace(' ', '_', str_replace('%20', '_', $tp->ustrtolower($name))));
 			$raw_name = $name; // Save 'proper' file name - useful for display
-			$file_ext = trim(strtolower(substr(strrchr($name, "."), 1))); 	// File extension - forced to lower case internally
+			$file_ext = trim(strtolower(substr(strrchr((string) $name, "."), 1))); 	// File extension - forced to lower case internally
 
-			if (!trim($files['type'][$key]))
+			if (!trim((string) $files['type'][$key]))
 				$files['type'][$key] = 'Unknowm mime-type';
 
 			if (UH_DEBUG)
@@ -281,13 +281,13 @@ function process_uploaded_files($uploaddir, $fileinfo = FALSE, $options = NULL)
 					if ($ul_temp_dir)
 					{ // Need to move file to our own temporary directory
 						$tempfilename = $uploadfile;
-						$uploadfile = $ul_temp_dir.basename($uploadfile);
-						
+						$uploadfile = $ul_temp_dir.basename((string) $uploadfile);
+
 						if (UH_DEBUG)
 						{
 							e107::getLog()->addEvent(10, __FILE__."|".__FUNCTION__."@".__LINE__, "DEBUG", "Upload Handler test", "Move {$tempfilename} to {$uploadfile} ", FALSE, LOG_TO_ROLLING);
 						}
-						
+
 						@move_uploaded_file($tempfilename, $uploadfile); // This should work on all hosts
 					}
 					
@@ -854,7 +854,7 @@ function get_image_mime($filename, $extended = false)
 	{
 		if ($filename != '')
 		{
-			
+
 			if (strtolower(substr($filename, -4) == '.xml'))
 			{
 				return get_XML_filetypes($filename, $file_mask);

--- a/e107_handlers/user_extended_class.php
+++ b/e107_handlers/user_extended_class.php
@@ -289,7 +289,7 @@ class e107_user_extended
 	 */
 	public function getDBFieldType($fieldname)
 	{
-		if(strpos($fieldname, 'user_') !== 0)
+		if(strpos((string) $fieldname, 'user_') !== 0)
 		{
 		//	$fieldname = 'user_'. $fieldname;
 			var_dump($fieldname);
@@ -412,7 +412,7 @@ class e107_user_extended
 	{
 		$tp = e107::getParser();
 
-		$parms = explode('^,^', $params['user_extended_struct_parms']);
+		$parms = explode('^,^', (string) $params['user_extended_struct_parms']);
 		$requiredField = $params['user_extended_struct_required'] == 1;
 		$regex = $tp->toText($parms[1]);
 		$regexfail = $tp->toText($parms[2]);
@@ -438,7 +438,7 @@ class e107_user_extended
 		}
 		if($regex != "" && $val != "")
 		{
-			if(!preg_match($regex, $val))
+			if(!preg_match($regex, (string) $val))
 			{
 				return $regexfail ? $regexfail : true;
 			}
@@ -731,10 +731,10 @@ class e107_user_extended
 		$sql = e107::getDb('ue');
 
 		$ret = array();
-		
+
 		$more = ($cat != '') ? " AND user_extended_struct_parent = ".intval($cat)." " : "";
 		$sys = ($system == false) ? " AND user_extended_struct_text != '_system_' " : "";
-		
+
 		if($sql->select("user_extended_struct", "*", "user_extended_struct_type > 0 {$sys} {$more} ORDER BY user_extended_struct_order ASC"))
 		{
 			while($row = $sql->fetch())
@@ -822,7 +822,7 @@ class e107_user_extended
 	{
 		if(!empty($this->fieldAttributes[$field]['values']))
 		{
-			return html_entity_decode($this->fieldAttributes[$field]['values']);
+			return html_entity_decode((string) $this->fieldAttributes[$field]['values']);
 		}
 
 		return false;
@@ -1184,21 +1184,21 @@ class e107_user_extended
 	{
 		$tp = e107::getParser();
 		$frm = e107::getForm();
-		$curval = trim($curval);
+		$curval = trim((string) $curval);
 
 		if(empty($curval) && !empty($struct['user_extended_struct_default']))
 		{
 			$curval = $struct['user_extended_struct_default'];
 		}
 		
-		$choices = explode(",",$struct['user_extended_struct_values']);
+		$choices = explode(",",(string) $struct['user_extended_struct_values']);
 		
 		foreach($choices as $k => $v)
 		{
 			$choices[$k] = str_replace("[E_COMMA]", ",", $v);
 		}
 		
-		$parms 		= explode("^,^",$struct['user_extended_struct_parms']);
+		$parms 		= explode("^,^",(string) $struct['user_extended_struct_parms']);
 		$include 	= preg_replace("/\n/", " ", $tp->toHTML($parms[0]));
 		// $regex 		= $tp->toText(varset($parms[1]));
 		// $regexfail 	= $tp->toText(varset($parms[2]));
@@ -1220,7 +1220,7 @@ class e107_user_extended
 			$title = '';
 		}
 
-		if(strpos($include, 'class') === FALSE)
+		if(strpos((string) $include, 'class') === FALSE)
 		{
 			$include .= " class='".$class."' ";
 		}
@@ -1332,7 +1332,7 @@ class e107_user_extended
 			  break;
 
 			case EUF_PREDEFINED : // predefined list, shown in dropdown
-				$listRoot = trim($struct['user_extended_struct_values']);			// Base list name
+				$listRoot = trim((string) $struct['user_extended_struct_values']);			// Base list name
 
 				if(!$temp = $this->getFieldTypeClass($listRoot))
 				{
@@ -1395,8 +1395,8 @@ class e107_user_extended
 
 					foreach($choiceList as $cArray)
 					{
-						$cID = trim($cArray[$choices[1]]);
-						$cText = trim($cArray[$choices[2]]);
+						$cID = trim((string) $cArray[$choices[1]]);
+						$cText = trim((string) $cArray[$choices[2]]);
 						$sel = ($curval == $cID) ? " selected='selected' " : "";
 						$ret .= "<option value='{$cID}' {$sel}>{$cText}</option>\n";
 					}
@@ -1455,7 +1455,7 @@ class e107_user_extended
 					$ret .= "<option value=''>&nbsp;</option>\n";  // ensures that the user chose it.
 					foreach($lanlist as $choice)
 					{
-						$choice = trim($choice);
+						$choice = trim((string) $choice);
 						$sel = ($curval == $choice || (!USER && $choice == e_LANGUAGE))? " selected='selected' " : "";
 						$ret .= "<option value='{$choice}' {$sel}>{$choice}</option>\n";
 					}
@@ -1544,7 +1544,7 @@ class e107_user_extended
 
 			$info = array(
 						"name" 			=> $item['@attributes']['name'],
-						"text" 			=> "UE_LAN_".strtoupper($item['@attributes']['name']),
+						"text" 			=> "UE_LAN_".strtoupper((string) $item['@attributes']['name']),
 						"type" 			=> varset($item['type']),
 						"values" 		=> varset($item['values']),
 						"default" 		=> varset($item['default']),
@@ -1562,7 +1562,7 @@ class e107_user_extended
 			}
 			if($item['regex'])
 			{
-				$info['parms'] .= $item['include_text']."^,^".$item['regex']."^,^LAN_UE_FAIL_".strtoupper($item['@attributes']['name']);
+				$info['parms'] .= $item['include_text']."^,^".$item['regex']."^,^LAN_UE_FAIL_".strtoupper((string) $item['@attributes']['name']);
 			}
 			$ret[$item['@attributes']['name']] = $info;
 		}

--- a/e107_handlers/user_handler.php
+++ b/e107_handlers/user_handler.php
@@ -721,7 +721,7 @@ class UserHandler
 			return true;
 		}
 
-		$cookieval = $lode['user_id'].'.'.md5($lode['user_password']);		// (Use extra md5 on cookie value to obscure hashed value for password)
+		$cookieval = $lode['user_id'].'.'.md5((string) $lode['user_password']);		// (Use extra md5 on cookie value to obscure hashed value for password)
 		if (e107::getPref('user_tracking','session') == 'session')
 		{
 			$_SESSION[e107::getPref('cookie_name')] = $cookieval;
@@ -766,7 +766,7 @@ class UserHandler
 		}
 		else
 		{
-			if (!empty($userData['user_class'])) $classList = explode(',',$userData['user_class']);
+			if (!empty($userData['user_class'])) $classList = explode(',',(string) $userData['user_class']);
 		}
 		foreach (array(e_UC_MEMBER, e_UC_READONLY, e_UC_PUBLIC) as $c)
 		{
@@ -775,10 +775,10 @@ class UserHandler
 				$classList[] = $c;
 			}
 		}
-		if (((varset($userData['user_admin'],0) == 1) && strlen($userData['user_perms'])) || ($fromAdmin && ADMIN))
+		if (((varset($userData['user_admin'],0) == 1) && strlen((string) $userData['user_perms'])) || ($fromAdmin && ADMIN))
 		{
 			$classList[] = e_UC_ADMIN;
-			if ((strpos($userData['user_perms'],'0') === 0) || getperms('0'))
+			if ((strpos((string) $userData['user_perms'],'0') === 0) || getperms('0'))
 			{
 				$classList[] = e_UC_MAINADMIN;
 			}
@@ -1022,7 +1022,7 @@ Following fields auto-filled in code as required:
 		{
 			if(isset($pref['initial_user_classes']))   // Any initial user classes to be set at some stage
 			{
-				$initClasses = explode(',', $pref['initial_user_classes']);
+				$initClasses = explode(',', (string) $pref['initial_user_classes']);
 			}
 
 			if($doProbation && (varset($pref['user_new_period'], 0) > 0))
@@ -1034,7 +1034,7 @@ Following fields auto-filled in code as required:
 			{    // Update the user classes
 				if($user['user_class'])
 				{
-					$initClasses = array_unique(array_merge($initClasses, explode(',', $user['user_class'])));
+					$initClasses = array_unique(array_merge($initClasses, explode(',', (string) $user['user_class'])));
 				}
 				$user['user_class'] = $tp->toDB(implode(',', $initClasses));
 				//$ret = TRUE;
@@ -1505,7 +1505,7 @@ class e_user_provider
 				}
 				break;
 			case T_CONSTANT_ENCAPSED_STRING:
-				$carry[] = trim($tokenValue, '\'"');
+				$carry[] = trim((string) $tokenValue, '\'"');
 				break;
 		}
 		++$index;
@@ -1569,7 +1569,7 @@ class e_user_provider
 			{
 				$redirectUrl = SITEURL;
 			}
-			elseif (strpos($redirectUrl, 'http://') !== 0 && strpos($redirectUrl, 'https://') !== 0)
+			elseif (strpos((string) $redirectUrl, 'http://') !== 0 && strpos((string) $redirectUrl, 'https://') !== 0)
 			{
 				$redirectUrl = e107::getUrl()->create($redirectUrl);
 			}

--- a/e107_handlers/user_model.php
+++ b/e107_handlers/user_model.php
@@ -509,7 +509,7 @@ class e_user_model extends e_admin_model
 
 		foreach($botlist as $bot)
 		{
-			if(stripos($userAgent, $bot) !== false){ return true; }
+			if(stripos((string) $userAgent, $bot) !== false){ return true; }
 		}
 
 		return false;
@@ -1097,7 +1097,7 @@ class e_user_model extends e_admin_model
 	{
 		if($this->get('user_xup'))
 		{
-			$provider = explode('_', $this->get('user_xup'));
+			$provider = explode('_', (string) $this->get('user_xup'));
 			return array_shift($provider);
 		}
 		return null;
@@ -1676,7 +1676,7 @@ class e_system_user extends e_user_model
 			
 			$sc['LOGINNAME'] 		= intval($pref['allowEmailLogin']) === 0 ? $userInfo['user_loginname'] : $userInfo['user_email'];
 			$sc['PASSWORD']			= ($pass_show && !empty($userInfo['user_password'])) ?  '*************' : $userInfo['user_password'];
-			$sc['ACTIVATION_LINK']	= strpos($userInfo['activation_url'], 'http') === 0 ? '<a href="'.$userInfo['activation_url'].'">'.$userInfo['activation_url'].'</a>' : $userInfo['activation_url'];
+			$sc['ACTIVATION_LINK']	= strpos((string) $userInfo['activation_url'], 'http') === 0 ? '<a href="'.$userInfo['activation_url'].'">'.$userInfo['activation_url'].'</a>' : $userInfo['activation_url'];
 		//	$sc['SITENAME']			= SITENAME;
 			$sc['SITEURL']			= "<a href='".SITEURL."' {$style}>".SITEURL."</a>";
 			$sc['USERNAME']			= $userInfo['user_name'];
@@ -2080,7 +2080,7 @@ class e_user extends e_user_model
 			}
 
 			// we have a match
-			if(md5($udata['user_password']) == $upw)
+			if(md5((string) $udata['user_password']) == $upw)
 			{
 				// set current user data
 				$this->setData($udata);
@@ -2520,7 +2520,7 @@ class e_user_extended_model extends e_admin_model
 
 		// retrieve db data
 		$value = $this->get($field);
-		list($table, $field_id, $field_name, $field_order) = explode(',', $this->_struct_index[$field]['db'], 4);
+		list($table, $field_id, $field_name, $field_order) = explode(',', (string) $this->_struct_index[$field]['db'], 4);
 		$this->_struct_index[$field]['db_value'] = $value;
 		if($value && $table && $field_id && $field_name && e107::getDb()->select($table, $field_name, "{$field_id}='{$value}'"))
 		{
@@ -2609,7 +2609,7 @@ class e_user_extended_model extends e_admin_model
 		$hidden = $this->get('user_hidden_fields');
 		$editor = $this->getEditor();
 
-		if(!empty($hidden) && $this->getId() !== $editor->getId() && strpos($hidden, '^'.$field.'^') !== false) return false;
+		if(!empty($hidden) && $this->getId() !== $editor->getId() && strpos((string) $hidden, '^'.$field.'^') !== false) return false;
 
 		return ($this->checkApplicable($field) && $editor->checkClass($this->_memberlist_access) && $editor->checkClass(varset($this->_struct_index[$field]['read'])));
 	}
@@ -2728,7 +2728,7 @@ class e_user_extended_model extends e_admin_model
 		$ftype = $structure_model->getValue('type') == 6 ? 'integer' : 'string';
 
 		// 0- field control (html) attributes;1 - regex; 2 - validation error msg;
-		$parms = explode('^,^', $structure_model->getValue('parms'));
+		$parms = explode('^,^', (string) $structure_model->getValue('parms'));
 
 		// validaton rules
 		$vtype = $parms[1] ? 'regex' : $ftype;
@@ -3123,7 +3123,7 @@ class e_user_pref extends e_front_model
 			if(!empty($data))
 			{
 				// BC
-				$data = strpos($data, "array") === 0 ? e107::unserialize($data) : unserialize($data);
+				$data = strpos((string) $data, "array") === 0 ? e107::unserialize($data) : unserialize($data);
 				if(!$data) $data = array();
 			}
 			else $data = array();

--- a/e107_handlers/user_select_class.php
+++ b/e107_handlers/user_select_class.php
@@ -313,7 +313,7 @@ class user_select
 		if ($sql->select("user", "*", "user_name LIKE '%".$tp -> toDB($s)."%'".$inc))
 		{
 			while ($row = $sql ->fetch()) {
-				$ret[strtolower($row['user_name'])] = $row['user_name'];
+				$ret[strtolower((string) $row['user_name'])] = $row['user_name'];
 			}
 			ksort($ret);
 		} else {

--- a/e107_handlers/userclass_class.php
+++ b/e107_handlers/userclass_class.php
@@ -86,14 +86,14 @@ class user_class
 				e_UC_BOTS      => UC_LAN_10,
 		//		e_UC_MODS      => UC_LAN_7 // specific to Forum plugin
 		);
-							
-		
+
+
 
 		$this->text_class_link = array('public' => e_UC_PUBLIC, 'guest' => e_UC_GUEST, 'nobody' => e_UC_NOBODY, 'member' => e_UC_MEMBER,
 									'admin' => e_UC_ADMIN, 'main' => e_UC_MAINADMIN, 'new' => e_UC_NEWUSER,/* 'mods' => e_UC_MODS,*/
 									'bots' => e_UC_BOTS, 'readonly' => e_UC_READONLY);
-									
-		
+
+
 
 		$this->readTree(TRUE);			// Initialise the classes on entry
 	}
@@ -250,7 +250,7 @@ class user_class
 			{
 				if($this->class_tree[$sa]['userclass_accum'])
 				{
-					$is = array_merge($is,explode(',',$this->class_tree[$sa]['userclass_accum']));
+					$is = array_merge($is,explode(',',(string) $this->class_tree[$sa]['userclass_accum']));
 				}
 			}
 		}
@@ -386,7 +386,7 @@ class user_class
 		$dropClasses = array();
 		foreach ($oldClasses as $c)
 		{  // Look at our parents (which are in 'userclass_accum') - if any of them are contained in oldClasses, we can drop them.
-			$tc = array_flip(explode(',',$this->class_tree[$c]['userclass_accum']));
+			$tc = array_flip(explode(',',(string) $this->class_tree[$c]['userclass_accum']));
 			unset($tc[$c]);		// Current class should be in $tc anyway
 			foreach ($tc as $tc_c => $v)
 			{
@@ -792,7 +792,7 @@ class user_class
 		$classIndex = abs($classnum);			// Handle negative class values
 		$classSign = (strpos($classnum, '-') === 0) ? '-' : '';
 		if ($classIndex == e_UC_BLANK)  return "<option value=''>&nbsp;</option>\n";
-		$tmp = explode(',',$current_value);
+		$tmp = explode(',',(string) $current_value);
 		$sel = in_array($classnum, $tmp) ? " selected='selected'" : '';
 		if ($nest_level == 0)
 		{
@@ -825,16 +825,16 @@ class user_class
 	public function checkbox($treename, $classnum, $current_value, $nest_level, $opt_options = '')
 	{
 		$frm = e107::getForm();
-		
+
 		$classIndex 		= abs($classnum);			// Handle negative class values
-		$classSign 			= (strpos($classnum, '-') === 0) ? '-' : '';
-		
+		$classSign 			= (strpos((string) $classnum, '-') === 0) ? '-' : '';
+
 		if ($classIndex == e_UC_BLANK)  return '';
-		
-		$tmp 				= explode(',',$current_value);
+
+		$tmp 				= explode(',',(string) $current_value);
 		$chk 				= in_array($classnum, $tmp) ? " checked='checked'" : '';
 		$style				= "";
-		
+
 		if ($nest_level == 0)
 		{
 			$style = " style='font-weight:bold'";
@@ -843,14 +843,14 @@ class user_class
 		{
 			$style = " style='text-indent:".(1.2 * $nest_level)."em'";
 		}
-		
+
 		$ucString = $this->class_tree[$classIndex]['userclass_name'];
-		
+
 		if ($classSign == '-')
 		{
 			$ucString = str_replace('[x]', $ucString, UC_LAN_INVERT);
 		}
-		
+
 		$checked = in_array($classnum, $tmp) ? true : false;
 
 		$pre = "<div {$style}>";
@@ -863,8 +863,8 @@ class user_class
 		}
 
 		return $pre.$frm->checkbox($treename.'[]',$classSign.$classIndex, $checked, array('label'=> $ucString)).$post;
-		
-		
+
+
 	//	return "<div {$style}><input type='checkbox' class='checkbox' name='{$treename}[]' id='{$treename}_{$classSign}{$classIndex}' value='{$classSign}{$classIndex}'{$chk} />".$ucString."</div>\n";
 	}
 
@@ -876,13 +876,13 @@ class user_class
 	public function checkbox_desc($treename, $classnum, $current_value, $nest_level, $opt_options = '')
 	{
 		$classIndex = abs($classnum);			// Handle negative class values
-		$classSign = (strpos($classnum, '-') === 0) ? '-' : '';
-		
+		$classSign = (strpos((string) $classnum, '-') === 0) ? '-' : '';
+
 		if ($classIndex == e_UC_BLANK)  return '';
-		
-		$tmp = explode(',',$current_value);
+
+		$tmp = explode(',',(string) $current_value);
 		$chk = in_array($classnum, $tmp) ? " checked='checked'" : '';
-		
+
 		if ($nest_level == 0)
 		{
 			$style = " style='font-weight:bold'";
@@ -891,16 +891,16 @@ class user_class
 		{
 			$style = " style='text-indent:".(0.3 * $nest_level)."em'";
 		}
-		
+
 		$id = "{$treename}_{$classnum}";
-		
+
 		$ucString = $this->class_tree[$classIndex]['userclass_name'];
-		
+
 		if ($classSign == '-')
 		{
 			$ucString = str_replace('[x]', $ucString, UC_LAN_INVERT);
 		}
-	
+
 		$description = $ucString.'  ('.$this->class_tree[$classIndex]['userclass_description'].")";
 
 		$id ="{$treename}_{$classSign}{$classnum}";
@@ -915,7 +915,7 @@ class user_class
 		}
 
 		return $pre.e107::getForm()->checkbox($treename.'[]', $classnum , $chk, array("id"=>$id,'label'=>$description)).$post;
-		
+
 	//	return "<div {$style}><input type='checkbox' class='checkbox' name='{$treename}[]' id='{$treename}_{$classSign}{$classnum}' value='{$classSign}{$classnum}'{$chk} />".$this->class_tree[$classIndex]['userclass_name'].'  ('.$this->class_tree[$classIndex]['userclass_description'].")</div>\n";
 	}
 
@@ -1533,7 +1533,7 @@ class user_class_admin extends user_class
 	{
 		$rights  = array($our_class);				// Accumulator always has rights to its own class
 
-		if ($this->class_tree[$our_class]['userclass_type'] == UC_TYPE_GROUP) return array_merge($rights, explode(',',$this->class_tree[$our_class]['userclass_accum']));					// Stop rights accumulation at a group
+		if ($this->class_tree[$our_class]['userclass_type'] == UC_TYPE_GROUP) return array_merge($rights, explode(',',(string) $this->class_tree[$our_class]['userclass_accum']));					// Stop rights accumulation at a group
 
 		foreach ($this->class_tree[$our_class]['class_children'] as $cc)
 		{
@@ -1819,7 +1819,7 @@ class user_class_admin extends user_class
 		}
 		if ($classrec['userclass_type'] == UC_TYPE_GROUP)
 		{	// Need to make sure our ID is in the accumulation array
-			$temp = explode(',',$classrec['userclass_accum']);
+			$temp = explode(',',(string) $classrec['userclass_accum']);
 			if (!in_array($classrec['userclass_id'], $temp))
 			{
 				$temp[] = $classrec['userclass_id'];
@@ -1860,7 +1860,7 @@ class user_class_admin extends user_class
 		$spacer = '';
 		if (isset($classrec['userclass_type']) && ($classrec['userclass_type'] == UC_TYPE_GROUP))
 		{	// Need to make sure our ID is in the accumulation array
-			$temp = explode(',',$classrec['userclass_accum']);
+			$temp = explode(',',(string) $classrec['userclass_accum']);
 			if (!in_array($classrec['userclass_id'], $temp))
 			{
 				$temp[] = $classrec['userclass_id'];
@@ -1899,14 +1899,14 @@ class user_class_admin extends user_class
 	public function queryCanEditClass($classID, $classList = USERCLASS_LIST)
 	{
 		if (!isset($this->class_tree[$classID])) return 0;			// Class doesn't exist - no hope of editing!
-		
+
 		$blockers = array(e_UC_PUBLIC => 1, e_UC_READONLY => 1, e_UC_NOBODY => 1, e_UC_GUEST => 1);
 		if (isset($blockers[$classID])) return 0;					// Don't allow edit of some fixed classes
 
 		$canEdit = $this->isAdmin;
 		$possibles = array_flip(explode(',',$classList));
 		if (isset($possibles[$this->class_tree[$classID]['userclass_editclass']])) $canEdit = TRUE;
-		
+
 		if (!$canEdit) return 0;
 
 		if (($classID >= e_UC_SPECIAL_BASE) && ($classID <= e_UC_SPECIAL_END)) return  1;	// Restricted edit of fixed classes

--- a/e107_handlers/validator_class.php
+++ b/e107_handlers/validator_class.php
@@ -626,7 +626,7 @@ class e_validator
 
 			case 'set':
 			case 'enum':
-				$tmp = array_map('trim', explode(',', $cond));
+				$tmp = array_map('trim', explode(',', (string) $cond));
 				if (!$value || !in_array($value, $tmp))
 				{
 					$this->addValidateResult($name, self::ERR_FIELDS_MATCH);
@@ -692,7 +692,7 @@ class e_validator
 				break;
 
 			case 'file': // TODO - type image - validate dimensions?
-				parse_str($cond, $params);
+				parse_str((string) $cond, $params);
 				$path = e107::getParser()->replaceConstants(varset($params['base']) . $value);
 				if (!$value || !is_file($path))
 				{
@@ -841,7 +841,7 @@ class e_validator
 	protected function parseMinMax($string)
 	{
 
-		return explode(':', $this->_convertConditionBC($string), 2);
+		return explode(':', (string) $this->_convertConditionBC($string), 2);
 	}
 
 	/**
@@ -852,9 +852,9 @@ class e_validator
 	{
 
 		// BC! Will be removed after we replace '-' with ':' separator!
-		if (strpos($condition, ':') === false)
+		if (strpos((string) $condition, ':') === false)
 		{
-			return preg_replace('/^([0-9]+)-([0-9]+)$/', '$1:$2', $condition);
+			return preg_replace('/^([0-9]+)-([0-9]+)$/', '$1:$2', (string) $condition);
 		}
 
 		return $condition;
@@ -1236,7 +1236,7 @@ class validatorClass
 								$temp = array();
 								foreach ($value as $v)
 								{
-									$v = trim($v);
+									$v = trim((string) $v);
 									if (is_numeric($v))
 									{
 										$temp[] = (int) $v;
@@ -1250,7 +1250,7 @@ class validatorClass
 							}
 							break;
 						case 2 :        // Assumes we're processing a dual password field - array name for second value is one more than for first
-							$src2 = substr($src, 0, -1) . (substr($src, -1, 1) + 1);
+							$src2 = substr((string) $src, 0, -1) . (substr((string) $src, -1, 1) + 1);
 							if (!isset($sourceFields[$src2]) || ($sourceFields[$src2] != $value))
 							{
 								$errNum = ERR_PASSWORDS_DIFFERENT;
@@ -1326,7 +1326,7 @@ class validatorClass
 				$ret['errors'][$dest] = $errNum;
 				if ($defs['dataType'] == 2)
 				{
-					$ret['failed'][$dest] = str_repeat('*', strlen($sourceFields[$src]));        // Save value with error - obfuscated
+					$ret['failed'][$dest] = str_repeat('*', strlen((string) $sourceFields[$src]));        // Save value with error - obfuscated
 				}
 				else
 				{
@@ -1391,7 +1391,7 @@ class validatorClass
 				$options = $definitions[$f];            // Validation options to use
 				if (!vartrue($options['fieldOptional']) || ($v != ''))
 				{
-					$toDo = explode(',', $options['vetMethod']);
+					$toDo = explode(',', (string) $options['vetMethod']);
 
 					foreach ($toDo as $vm)
 					{
@@ -1435,7 +1435,7 @@ class validatorClass
 							case 2 :        // Check against $pref
 								if (isset($options['vetParam']) && !empty($pref[$options['vetParam']]))
 								{
-									$tmp = explode(",", $pref[$options['vetParam']]);
+									$tmp = explode(",", (string) $pref[$options['vetParam']]);
 
 									foreach ($tmp as $disallow)
 									{
@@ -1445,7 +1445,7 @@ class validatorClass
 										{    // Exact match search (noticed with exclamation mark in the end of the word)
 											$errMsg = ERR_DISALLOWED_TEXT_EXACT_MATCH;
 										}
-										elseif (stripos($v, $disTrim) !== false)
+										elseif (stripos((string) $v, $disTrim) !== false)
 										{    // Wild card search
 											$errMsg = ERR_DISALLOWED_TEXT;
 										}
@@ -1506,7 +1506,7 @@ class validatorClass
 	public static function checkMandatory($fieldList, &$target)
 	{
 
-		$fields = explode(',', $fieldList);
+		$fields = explode(',', (string) $fieldList);
 		$allOK = true;
 		foreach ($fields as $f)
 		{

--- a/e107_handlers/vendor/guzzlehttp/psr7/src/Message.php
+++ b/e107_handlers/vendor/guzzlehttp/psr7/src/Message.php
@@ -142,12 +142,12 @@ final class Message
         }
 
         /** @var array[] $headerLines */
-        $count = preg_match_all(Rfc7230::HEADER_REGEX, $rawHeaders, $headerLines, PREG_SET_ORDER);
+        $count = preg_match_all(Rfc7230::HEADER_REGEX, (string) $rawHeaders, $headerLines, PREG_SET_ORDER);
 
         // If these aren't the same, then one line didn't match and there's an invalid header.
-        if ($count !== substr_count($rawHeaders, "\n")) {
+        if ($count !== substr_count((string) $rawHeaders, "\n")) {
             // Folding is deprecated, see https://datatracker.ietf.org/doc/html/rfc7230#section-3.2.4
-            if (preg_match(Rfc7230::HEADER_FOLD_REGEX, $rawHeaders)) {
+            if (preg_match(Rfc7230::HEADER_FOLD_REGEX, (string) $rawHeaders)) {
                 throw new \InvalidArgumentException('Invalid header syntax: Obsolete line folding');
             }
 
@@ -188,7 +188,7 @@ final class Message
         }
 
         $host = $headers[reset($hostKey)][0];
-        $scheme = substr($host, -4) === ':443' ? 'https' : 'http';
+        $scheme = substr((string) $host, -4) === ':443' ? 'https' : 'http';
 
         return $scheme.'://'.$host.'/'.ltrim($path, '/');
     }
@@ -202,10 +202,10 @@ final class Message
     {
         $data = self::parseMessage($message);
         $matches = [];
-        if (!preg_match('/^[\S]+\s+([a-zA-Z]+:\/\/|\/).*/', $data['start-line'], $matches)) {
+        if (!preg_match('/^[\S]+\s+([a-zA-Z]+:\/\/|\/).*/', (string) $data['start-line'], $matches)) {
             throw new \InvalidArgumentException('Invalid request string');
         }
-        $parts = explode(' ', $data['start-line'], 3);
+        $parts = explode(' ', (string) $data['start-line'], 3);
         $version = isset($parts[2]) ? explode('/', $parts[2])[1] : '1.1';
 
         $request = new Request(
@@ -230,10 +230,10 @@ final class Message
         // According to https://datatracker.ietf.org/doc/html/rfc7230#section-3.1.2
         // the space between status-code and reason-phrase is required. But
         // browsers accept responses without space and reason as well.
-        if (!preg_match('/^HTTP\/.* [0-9]{3}( .*|$)/', $data['start-line'])) {
+        if (!preg_match('/^HTTP\/.* [0-9]{3}( .*|$)/', (string) $data['start-line'])) {
             throw new \InvalidArgumentException('Invalid response string: '.$data['start-line']);
         }
-        $parts = explode(' ', $data['start-line'], 3);
+        $parts = explode(' ', (string) $data['start-line'], 3);
 
         return new Response(
             (int) $parts[1],

--- a/e107_handlers/vendor/guzzlehttp/psr7/src/MessageTrait.php
+++ b/e107_handlers/vendor/guzzlehttp/psr7/src/MessageTrait.php
@@ -48,12 +48,12 @@ trait MessageTrait
 
     public function hasHeader($header): bool
     {
-        return isset($this->headerNames[strtolower($header)]);
+        return isset($this->headerNames[strtolower((string) $header)]);
     }
 
     public function getHeader($header): array
     {
-        $header = strtolower($header);
+        $header = strtolower((string) $header);
 
         if (!isset($this->headerNames[$header])) {
             return [];
@@ -73,7 +73,7 @@ trait MessageTrait
     {
         $this->assertHeader($header);
         $value = $this->normalizeHeaderValue($value);
-        $normalized = strtolower($header);
+        $normalized = strtolower((string) $header);
 
         $new = clone $this;
         if (isset($new->headerNames[$normalized])) {
@@ -89,7 +89,7 @@ trait MessageTrait
     {
         $this->assertHeader($header);
         $value = $this->normalizeHeaderValue($value);
-        $normalized = strtolower($header);
+        $normalized = strtolower((string) $header);
 
         $new = clone $this;
         if (isset($new->headerNames[$normalized])) {
@@ -105,7 +105,7 @@ trait MessageTrait
 
     public function withoutHeader($header): MessageInterface
     {
-        $normalized = strtolower($header);
+        $normalized = strtolower((string) $header);
 
         if (!isset($this->headerNames[$normalized])) {
             return $this;

--- a/e107_handlers/vendor/guzzlehttp/psr7/src/ServerRequest.php
+++ b/e107_handlers/vendor/guzzlehttp/psr7/src/ServerRequest.php
@@ -226,7 +226,7 @@ class ServerRequest extends Request implements ServerRequestInterface
 
         $hasQuery = false;
         if (isset($_SERVER['REQUEST_URI'])) {
-            $requestUriParts = explode('?', $_SERVER['REQUEST_URI'], 2);
+            $requestUriParts = explode('?', (string) $_SERVER['REQUEST_URI'], 2);
             $uri = $uri->withPath($requestUriParts[0]);
             if (isset($requestUriParts[1])) {
                 $hasQuery = true;

--- a/e107_handlers/vendor/guzzlehttp/psr7/src/Uri.php
+++ b/e107_handlers/vendor/guzzlehttp/psr7/src/Uri.php
@@ -722,7 +722,7 @@ class Uri implements UriInterface, \JsonSerializable
 
     private function rawurlencodeMatchZero(array $match): string
     {
-        return rawurlencode($match[0]);
+        return rawurlencode((string) $match[0]);
     }
 
     private function validateState(): void

--- a/e107_handlers/vendor/guzzlehttp/psr7/src/UriNormalizer.php
+++ b/e107_handlers/vendor/guzzlehttp/psr7/src/UriNormalizer.php
@@ -186,7 +186,7 @@ final class UriNormalizer
         $regex = '/(?:%[A-Fa-f0-9]{2})++/';
 
         $callback = function (array $match): string {
-            return strtoupper($match[0]);
+            return strtoupper((string) $match[0]);
         };
 
         return
@@ -202,7 +202,7 @@ final class UriNormalizer
         $regex = '/%(?:2D|2E|5F|7E|3[0-9]|[46][1-9A-F]|[57][0-9A])/i';
 
         $callback = function (array $match): string {
-            return rawurldecode($match[0]);
+            return rawurldecode((string) $match[0]);
         };
 
         return

--- a/e107_handlers/vendor/hybridauth/hybridauth/src/Adapter/OAuth1.php
+++ b/e107_handlers/vendor/hybridauth/hybridauth/src/Adapter/OAuth1.php
@@ -285,13 +285,13 @@ abstract class OAuth1 extends AbstractAdapter implements AdapterInterface
 
         if ($denied) {
             throw new AuthorizationDeniedException(
-                'User denied access request. Provider returned a denied token: ' . htmlentities($denied)
+                'User denied access request. Provider returned a denied token: ' . htmlentities((string) $denied)
             );
         }
 
         if ($oauth_problem) {
             throw new InvalidOauthTokenException(
-                'Provider returned an error. oauth_problem: ' . htmlentities($oauth_problem)
+                'Provider returned an error. oauth_problem: ' . htmlentities((string) $oauth_problem)
             );
         }
 

--- a/e107_handlers/vendor/hybridauth/hybridauth/src/Adapter/OAuth2.php
+++ b/e107_handlers/vendor/hybridauth/hybridauth/src/Adapter/OAuth2.php
@@ -429,7 +429,7 @@ abstract class OAuth2 extends AbstractAdapter implements AdapterInterface
         ) {
             $this->deleteStoredData('authorization_state');
             throw new InvalidAuthorizationStateException(
-                'The authorization state [state=' . substr(htmlentities($state), 0, 100) . '] '
+                'The authorization state [state=' . substr(htmlentities((string) $state), 0, 100) . '] '
                 . 'of this page is either invalid or has already been consumed.'
             );
         }

--- a/e107_handlers/vendor/hybridauth/hybridauth/src/Data/Parser.php
+++ b/e107_handlers/vendor/hybridauth/hybridauth/src/Data/Parser.php
@@ -49,7 +49,7 @@ final class Parser
      */
     public function parseJson($result)
     {
-        return json_decode($result);
+        return json_decode((string) $result);
     }
 
     /**
@@ -63,7 +63,7 @@ final class Parser
     {
         libxml_use_internal_errors(true);
 
-        $result = preg_replace('/([<\/])([a-z0-9-]+):/i', '$1', $result);
+        $result = preg_replace('/([<\/])([a-z0-9-]+):/i', '$1', (string) $result);
         $xml = simplexml_load_string($result);
 
         libxml_use_internal_errors(false);
@@ -87,7 +87,7 @@ final class Parser
      */
     public function parseQueryString($result)
     {
-        parse_str($result, $output);
+        parse_str((string) $result, $output);
 
         if (!is_array($output)) {
             return $result;

--- a/e107_handlers/vendor/hybridauth/hybridauth/src/HttpClient/Curl.php
+++ b/e107_handlers/vendor/hybridauth/hybridauth/src/HttpClient/Curl.php
@@ -308,7 +308,7 @@ class Curl implements HttpClientInterface
         $headers = [];
 
         foreach ($this->requestHeader as $header => $value) {
-            $headers[] = trim($header) . ': ' . trim($value);
+            $headers[] = trim((string) $header) . ': ' . trim((string) $value);
         }
 
         return $headers;

--- a/e107_handlers/vendor/hybridauth/hybridauth/src/Provider/Apple.php
+++ b/e107_handlers/vendor/hybridauth/hybridauth/src/Provider/Apple.php
@@ -185,7 +185,7 @@ class Apple extends OAuth2
             // payload extraction by https://github.com/omidborjian
             // https://github.com/hybridauth/hybridauth/issues/1095#issuecomment-626479263
             // JWT splits the string to 3 components 1) first is header 2) is payload 3) is signature
-            $payload = explode('.', $id_token)[1];
+            $payload = explode('.', (string) $id_token)[1];
             $payload = json_decode(base64_decode($payload));
         } else {
             // validate the token signature and get the payload
@@ -202,7 +202,7 @@ class Apple extends OAuth2
 
                     $key = PublicKeyLoader::load(
                         [
-                            'e' => new BigInteger(base64_decode($jwk['e']), 256),
+                            'e' => new BigInteger(base64_decode((string) $jwk['e']), 256),
                             'n' => new BigInteger(base64_decode(strtr($jwk['n'], '-_', '+/'), true), 256)
                         ]
                     )
@@ -240,7 +240,7 @@ class Apple extends OAuth2
         $this->storeData('expires_at', $data->get('exp'));
 
         if (!empty($_REQUEST['user'])) {
-            $objUser = json_decode($_REQUEST['user']);
+            $objUser = json_decode((string) $_REQUEST['user']);
             $user = new Data\Collection($objUser);
             if (!$user->isEmpty()) {
                 $name = $user->get('name');

--- a/e107_handlers/vendor/hybridauth/hybridauth/src/Provider/DeviantArt.php
+++ b/e107_handlers/vendor/hybridauth/hybridauth/src/Provider/DeviantArt.php
@@ -70,7 +70,7 @@ class DeviantArt extends OAuth2
 
         $userProfile = new User\Profile();
 
-        $full_name = explode(' ', $data->filter('profile')->get('real_name'));
+        $full_name = explode(' ', (string) $data->filter('profile')->get('real_name'));
         if (count($full_name) < 2) {
             $full_name[1] = '';
         }

--- a/e107_handlers/vendor/hybridauth/hybridauth/src/Provider/Facebook.php
+++ b/e107_handlers/vendor/hybridauth/hybridauth/src/Provider/Facebook.php
@@ -91,7 +91,7 @@ class Facebook extends OAuth2
         // Require proof on all Facebook api calls
         // https://developers.facebook.com/docs/graph-api/securing-requests#appsecret_proof
         if ($accessToken = $this->getStoredData('access_token')) {
-            $this->apiRequestParameters['appsecret_proof'] = hash_hmac('sha256', $accessToken, $this->clientSecret);
+            $this->apiRequestParameters['appsecret_proof'] = hash_hmac('sha256', (string) $accessToken, $this->clientSecret);
         }
     }
 
@@ -269,7 +269,7 @@ class Facebook extends OAuth2
         $jwk = array_shift($filteredKeys);
 
         $keyData = [
-            'e' => new BigInteger(base64_decode($jwk->e), 256),
+            'e' => new BigInteger(base64_decode((string) $jwk->e), 256),
             'n' => new BigInteger(base64_decode(strtr($jwk->n, '-_', '+/'), true), 256),
         ];
 
@@ -310,7 +310,7 @@ class Facebook extends OAuth2
     protected function fetchUserRegion(User\Profile $userProfile)
     {
         if (!empty($userProfile->region)) {
-            $regionArr = explode(',', $userProfile->region);
+            $regionArr = explode(',', (string) $userProfile->region);
 
             if (count($regionArr) > 1) {
                 $userProfile->city = trim($regionArr[0]);
@@ -435,7 +435,7 @@ class Facebook extends OAuth2
 
         // Refresh proof for API call.
         $parameters = $status + [
-                'appsecret_proof' => hash_hmac('sha256', $page->access_token, $this->clientSecret),
+                'appsecret_proof' => hash_hmac('sha256', (string) $page->access_token, $this->clientSecret),
             ];
 
         $response = $this->apiRequest("{$pageId}/feed", 'POST', $parameters, $headers);

--- a/e107_handlers/vendor/hybridauth/hybridauth/src/Provider/Medium.php
+++ b/e107_handlers/vendor/hybridauth/hybridauth/src/Provider/Medium.php
@@ -71,7 +71,7 @@ class Medium extends OAuth2
         $userProfile = new User\Profile();
         $data = $data->filter('data');
 
-        $full_name = explode(' ', $data->get('name'));
+        $full_name = explode(' ', (string) $data->get('name'));
         if (count($full_name) < 2) {
             $full_name[1] = '';
         }

--- a/e107_handlers/vendor/hybridauth/hybridauth/src/Provider/MicrosoftGraph.php
+++ b/e107_handlers/vendor/hybridauth/hybridauth/src/Provider/MicrosoftGraph.php
@@ -129,7 +129,7 @@ class MicrosoftGraph extends OAuth2
         $userProfile->email = $data->get('mail');
         if (empty($userProfile->email)) {
             $email = $data->get('userPrincipalName');
-            if (strpos($email, '@') !== false) {
+            if (strpos((string) $email, '@') !== false) {
                 $userProfile->email = $email;
             }
         }

--- a/e107_handlers/vendor/hybridauth/hybridauth/src/Provider/Slack.php
+++ b/e107_handlers/vendor/hybridauth/hybridauth/src/Provider/Slack.php
@@ -85,7 +85,7 @@ class Slack extends OAuth2
     {
         $maxSize = 0;
         foreach ($data->filter('user')->properties() as $property) {
-            if (preg_match('/^image_(\d+)$/', $property, $matches) === 1) {
+            if (preg_match('/^image_(\d+)$/', (string) $property, $matches) === 1) {
                 $availableSize = (int)$matches[1];
                 if ($maxSize < $availableSize) {
                     $maxSize = $availableSize;

--- a/e107_handlers/vendor/hybridauth/hybridauth/src/Provider/Steam.php
+++ b/e107_handlers/vendor/hybridauth/hybridauth/src/Provider/Steam.php
@@ -99,7 +99,7 @@ class Steam extends OpenID
 
         $response = $this->httpClient->request($apiUrl);
 
-        $data = json_decode($response);
+        $data = json_decode((string) $response);
 
         $data = isset($data->response->players[0]) ? $data->response->players[0] : null;
 

--- a/e107_handlers/vendor/hybridauth/hybridauth/src/Provider/Telegram.php
+++ b/e107_handlers/vendor/hybridauth/hybridauth/src/Provider/Telegram.php
@@ -153,10 +153,10 @@ class Telegram extends AbstractAdapter implements AdapterInterface
         sort($data_check_arr);
 
         $data_check_string = implode("\n", $data_check_arr);
-        $secret_key = hash('sha256', $this->botSecret, true);
+        $secret_key = hash('sha256', (string) $this->botSecret, true);
         $hash = hash_hmac('sha256', $data_check_string, $secret_key);
 
-        if (strcmp($hash, $check_hash) !== 0) {
+        if (strcmp($hash, (string) $check_hash) !== 0) {
             throw new InvalidAuthorizationCodeException(
                 sprintf('Provider returned an error: %s', 'Data is NOT from Telegram')
             );

--- a/e107_handlers/vendor/hybridauth/hybridauth/src/Provider/Tumblr.php
+++ b/e107_handlers/vendor/hybridauth/hybridauth/src/Provider/Tumblr.php
@@ -66,9 +66,9 @@ class Tumblr extends OAuth1
                 $userProfile->identifier = $blog->get('url');
                 $userProfile->profileURL = $blog->get('url');
                 $userProfile->webSiteURL = $blog->get('url');
-                $userProfile->description = strip_tags($blog->get('description'));
+                $userProfile->description = strip_tags((string) $blog->get('description'));
 
-                $bloghostname = explode('://', $blog->get('url'));
+                $bloghostname = explode('://', (string) $blog->get('url'));
                 $bloghostname = substr($bloghostname[1], 0, -1);
 
                 // store user's primary blog which will be used as target by setUserStatus

--- a/e107_handlers/vendor/hybridauth/hybridauth/src/Provider/TwitchTV.php
+++ b/e107_handlers/vendor/hybridauth/hybridauth/src/Provider/TwitchTV.php
@@ -74,7 +74,7 @@ class TwitchTV extends OAuth2
         $userProfile->displayName = $user->get('display_name');
         $userProfile->photoURL = $user->get('profile_image_url');
         $userProfile->email = $user->get('email');
-        $userProfile->description = strip_tags($user->get('description'));
+        $userProfile->description = strip_tags((string) $user->get('description'));
         $userProfile->profileURL = "https://www.twitch.tv/{$userProfile->displayName}";
 
         return $userProfile;

--- a/e107_handlers/vendor/hybridauth/hybridauth/src/Storage/Session.php
+++ b/e107_handlers/vendor/hybridauth/hybridauth/src/Storage/Session.php
@@ -119,7 +119,7 @@ class Session implements StorageInterface
             $tmp = $_SESSION[$this->storeNamespace];
 
             foreach ($tmp as $k => $v) {
-                if (strstr($k, $key)) {
+                if (strstr((string) $k, $key)) {
                     unset($tmp[$k]);
                 }
             }

--- a/e107_handlers/vendor/hybridauth/hybridauth/src/Thirdparty/OAuth/OAuthRequest.php
+++ b/e107_handlers/vendor/hybridauth/hybridauth/src/Thirdparty/OAuth/OAuthRequest.php
@@ -32,7 +32,7 @@ class OAuthRequest
     public function __construct($http_method, $http_url, $parameters = null)
     {
         $parameters = ($parameters) ? $parameters : array();
-        $parameters = array_merge(OAuthUtil::parse_parameters(parse_url($http_url, PHP_URL_QUERY)), $parameters);
+        $parameters = array_merge(OAuthUtil::parse_parameters(parse_url((string) $http_url, PHP_URL_QUERY)), $parameters);
         $this->parameters  = $parameters;
         $this->http_method = $http_method;
         $this->http_url    = $http_url;
@@ -209,7 +209,7 @@ class OAuthRequest
      */
     public function get_normalized_http_method()
     {
-        return strtoupper($this->http_method);
+        return strtoupper((string) $this->http_method);
     }
     
     /**
@@ -218,7 +218,7 @@ class OAuthRequest
      */
     public function get_normalized_http_url()
     {
-        $parts = parse_url($this->http_url);
+        $parts = parse_url((string) $this->http_url);
         
         $scheme = (isset($parts['scheme'])) ? $parts['scheme'] : 'http';
         $port   = (isset($parts['port'])) ? $parts['port'] : (($scheme == 'https') ? '443' : '80');
@@ -266,9 +266,9 @@ class OAuthRequest
         } else {
             $out = 'OAuth';
         }
-        
+
         foreach ($this->parameters as $k => $v) {
-            if (substr($k, 0, 5) != "oauth") {
+            if (substr((string) $k, 0, 5) != "oauth") {
                 continue;
             }
             if (is_array($v)) {
@@ -332,7 +332,7 @@ class OAuthRequest
     {
         $mt   = microtime();
         $rand = mt_rand();
-        
+
         return md5($mt . $rand); // md5s look nicer than numbers
     }
 }

--- a/e107_handlers/vendor/hybridauth/hybridauth/src/Thirdparty/OAuth/OAuthSignatureMethodHMACSHA1.php
+++ b/e107_handlers/vendor/hybridauth/hybridauth/src/Thirdparty/OAuth/OAuthSignatureMethodHMACSHA1.php
@@ -39,6 +39,6 @@ class OAuthSignatureMethodHMACSHA1 extends OAuthSignatureMethod
         $key_parts = OAuthUtil::urlencode_rfc3986($key_parts);
         $key = implode('&', $key_parts);
         
-        return base64_encode(hash_hmac('sha1', $base_string, $key, true));
+        return base64_encode(hash_hmac('sha1', (string) $base_string, $key, true));
     }
 }

--- a/e107_handlers/vendor/hybridauth/hybridauth/src/Thirdparty/OAuth/OAuthUtil.php
+++ b/e107_handlers/vendor/hybridauth/hybridauth/src/Thirdparty/OAuth/OAuthUtil.php
@@ -43,7 +43,7 @@ class OAuthUtil
      */
     public static function urldecode_rfc3986($string)
     {
-        return urldecode($string);
+        return urldecode((string) $string);
     }
     
     // Utility function for turning the Authorization: header into
@@ -60,7 +60,7 @@ class OAuthUtil
     public static function split_header($header, $only_allow_oauth_parameters = true)
     {
         $params = array();
-        if (preg_match_all('/(' . ($only_allow_oauth_parameters ? 'oauth_' : '') . '[a-z_-]*)=(:?"([^"]*)"|([^,]*))/', $header, $matches)) {
+        if (preg_match_all('/(' . ($only_allow_oauth_parameters ? 'oauth_' : '') . '[a-z_-]*)=(:?"([^"]*)"|([^,]*))/', (string) $header, $matches)) {
             foreach ($matches[1] as $i => $h) {
                 $params[$h] = OAuthUtil::urldecode_rfc3986(empty($matches[3][$i]) ? $matches[4][$i] : $matches[3][$i]);
             }
@@ -104,11 +104,11 @@ class OAuthUtil
             }
             
             foreach ($_SERVER as $key => $value) {
-                if (substr($key, 0, 5) == "HTTP_") {
+                if (substr((string) $key, 0, 5) == "HTTP_") {
                     // this is chaos, basically it is just there to capitalize the first
                     // letter of every word that is not an initial HTTP and strip HTTP
                     // code from przemek
-                    $key       = str_replace(" ", "-", ucwords(strtolower(str_replace("_", " ", substr($key, 5)))));
+                    $key       = str_replace(" ", "-", ucwords(strtolower(str_replace("_", " ", substr((string) $key, 5)))));
                     $out[$key] = $value;
                 }
             }
@@ -130,7 +130,7 @@ class OAuthUtil
             return array();
         }
         
-        $pairs = explode('&', $input);
+        $pairs = explode('&', (string) $input);
         
         $parsed_parameters = array();
         foreach ($pairs as $pair) {

--- a/e107_handlers/vendor/hybridauth/hybridauth/src/Thirdparty/OpenID/LightOpenID.php
+++ b/e107_handlers/vendor/hybridauth/hybridauth/src/Thirdparty/OpenID/LightOpenID.php
@@ -99,7 +99,7 @@ class LightOpenID
         $this->set_realm($host);
         $this->set_proxy($proxy);
 
-        $uri = rtrim(preg_replace('#((?<=\?)|&)openid\.[^&]+#', '', $_SERVER['REQUEST_URI']), '?');
+        $uri = rtrim((string) preg_replace('#((?<=\?)|&)openid\.[^&]+#', '', (string) $_SERVER['REQUEST_URI']), '?');
         $this->returnUrl = $this->trustRoot . $uri;
 
         $this->data = ($_SERVER['REQUEST_METHOD'] === 'POST') ? $_POST : $_GET;
@@ -141,7 +141,7 @@ class LightOpenID
             break;
         case 'trustRoot':
         case 'realm':
-            $this->trustRoot = trim($value);
+            $this->trustRoot = trim((string) $value);
             break;
         case 'xrdsOverride':
             if (is_array($value)) {
@@ -186,7 +186,7 @@ class LightOpenID
         if (!empty($proxy)) {
             // When the proxy is a string - try to parse it.
             if (!is_array($proxy)) {
-                $proxy = parse_url($proxy);
+                $proxy = parse_url((string) $proxy);
             }
 
             // Check if $proxy is valid after the parsing.
@@ -215,10 +215,10 @@ class LightOpenID
      */
     public function hostExists($url)
     {
-        if (strpos($url, '/') === false) {
+        if (strpos((string) $url, '/') === false) {
             $server = $url;
         } else {
-            $server = @parse_url($url, PHP_URL_HOST);
+            $server = @parse_url((string) $url, PHP_URL_HOST);
         }
 
         if (!$server) {
@@ -236,13 +236,13 @@ class LightOpenID
         $realm = '';
 
         # Set a protocol, if not specified.
-        $realm .= (($offset = strpos($uri, '://')) === false) ? $this->get_realm_protocol() : '';
+        $realm .= (($offset = strpos((string) $uri, '://')) === false) ? $this->get_realm_protocol() : '';
 
         # Set the offset properly.
         $offset = (($offset !== false) ? $offset + 3 : 0);
 
         # Get only the root, without the path.
-        $realm .= (($end = strpos($uri, '/', $offset)) === false) ? $uri : substr($uri, 0, $end);
+        $realm .= (($end = strpos((string) $uri, '/', $offset)) === false) ? $uri : substr((string) $uri, 0, $end);
 
         $this->trustRoot = $realm;
     }
@@ -384,10 +384,10 @@ class LightOpenID
     {
         $headers = array();
         foreach ($array as $header) {
-            $pos = strpos($header, ':');
+            $pos = strpos((string) $header, ':');
             if ($pos !== false) {
-                $name = strtolower(trim(substr($header, 0, $pos)));
-                $headers[$name] = trim(substr($header, $pos+1));
+                $name = strtolower(trim(substr((string) $header, 0, $pos)));
+                $headers[$name] = trim(substr((string) $header, $pos+1));
 
                 # Following possible redirections. The point is just to have
                 # claimed_id change with them, because the redirections
@@ -398,7 +398,7 @@ class LightOpenID
                     if (strpos($headers[$name], 'http') === 0) {
                         $this->identity = $this->claimed_id = $headers[$name];
                     } elseif ($headers[$name][0] == '/') {
-                        $parsed_url = parse_url($this->claimed_id);
+                        $parsed_url = parse_url((string) $this->claimed_id);
                         $this->identity =
                         $this->claimed_id = $parsed_url['scheme'] . '://'
                                           . $parsed_url['host']
@@ -426,7 +426,7 @@ class LightOpenID
         }
 
         if (empty($this->cnmatch)) {
-            $this->cnmatch = parse_url($url, PHP_URL_HOST);
+            $this->cnmatch = parse_url((string) $url, PHP_URL_HOST);
         }
 
         $params = http_build_query($params, '', '&');
@@ -521,7 +521,7 @@ class LightOpenID
             stream_context_get_default($default);
 
             if (!empty($headers)) {
-                if (intval(substr($headers[0], strlen('HTTP/1.1 '))) == 405) {
+                if (intval(substr((string) $headers[0], strlen('HTTP/1.1 '))) == 405) {
                     // The server doesn't support HEAD - emulate it with a GET.
                     $args = func_get_args();
                     $args[1] = 'GET';
@@ -655,8 +655,8 @@ class LightOpenID
      */
     protected function htmlTag($content, $tag, $attrName, $attrValue, $valueName)
     {
-        preg_match_all("#<{$tag}[^>]*$attrName=['\"].*?$attrValue.*?['\"][^>]*$valueName=['\"](.+?)['\"][^>]*/?>#i", $content, $matches1);
-        preg_match_all("#<{$tag}[^>]*$valueName=['\"](.+?)['\"][^>]*$attrName=['\"].*?$attrValue.*?['\"][^>]*/?>#i", $content, $matches2);
+        preg_match_all("#<{$tag}[^>]*$attrName=['\"].*?$attrValue.*?['\"][^>]*$valueName=['\"](.+?)['\"][^>]*/?>#i", (string) $content, $matches1);
+        preg_match_all("#<{$tag}[^>]*$valueName=['\"](.+?)['\"][^>]*$attrName=['\"].*?$attrValue.*?['\"][^>]*/?>#i", (string) $content, $matches2);
 
         $result = array_merge($matches1[1], $matches2[1]);
         return empty($result)?false:$result[0];
@@ -674,7 +674,7 @@ class LightOpenID
             throw new ErrorException('No identity supplied.');
         }
         # Use xri.net proxy to resolve i-name identities
-        if (!preg_match('#^https?:#', $url)) {
+        if (!preg_match('#^https?:#', (string) $url)) {
             $url = "https://xri.net/$url";
         }
 
@@ -689,7 +689,7 @@ class LightOpenID
         # Allows optional regex replacement of the URL, e.g. to use Google Apps
         # as an OpenID provider without setting up XRDS on the domain hosting.
         if (!is_null($this->xrds_override_pattern) && !is_null($this->xrds_override_replacement)) {
-            $url = preg_replace($this->xrds_override_pattern, $this->xrds_override_replacement, $url);
+            $url = preg_replace($this->xrds_override_pattern, $this->xrds_override_replacement, (string) $url);
         }
 
         # We'll jump a maximum of 5 times, to avoid endless redirections.
@@ -699,7 +699,7 @@ class LightOpenID
 
                 $next = false;
                 if (isset($headers['x-xrds-location'])) {
-                    $url = $this->build_url(parse_url($url), parse_url(trim($headers['x-xrds-location'])));
+                    $url = $this->build_url(parse_url((string) $url), parse_url(trim($headers['x-xrds-location'])));
                     $next = true;
                 }
 
@@ -775,13 +775,13 @@ class LightOpenID
                 $content = $this->request($url, 'GET', array(), true);
 
                 if (isset($this->headers['x-xrds-location'])) {
-                    $url = $this->build_url(parse_url($url), parse_url(trim($this->headers['x-xrds-location'])));
+                    $url = $this->build_url(parse_url((string) $url), parse_url(trim($this->headers['x-xrds-location'])));
                     continue;
                 }
 
                 $location = $this->htmlTag($content, 'meta', 'http-equiv', 'X-XRDS-Location', 'content');
                 if ($location) {
-                    $url = $this->build_url(parse_url($url), parse_url($location));
+                    $url = $this->build_url(parse_url((string) $url), parse_url($location));
                     continue;
                 }
             }
@@ -837,7 +837,7 @@ class LightOpenID
         }
 
         foreach ($allowed_types as $type) {
-            if (strpos($content_type, $type) !== false) {
+            if (strpos((string) $content_type, $type) !== false) {
                 return true;
             }
         }
@@ -856,7 +856,7 @@ class LightOpenID
 
         if (!empty($provider_url)) {
             $tokens = array_reverse(
-                explode('.', parse_url($provider_url, PHP_URL_HOST))
+                explode('.', parse_url((string) $provider_url, PHP_URL_HOST))
             );
             $result = strtolower(
                 (count($tokens) > 1 && strlen($tokens[1]) > 3)
@@ -962,7 +962,7 @@ class LightOpenID
         # we need to somehow preserve the claimed id between requests.
         # The simplest way is to just send it along with the return_to url.
         if ($this->identity != $this->claimed_id) {
-            $returnUrl .= (strpos($returnUrl, '?') ? '&' : '?') . 'openid.claimed_id=' . $this->claimed_id;
+            $returnUrl .= (strpos((string) $returnUrl, '?') ? '&' : '?') . 'openid.claimed_id=' . $this->claimed_id;
         }
 
         $params = array(
@@ -972,7 +972,7 @@ class LightOpenID
             'openid.trust_root' => $this->trustRoot,
             ) + $this->sregParams();
 
-        return $this->build_url(parse_url($this->server), array('query' => http_build_query($params, '', '&')));
+        return $this->build_url(parse_url((string) $this->server), array('query' => http_build_query($params, '', '&')));
     }
 
     /**
@@ -1017,7 +1017,7 @@ class LightOpenID
             $params['openid.claimed_id'] = $this->claimed_id;
         }
 
-        return $this->build_url(parse_url($this->server), array('query' => http_build_query($params, '', '&')));
+        return $this->build_url(parse_url((string) $this->server), array('query' => http_build_query($params, '', '&')));
     }
 
     /**
@@ -1077,7 +1077,7 @@ class LightOpenID
         ) {
             # If it's an OpenID 1 provider, and we've got claimed_id,
             # we have to append it to the returnUrl, like authUrl_v1 does.
-            $this->returnUrl .= (strpos($this->returnUrl, '?') ? '&' : '?')
+            $this->returnUrl .= (strpos((string) $this->returnUrl, '?') ? '&' : '?')
                              .  'openid.claimed_id=' . $this->claimed_id;
         }
 
@@ -1089,7 +1089,7 @@ class LightOpenID
 
         $server = $this->discover($this->claimed_id);
 
-        foreach (explode(',', $this->data['openid_signed']) as $item) {
+        foreach (explode(',', (string) $this->data['openid_signed']) as $item) {
             $value = $this->data['openid_' . str_replace('.', '_', $item)];
             $params['openid.' . $item] = $value;
         }
@@ -1112,7 +1112,7 @@ class LightOpenID
             $prefix = 'openid_' . $alias;
             $length = strlen('http://axschema.org/');
 
-            foreach (explode(',', $this->data['openid_signed']) as $key) {
+            foreach (explode(',', (string) $this->data['openid_signed']) as $key) {
                 $keyMatch = $alias . '.type.';
 
                 if (strncmp($key, $keyMatch, strlen($keyMatch)) !== 0) {
@@ -1122,7 +1122,7 @@ class LightOpenID
                 $key = substr($key, strlen($keyMatch));
                 $idv = $prefix . '_value_' . $key;
                 $idc = $prefix . '_count_' . $key;
-                $key = substr($this->getItem($prefix . '_type_' . $key), $length);
+                $key = substr((string) $this->getItem($prefix . '_type_' . $key), $length);
 
                 if (!empty($key)) {
                     if (($count = intval($this->getItem($idc))) > 0) {
@@ -1158,7 +1158,7 @@ class LightOpenID
         $attributes = array();
         $sreg_to_ax = array_flip(self::$ax_to_sreg);
         if ($alias = $this->getNamespaceAlias('http://openid.net/extensions/sreg/1.1', 'sreg')) {
-            foreach (explode(',', $this->data['openid_signed']) as $key) {
+            foreach (explode(',', (string) $this->data['openid_signed']) as $key) {
                 $keyMatch = $alias . '.';
                 if (strncmp($key, $keyMatch, strlen($keyMatch)) !== 0) {
                     continue;
@@ -1231,8 +1231,8 @@ class LightOpenID
             $length = strlen($prefix);
 
             foreach ($this->data as $key => $val) {
-                if (strncmp($key, $prefix, $length) === 0 && $val === $namespace) {
-                    $result = trim(substr($key, $length));
+                if (strncmp((string) $key, $prefix, $length) === 0 && $val === $namespace) {
+                    $result = trim(substr((string) $key, $length));
                     break;
                 }
             }

--- a/e107_handlers/vendor/ifsnop/mysqldump-php/src/Ifsnop/Mysqldump/Mysqldump.php
+++ b/e107_handlers/vendor/ifsnop/mysqldump-php/src/Ifsnop/Mysqldump/Mysqldump.php
@@ -691,7 +691,7 @@ class Mysqldump
             if ('/' != $pattern[0]) {
                 continue;
             }
-            if (1 == preg_match($pattern, $table)) {
+            if (1 == preg_match($pattern, (string) $table)) {
                 $match = true;
             }
         }
@@ -1458,7 +1458,7 @@ class CompressGzip extends CompressManagerFactory
 
     public function write($str)
     {
-        $bytesWritten = gzwrite($this->fileHandler, $str);
+        $bytesWritten = gzwrite($this->fileHandler, (string) $str);
         if (false === $bytesWritten) {
             throw new Exception("Writting to file failed! Probably, there is no more free space left?");
         }
@@ -1490,7 +1490,7 @@ class CompressNone extends CompressManagerFactory
 
     public function write($str)
     {
-        $bytesWritten = fwrite($this->fileHandler, $str);
+        $bytesWritten = fwrite($this->fileHandler, (string) $str);
         if (false === $bytesWritten) {
             throw new Exception("Writting to file failed! Probably, there is no more free space left?");
         }
@@ -1526,7 +1526,7 @@ class CompressGzipstream extends CompressManagerFactory
     public function write($str)
     {
 
-    $bytesWritten = fwrite($this->fileHandler, deflate_add($this->compressContext, $str, ZLIB_NO_FLUSH));
+    $bytesWritten = fwrite($this->fileHandler, deflate_add($this->compressContext, (string) $str, ZLIB_NO_FLUSH));
     if (false === $bytesWritten) {
         throw new Exception("Writting to file failed! Probably, there is no more free space left?");
     }
@@ -1929,7 +1929,7 @@ class TypeAdapterMysql extends TypeAdapterFactory
         }
 
 		if ($this->dumpSettings['if-not-exists'] ) {
-			$createTable = preg_replace('/^CREATE TABLE/', 'CREATE TABLE IF NOT EXISTS', $createTable);
+			$createTable = preg_replace('/^CREATE TABLE/', 'CREATE TABLE IF NOT EXISTS', (string) $createTable);
         }
 
         $ret = "/*!40101 SET @saved_cs_client     = @@character_set_client */;".PHP_EOL.
@@ -2298,7 +2298,7 @@ class TypeAdapterMysql extends TypeAdapterFactory
     public function parseColumnType($colType)
     {
         $colInfo = array();
-        $colParts = explode(" ", $colType['Type']);
+        $colParts = explode(" ", (string) $colType['Type']);
 
         if ($fparen = strpos($colParts[0], "(")) {
             $colInfo['type'] = substr($colParts[0], 0, $fparen);
@@ -2312,7 +2312,7 @@ class TypeAdapterMysql extends TypeAdapterFactory
         // for virtual columns that are of type 'Extra', column type
         // could by "STORED GENERATED" or "VIRTUAL GENERATED"
         // MySQL reference: https://dev.mysql.com/doc/refman/5.7/en/create-table-generated-columns.html
-        $colInfo['is_virtual'] = strpos($colType['Extra'], "VIRTUAL GENERATED") !== false || strpos($colType['Extra'], "STORED GENERATED") !== false;
+        $colInfo['is_virtual'] = strpos((string) $colType['Extra'], "VIRTUAL GENERATED") !== false || strpos((string) $colType['Extra'], "STORED GENERATED") !== false;
 
         return $colInfo;
     }

--- a/e107_handlers/vendor/intervention/image/src/Intervention/Image/AbstractDecoder.php
+++ b/e107_handlers/vendor/intervention/image/src/Intervention/Image/AbstractDecoder.php
@@ -345,7 +345,7 @@ abstract class AbstractDecoder
 
             // isBase64 has to be after isFilePath to prevent false positives
             case $this->isBase64():
-                return $this->initFromBinary(base64_decode($this->data));
+                return $this->initFromBinary(base64_decode((string) $this->data));
 
             default:
                 throw new NotReadableException("Image source not readable");

--- a/e107_handlers/vendor/intervention/image/src/Intervention/Image/Commands/Argument.php
+++ b/e107_handlers/vendor/intervention/image/src/Intervention/Image/Commands/Argument.php
@@ -90,7 +90,7 @@ class Argument
             return $this;
         }
 
-        switch (strtolower($type)) {
+        switch (strtolower((string) $type)) {
             case 'bool':
             case 'boolean':
                 $valid = \is_bool($value);

--- a/e107_handlers/vendor/intervention/image/src/Intervention/Image/Gd/Commands/FlipCommand.php
+++ b/e107_handlers/vendor/intervention/image/src/Intervention/Image/Gd/Commands/FlipCommand.php
@@ -17,7 +17,7 @@ class FlipCommand extends ResizeCommand
         $size = $image->getSize();
         $dst = clone $size;
 
-        switch (strtolower($mode)) {
+        switch (strtolower((string) $mode)) {
             case 2:
             case 'v':
             case 'vert':

--- a/e107_handlers/vendor/intervention/image/src/Intervention/Image/Gd/Commands/TrimCommand.php
+++ b/e107_handlers/vendor/intervention/image/src/Intervention/Image/Gd/Commands/TrimCommand.php
@@ -34,11 +34,11 @@ class TrimCommand extends ResizeCommand
 
         // lower border names
         foreach ($away as $key => $value) {
-            $away[$key] = strtolower($value);
+            $away[$key] = strtolower((string) $value);
         }
 
         // define base color position
-        switch (strtolower($base)) {
+        switch (strtolower((string) $base)) {
             case 'transparent':
             case 'trans':
                 $checkTransparency = true;

--- a/e107_handlers/vendor/intervention/image/src/Intervention/Image/Gd/Font.php
+++ b/e107_handlers/vendor/intervention/image/src/Intervention/Image/Gd/Font.php
@@ -87,7 +87,7 @@ class Font extends \Intervention\Image\AbstractFont
             // represented as is.
             // eg: &amp;#160; will render &#160; rather than its character.
             $this->text = preg_replace('/&(#(?:x[a-fA-F0-9]+|[0-9]+);)/', '&#38;\1', $this->text);
-            $this->text = mb_encode_numericentity($this->text, array(0x0080, 0xffff, 0, 0xffff), 'UTF-8');
+            $this->text = mb_encode_numericentity((string) $this->text, array(0x0080, 0xffff, 0, 0xffff), 'UTF-8');
 
             // get bounding box with angle 0
             $box = imagettfbbox($this->getPointSize(), 0, $this->file, $this->text);

--- a/e107_handlers/vendor/intervention/image/src/Intervention/Image/Imagick/Commands/ExifCommand.php
+++ b/e107_handlers/vendor/intervention/image/src/Intervention/Image/Imagick/Commands/ExifCommand.php
@@ -50,11 +50,11 @@ class ExifCommand extends BaseCommand
         $exif = [];
         $properties = $core->getImageProperties();
         foreach ($properties as $key => $value) {
-            if (substr($key, 0, 5) !== 'exif:') {
+            if (substr((string) $key, 0, 5) !== 'exif:') {
                 continue;
             }
 
-            $exif[substr($key, 5)] = $value;
+            $exif[substr((string) $key, 5)] = $value;
         }
 
         $this->setOutput($exif);

--- a/e107_handlers/vendor/intervention/image/src/Intervention/Image/Imagick/Commands/FlipCommand.php
+++ b/e107_handlers/vendor/intervention/image/src/Intervention/Image/Imagick/Commands/FlipCommand.php
@@ -16,7 +16,7 @@ class FlipCommand extends AbstractCommand
     {
         $mode = $this->argument(0)->value('h');
 
-        if (in_array(strtolower($mode), [2, 'v', 'vert', 'vertical'])) {
+        if (in_array(strtolower((string) $mode), [2, 'v', 'vert', 'vertical'])) {
             // flip vertical
             return $image->getCore()->flipImage();
         } else {

--- a/e107_handlers/vendor/intervention/image/src/Intervention/Image/Imagick/Commands/TrimCommand.php
+++ b/e107_handlers/vendor/intervention/image/src/Intervention/Image/Imagick/Commands/TrimCommand.php
@@ -34,11 +34,11 @@ class TrimCommand extends AbstractCommand
 
         // lower border names
         foreach ($away as $key => $value) {
-            $away[$key] = strtolower($value);
+            $away[$key] = strtolower((string) $value);
         }
 
         // define base color position
-        switch (strtolower($base)) {
+        switch (strtolower((string) $base)) {
             case 'transparent':
             case 'trans':
                 $checkTransparency = true;

--- a/e107_handlers/vendor/matthiasmullie/minify/src/CSS.php
+++ b/e107_handlers/vendor/matthiasmullie/minify/src/CSS.php
@@ -496,11 +496,11 @@ class CSS extends Minify
         $content = preg_replace('/(?<=[: ])#([0-9a-f])\\1([0-9a-f])\\2([0-9a-f])\\3(?:([0-9a-f])\\4)?(?=[; }])/i', '#$1$2$3$4', $content);
 
         // remove alpha channel if it's pointless ..
-        $content = preg_replace('/(?<=[: ])#([0-9a-f]{6})ff(?=[; }])/i', '#$1', $content);
-        $content = preg_replace('/(?<=[: ])#([0-9a-f]{3})f(?=[; }])/i', '#$1', $content);
+        $content = preg_replace('/(?<=[: ])#([0-9a-f]{6})ff(?=[; }])/i', '#$1', (string) $content);
+        $content = preg_replace('/(?<=[: ])#([0-9a-f]{3})f(?=[; }])/i', '#$1', (string) $content);
 
         // replace `transparent` with shortcut ..
-        $content = preg_replace('/(?<=[: ])#[0-9a-f]{6}00(?=[; }])/i', '#fff0', $content);
+        $content = preg_replace('/(?<=[: ])#[0-9a-f]{6}00(?=[; }])/i', '#fff0', (string) $content);
 
         $colors = array(
             // make these more readable
@@ -561,7 +561,7 @@ class CSS extends Minify
             function ($match) use ($colors) {
                 return $colors[strtolower($match[0])];
             },
-            $content
+            (string) $content
         );
     }
 
@@ -584,9 +584,9 @@ class CSS extends Minify
 
         // convert legacy color syntax
         $content = preg_replace('/(rgb)a?\(\s*([0-9]{1,3}%?)\s*,\s*([0-9]{1,3}%?)\s*,\s*([0-9]{1,3}%?)\s*,\s*([0,1]?(?:\.[0-9]*)?)\s*\)/i', '$1($2 $3 $4 / $5)', $content);
-        $content = preg_replace('/(rgb)a?\(\s*([0-9]{1,3}%?)\s*,\s*([0-9]{1,3}%?)\s*,\s*([0-9]{1,3}%?)\s*\)/i', '$1($2 $3 $4)', $content);
-        $content = preg_replace('/(hsl)a?\(\s*([0-9]+(?:deg|grad|rad|turn)?)\s*,\s*([0-9]{1,3}%)\s*,\s*([0-9]{1,3}%)\s*,\s*([0,1]?(?:\.[0-9]*)?)\s*\)/i', '$1($2 $3 $4 / $5)', $content);
-        $content = preg_replace('/(hsl)a?\(\s*([0-9]+(?:deg|grad|rad|turn)?)\s*,\s*([0-9]{1,3}%)\s*,\s*([0-9]{1,3}%)\s*\)/i', '$1($2 $3 $4)', $content);
+        $content = preg_replace('/(rgb)a?\(\s*([0-9]{1,3}%?)\s*,\s*([0-9]{1,3}%?)\s*,\s*([0-9]{1,3}%?)\s*\)/i', '$1($2 $3 $4)', (string) $content);
+        $content = preg_replace('/(hsl)a?\(\s*([0-9]+(?:deg|grad|rad|turn)?)\s*,\s*([0-9]{1,3}%)\s*,\s*([0-9]{1,3}%)\s*,\s*([0,1]?(?:\.[0-9]*)?)\s*\)/i', '$1($2 $3 $4 / $5)', (string) $content);
+        $content = preg_replace('/(hsl)a?\(\s*([0-9]+(?:deg|grad|rad|turn)?)\s*,\s*([0-9]{1,3}%)\s*,\s*([0-9]{1,3}%)\s*\)/i', '$1($2 $3 $4)', (string) $content);
 
         // convert `rgb` to `hex`
         $dec = '([01]?[0-9]?[0-9]|2[0-4][0-9]|25[0-5])';
@@ -595,7 +595,7 @@ class CSS extends Minify
             function ($match) {
                 return sprintf('#%02x%02x%02x', $match[1], $match[2], $match[3]);
             },
-            $content
+            (string) $content
         );
     }
 
@@ -624,7 +624,7 @@ class CSS extends Minify
         $content = preg_replace('/' . $tag . '\(\s*([^\s]+)\s+([^\s]+)\s+([^\s]+)\s+\/\s+1(?:(?:\.\d?)*|00%)?\s*\)/i', '$1($2 $3 $4)', $content);
 
         // replace `transparent` with shortcut ..
-        $content = preg_replace('/' . $tag . '\(\s*[^\s]+\s+[^\s]+\s+[^\s]+\s+\/\s+0(?:[\.0%]*)?\s*\)/i', '#fff0', $content);
+        $content = preg_replace('/' . $tag . '\(\s*[^\s]+\s+[^\s]+\s+[^\s]+\s+\/\s+0(?:[\.0%]*)?\s*\)/i', '#fff0', (string) $content);
 
         return $content;
     }
@@ -682,23 +682,23 @@ class CSS extends Minify
         $content = preg_replace('/' . $before . '(-?0*(\.0+)?)(?<=0)px' . $after . '/', '\\1', $content);
 
         // strip 0-digits (.0 -> 0)
-        $content = preg_replace('/' . $before . '\.0+' . $units . '?' . $after . '/', '0\\1', $content);
+        $content = preg_replace('/' . $before . '\.0+' . $units . '?' . $after . '/', '0\\1', (string) $content);
         // strip trailing 0: 50.10 -> 50.1, 50.10px -> 50.1px
-        $content = preg_replace('/' . $before . '(-?[0-9]+\.[0-9]+)0+' . $units . '?' . $after . '/', '\\1\\2', $content);
+        $content = preg_replace('/' . $before . '(-?[0-9]+\.[0-9]+)0+' . $units . '?' . $after . '/', '\\1\\2', (string) $content);
         // strip trailing 0: 50.00 -> 50, 50.00px -> 50px
-        $content = preg_replace('/' . $before . '(-?[0-9]+)\.0+' . $units . '?' . $after . '/', '\\1\\2', $content);
+        $content = preg_replace('/' . $before . '(-?[0-9]+)\.0+' . $units . '?' . $after . '/', '\\1\\2', (string) $content);
         // strip leading 0: 0.1 -> .1, 01.1 -> 1.1
-        $content = preg_replace('/' . $before . '(-?)0+([0-9]*\.[0-9]+)' . $units . '?' . $after . '/', '\\1\\2\\3', $content);
+        $content = preg_replace('/' . $before . '(-?)0+([0-9]*\.[0-9]+)' . $units . '?' . $after . '/', '\\1\\2\\3', (string) $content);
 
         // strip negative zeroes (-0 -> 0) & truncate zeroes (00 -> 0)
-        $content = preg_replace('/' . $before . '-?0+' . $units . '?' . $after . '/', '0\\1', $content);
+        $content = preg_replace('/' . $before . '-?0+' . $units . '?' . $after . '/', '0\\1', (string) $content);
 
         // IE doesn't seem to understand a unitless flex-basis value (correct -
         // it goes against the spec), so let's add it in again (make it `%`,
         // which is only 1 char: 0%, 0px, 0 anything, it's all just the same)
         // @see https://developer.mozilla.org/nl/docs/Web/CSS/flex
-        $content = preg_replace('/flex:([0-9]+\s[0-9]+\s)0([;\}])/', 'flex:${1}0%${2}', $content);
-        $content = preg_replace('/flex-basis:0([;\}])/', 'flex-basis:0%${1}', $content);
+        $content = preg_replace('/flex:([0-9]+\s[0-9]+\s)0([;\}])/', 'flex:${1}0%${2}', (string) $content);
+        $content = preg_replace('/flex-basis:0([;\}])/', 'flex-basis:0%${1}', (string) $content);
 
         return $content;
     }
@@ -713,7 +713,7 @@ class CSS extends Minify
     protected function stripEmptyTags($content)
     {
         $content = preg_replace('/(?<=^)[^\{\};]+\{\s*\}/', '', $content);
-        $content = preg_replace('/(?<=(\}|;))[^\{\};]+\{\s*\}/', '', $content);
+        $content = preg_replace('/(?<=(\}|;))[^\{\};]+\{\s*\}/', '', (string) $content);
 
         return $content;
     }
@@ -737,24 +737,24 @@ class CSS extends Minify
     {
         // remove leading & trailing whitespace
         $content = preg_replace('/^\s*/m', '', $content);
-        $content = preg_replace('/\s*$/m', '', $content);
+        $content = preg_replace('/\s*$/m', '', (string) $content);
 
         // replace newlines with a single space
-        $content = preg_replace('/\s+/', ' ', $content);
+        $content = preg_replace('/\s+/', ' ', (string) $content);
 
         // remove whitespace around meta characters
         // inspired by stackoverflow.com/questions/15195750/minify-compress-css-with-regex
-        $content = preg_replace('/\s*([\*$~^|]?+=|[{};,>~]|!important\b)\s*/', '$1', $content);
-        $content = preg_replace('/([\[(:>\+])\s+/', '$1', $content);
-        $content = preg_replace('/\s+([\]\)>\+])/', '$1', $content);
-        $content = preg_replace('/\s+(:)(?![^\}]*\{)/', '$1', $content);
+        $content = preg_replace('/\s*([\*$~^|]?+=|[{};,>~]|!important\b)\s*/', '$1', (string) $content);
+        $content = preg_replace('/([\[(:>\+])\s+/', '$1', (string) $content);
+        $content = preg_replace('/\s+([\]\)>\+])/', '$1', (string) $content);
+        $content = preg_replace('/\s+(:)(?![^\}]*\{)/', '$1', (string) $content);
 
         // whitespace around + and - can only be stripped inside some pseudo-
         // classes, like `:nth-child(3+2n)`
         // not in things like `calc(3px + 2px)`, shorthands like `3px -2px`, or
         // selectors like `div.weird- p`
         $pseudos = array('nth-child', 'nth-last-child', 'nth-last-of-type', 'nth-of-type');
-        $content = preg_replace('/:(' . implode('|', $pseudos) . ')\(\s*([+-]?)\s*(.+?)\s*([+-]?)\s*(.*?)\s*\)/', ':$1($2$3$4$5)', $content);
+        $content = preg_replace('/:(' . implode('|', $pseudos) . ')\(\s*([+-]?)\s*(.+?)\s*([+-]?)\s*(.*?)\s*\)/', ':$1($2$3$4$5)', (string) $content);
 
         // remove semicolon/whitespace followed by closing bracket
         $content = str_replace(';}', '}', $content);
@@ -775,7 +775,7 @@ class CSS extends Minify
         $minifier = $this;
         $callback = function ($match) use ($minifier, $pattern, &$callback) {
             $function = $match[1];
-            $length = strlen($match[2]);
+            $length = strlen((string) $match[2]);
             $expr = '';
             $opened = 0;
 
@@ -823,7 +823,7 @@ class CSS extends Minify
             '/(?<=^|[;}{])\s*(--[^:;{}"\'\s]+)\s*:([^;{}]+)/m',
             function ($match) use ($minifier) {
                 $placeholder = '--custom-' . count($minifier->extracted) . ':0';
-                $minifier->extracted[$placeholder] = $match[1] . ':' . trim($match[2]);
+                $minifier->extracted[$placeholder] = $match[1] . ':' . trim((string) $match[2]);
 
                 return $placeholder;
             }

--- a/e107_handlers/vendor/matthiasmullie/minify/src/JS.php
+++ b/e107_handlers/vendor/matthiasmullie/minify/src/JS.php
@@ -336,7 +336,7 @@ class JS extends Minify
                 '/\s+(' . implode('|', $operatorsAfter) . ')/',
             ),
             '\\1',
-            $content
+            (string) $content
         );
 
         // make sure + and - can't be mistaken for, or joined into ++ and --
@@ -346,12 +346,12 @@ class JS extends Minify
                 '/(?<![\+\-])([\+\-])\s*(?![\+\-])/',
             ),
             '\\1',
-            $content
+            (string) $content
         );
 
         // collapse whitespace around reserved words into single space
-        $content = preg_replace('/(^|[;\}\s])\K(' . implode('|', $keywordsBefore) . ')\s+/', '\\2 ', $content);
-        $content = preg_replace('/\s+(' . implode('|', $keywordsAfter) . ')(?=([;\{\s]|$))/', ' \\1', $content);
+        $content = preg_replace('/(^|[;\}\s])\K(' . implode('|', $keywordsBefore) . ')\s+/', '\\2 ', (string) $content);
+        $content = preg_replace('/\s+(' . implode('|', $keywordsAfter) . ')(?=([;\{\s]|$))/', ' \\1', (string) $content);
 
         /*
          * We didn't strip whitespace after a couple of operators because they
@@ -361,8 +361,8 @@ class JS extends Minify
          */
         $operatorsDiffBefore = array_diff($operators, $operatorsBefore);
         $operatorsDiffAfter = array_diff($operators, $operatorsAfter);
-        $content = preg_replace('/(' . implode('|', $operatorsDiffBefore) . ')[^\S\n]+/', '\\1', $content);
-        $content = preg_replace('/[^\S\n]+(' . implode('|', $operatorsDiffAfter) . ')/', '\\1', $content);
+        $content = preg_replace('/(' . implode('|', $operatorsDiffBefore) . ')[^\S\n]+/', '\\1', (string) $content);
+        $content = preg_replace('/[^\S\n]+(' . implode('|', $operatorsDiffAfter) . ')/', '\\1', (string) $content);
 
         /*
          * Whitespace after `return` can be omitted in a few occasions
@@ -370,9 +370,9 @@ class JS extends Minify
          * Same for whitespace in between `)` and `{`, or between `{` and some
          * keywords.
          */
-        $content = preg_replace('/\breturn\s+(["\'\/\+\-])/', 'return$1', $content);
-        $content = preg_replace('/\)\s+\{/', '){', $content);
-        $content = preg_replace('/}\n(else|catch|finally)\b/', '}$1', $content);
+        $content = preg_replace('/\breturn\s+(["\'\/\+\-])/', 'return$1', (string) $content);
+        $content = preg_replace('/\)\s+\{/', '){', (string) $content);
+        $content = preg_replace('/}\n(else|catch|finally)\b/', '}$1', (string) $content);
 
         /*
          * Get rid of double semicolons, except where they can be used like:
@@ -381,9 +381,9 @@ class JS extends Minify
          * temporarily replacing them with an invalid condition: they won't have
          * a double semicolon and will be easy to spot to restore afterwards.
          */
-        $content = preg_replace('/\bfor\(([^;]*);;([^;]*)\)/', 'for(\\1;-;\\2)', $content);
-        $content = preg_replace('/;+/', ';', $content);
-        $content = preg_replace('/\bfor\(([^;]*);-;([^;]*)\)/', 'for(\\1;;\\2)', $content);
+        $content = preg_replace('/\bfor\(([^;]*);;([^;]*)\)/', 'for(\\1;-;\\2)', (string) $content);
+        $content = preg_replace('/;+/', ';', (string) $content);
+        $content = preg_replace('/\bfor\(([^;]*);-;([^;]*)\)/', 'for(\\1;;\\2)', (string) $content);
 
         /*
          * Next, we'll be removing all semicolons where ASI kicks in.
@@ -403,16 +403,16 @@ class JS extends Minify
          * of the three parts for a specific for() case.
          * REGEX throwing catastrophic backtracking: $content = preg_replace('/(for\([^;\{]*(\{([^\{\}]*(?-2))*[^\{\}]*\})?[^;\{]*;[^;\{]*(\{([^\{\}]*(?-2))*[^\{\}]*\})?[^;\{]*;[^;\{]*(\{([^\{\}]*(?-2))*[^\{\}]*\})?[^;\{]*\));(\}|$)/s', '\\1;;\\8', $content);
          */
-        $content = preg_replace('/(for\((?:[^;\{]*|[^;\{]*function[^;\{]*(\{([^\{\}]*(?-2))*[^\{\}]*\})?[^;\{]*);[^;\{]*;[^;\{]*\));(\}|$)/s', '\\1;;\\4', $content);
-        $content = preg_replace('/(for\([^;\{]*;(?:[^;\{]*|[^;\{]*function[^;\{]*(\{([^\{\}]*(?-2))*[^\{\}]*\})?[^;\{]*);[^;\{]*\));(\}|$)/s', '\\1;;\\4', $content);
-        $content = preg_replace('/(for\([^;\{]*;[^;\{]*;(?:[^;\{]*|[^;\{]*function[^;\{]*(\{([^\{\}]*(?-2))*[^\{\}]*\})?[^;\{]*)\));(\}|$)/s', '\\1;;\\4', $content);
+        $content = preg_replace('/(for\((?:[^;\{]*|[^;\{]*function[^;\{]*(\{([^\{\}]*(?-2))*[^\{\}]*\})?[^;\{]*);[^;\{]*;[^;\{]*\));(\}|$)/s', '\\1;;\\4', (string) $content);
+        $content = preg_replace('/(for\([^;\{]*;(?:[^;\{]*|[^;\{]*function[^;\{]*(\{([^\{\}]*(?-2))*[^\{\}]*\})?[^;\{]*);[^;\{]*\));(\}|$)/s', '\\1;;\\4', (string) $content);
+        $content = preg_replace('/(for\([^;\{]*;[^;\{]*;(?:[^;\{]*|[^;\{]*function[^;\{]*(\{([^\{\}]*(?-2))*[^\{\}]*\})?[^;\{]*)\));(\}|$)/s', '\\1;;\\4', (string) $content);
 
-        $content = preg_replace('/(for\([^;\{]+\s+in\s+[^;\{]+\));(\}|$)/s', '\\1;;\\2', $content);
+        $content = preg_replace('/(for\([^;\{]+\s+in\s+[^;\{]+\));(\}|$)/s', '\\1;;\\2', (string) $content);
 
         /*
          * Do the same for the if's that don't have a body but are followed by ;}
          */
-        $content = preg_replace('/(\bif\s*\([^{;]*\));\}/s', '\\1;;}', $content);
+        $content = preg_replace('/(\bif\s*\([^{;]*\));\}/s', '\\1;;}', (string) $content);
 
         /*
          * Below will also keep `;` after a `do{}while();` along with `while();`
@@ -420,7 +420,7 @@ class JS extends Minify
          * distinction is cumbersome, so I'll play it safe and make sure `;`
          * after any kind of `while` is kept.
          */
-        $content = preg_replace('/(while\([^;\{]+\));(\}|$)/s', '\\1;;\\2', $content);
+        $content = preg_replace('/(while\([^;\{]+\));(\}|$)/s', '\\1;;\\2', (string) $content);
 
         /*
          * We also can't strip empty else-statements. Even though they're
@@ -430,7 +430,7 @@ class JS extends Minify
          *
          * @see https://github.com/matthiasmullie/minify/issues/91
          */
-        $content = preg_replace('/else;/s', '', $content);
+        $content = preg_replace('/else;/s', '', (string) $content);
 
         /*
          * We also don't really want to terminate statements followed by closing
@@ -438,8 +438,8 @@ class JS extends Minify
          * script: ASI will kick in here & we're all about minifying.
          * Semicolons at beginning of the file don't make any sense either.
          */
-        $content = preg_replace('/;(\}|$)/s', '\\1', $content);
-        $content = ltrim($content, ';');
+        $content = preg_replace('/;(\}|$)/s', '\\1', (string) $content);
+        $content = ltrim((string) $content, ';');
 
         // get rid of remaining whitespace af beginning/end
         return trim($content);
@@ -577,7 +577,7 @@ class JS extends Minify
          * character and check if it's a `.`
          */
         $callback = function ($match) {
-            if (trim($match[1]) === '.') {
+            if (trim((string) $match[1]) === '.') {
                 return $match[0];
             }
 
@@ -586,10 +586,10 @@ class JS extends Minify
         $content = preg_replace_callback('/(^|.\s*)\b(true|false)\b(?!:)/', $callback, $content);
 
         // for(;;) is exactly the same as while(true), but shorter :)
-        $content = preg_replace('/\bwhile\(!0\){/', 'for(;;){', $content);
+        $content = preg_replace('/\bwhile\(!0\){/', 'for(;;){', (string) $content);
 
         // now make sure we didn't turn any do ... while(true) into do ... for(;;)
-        preg_match_all('/\bdo\b/', $content, $dos, PREG_OFFSET_CAPTURE | PREG_SET_ORDER);
+        preg_match_all('/\bdo\b/', (string) $content, $dos, PREG_OFFSET_CAPTURE | PREG_SET_ORDER);
 
         // go backward to make sure positional offsets aren't altered when $content changes
         $dos = array_reverse($dos);
@@ -598,12 +598,12 @@ class JS extends Minify
 
             // find all `while` (now `for`) following `do`: one of those must be
             // associated with the `do` and be turned back into `while`
-            preg_match_all('/\bfor\(;;\)/', $content, $whiles, PREG_OFFSET_CAPTURE | PREG_SET_ORDER, $offsetDo);
+            preg_match_all('/\bfor\(;;\)/', (string) $content, $whiles, PREG_OFFSET_CAPTURE | PREG_SET_ORDER, $offsetDo);
             foreach ($whiles as $while) {
                 $offsetWhile = $while[0][1];
 
-                $open = substr_count($content, '{', $offsetDo, $offsetWhile - $offsetDo);
-                $close = substr_count($content, '}', $offsetDo, $offsetWhile - $offsetDo);
+                $open = substr_count((string) $content, '{', $offsetDo, $offsetWhile - $offsetDo);
+                $close = substr_count((string) $content, '}', $offsetDo, $offsetWhile - $offsetDo);
                 if ($open === $close) {
                     // only restore `while` if amount of `{` and `}` are the same;
                     // otherwise, that `for` isn't associated with this `do`

--- a/e107_handlers/vendor/matthiasmullie/minify/src/Minify.php
+++ b/e107_handlers/vendor/matthiasmullie/minify/src/Minify.php
@@ -550,9 +550,9 @@ abstract class Minify
 
     protected static function str_replace_first($search, $replace, $subject)
     {
-        $pos = strpos($subject, $search);
+        $pos = strpos((string) $subject, (string) $search);
         if ($pos !== false) {
-            return substr_replace($subject, $replace, $pos, strlen($search));
+            return substr_replace($subject, $replace, $pos, strlen((string) $search));
         }
 
         return $subject;

--- a/e107_handlers/vendor/matthiasmullie/path-converter/src/Converter.php
+++ b/e107_handlers/vendor/matthiasmullie/path-converter/src/Converter.php
@@ -86,7 +86,7 @@ class Converter implements ConverterInterface
          *     /home/forkcms/frontend/core/layout/images/img.gif
          */
         do {
-            $path = preg_replace('/[^\/]+(?<!\.\.)\/\.\.\//', '', $path, -1, $count);
+            $path = preg_replace('/[^\/]+(?<!\.\.)\/\.\.\//', '', (string) $path, -1, $count);
         } while ($count);
 
         return $path;

--- a/e107_handlers/vendor/phpmailer/phpmailer/get_oauth_token.php
+++ b/e107_handlers/vendor/phpmailer/phpmailer/get_oauth_token.php
@@ -178,5 +178,5 @@ if (!isset($_GET['code'])) {
     );
     //Use this to interact with an API on the users behalf
     //Use this to get a new access token if the old one expires
-    echo 'Refresh Token: ', htmlspecialchars($token->getRefreshToken());
+    echo 'Refresh Token: ', htmlspecialchars((string) $token->getRefreshToken());
 }

--- a/e107_handlers/vendor/phpmailer/phpmailer/src/PHPMailer.php
+++ b/e107_handlers/vendor/phpmailer/phpmailer/src/PHPMailer.php
@@ -933,7 +933,7 @@ class PHPMailer
             case 'html':
                 //Cleans up output a bit for a better looking, HTML-safe output
                 echo htmlentities(
-                    preg_replace('/[\r\n]+/', '', $str),
+                    (string) preg_replace('/[\r\n]+/', '', $str),
                     ENT_QUOTES,
                     'UTF-8'
                 ), "<br>\n";
@@ -950,7 +950,7 @@ class PHPMailer
                     str_replace(
                         "\n",
                         "\n                   \t                  ",
-                        trim($str)
+                        trim((string) $str)
                     )
                 ),
                 "\n";
@@ -1115,7 +1115,7 @@ class PHPMailer
             return false;
         }
         if ($name !== null && is_string($name)) {
-            $name = trim(preg_replace('/[\r\n]+/', '', $name)); //Strip breaks and trim
+            $name = trim((string) preg_replace('/[\r\n]+/', '', $name)); //Strip breaks and trim
         } else {
             $name = '';
         }
@@ -1261,7 +1261,7 @@ class PHPMailer
                         property_exists($address, 'personal') &&
                         //Check for a Mbstring constant rather than using extension_loaded, which is sometimes disabled
                         defined('MB_CASE_UPPER') &&
-                        preg_match('/^=\?.*\?=$/s', $address->personal)
+                        preg_match('/^=\?.*\?=$/s', (string) $address->personal)
                     ) {
                         $origCharset = mb_internal_encoding();
                         mb_internal_encoding($charset);
@@ -1335,7 +1335,7 @@ class PHPMailer
     public function setFrom($address, $name = '', $auto = true)
     {
         $address = trim((string)$address);
-        $name = trim(preg_replace('/[\r\n]+/', '', $name)); //Strip breaks and trim
+        $name = trim((string) preg_replace('/[\r\n]+/', '', $name)); //Strip breaks and trim
         //Don't validate now addresses with IDN. Will be done in send().
         $pos = strrpos($address, '@');
         if (
@@ -2810,8 +2810,8 @@ class PHPMailer
         //Add custom headers
         foreach ($this->CustomHeader as $header) {
             $result .= $this->headerLine(
-                trim($header[0]),
-                $this->encodeHeader(trim($header[1]))
+                trim((string) $header[0]),
+                $this->encodeHeader(trim((string) $header[1]))
             );
         }
         if (!$this->sign_key_file) {
@@ -3622,7 +3622,7 @@ class PHPMailer
         }
 
         //Q/B encoding adds 8 chars and the charset ("` =?<charset>?[QB]?<content>?=`").
-        $overhead = 8 + strlen($charset);
+        $overhead = 8 + strlen((string) $charset);
 
         if ('mail' === $this->Mailer) {
             $maxlen = static::MAIL_MAX_LINE_LENGTH - $overhead;
@@ -4104,7 +4104,7 @@ class PHPMailer
     public function clearAddresses()
     {
         foreach ($this->to as $to) {
-            unset($this->all_recipients[strtolower($to[0])]);
+            unset($this->all_recipients[strtolower((string) $to[0])]);
         }
         $this->to = [];
         $this->clearQueuedAddresses('to');
@@ -4116,7 +4116,7 @@ class PHPMailer
     public function clearCCs()
     {
         foreach ($this->cc as $cc) {
-            unset($this->all_recipients[strtolower($cc[0])]);
+            unset($this->all_recipients[strtolower((string) $cc[0])]);
         }
         $this->cc = [];
         $this->clearQueuedAddresses('cc');
@@ -4128,7 +4128,7 @@ class PHPMailer
     public function clearBCCs()
     {
         foreach ($this->bcc as $bcc) {
-            unset($this->all_recipients[strtolower($bcc[0])]);
+            unset($this->all_recipients[strtolower((string) $bcc[0])]);
         }
         $this->bcc = [];
         $this->clearQueuedAddresses('bcc');
@@ -4578,7 +4578,7 @@ class PHPMailer
                         $message = preg_replace(
                             '/' . $images[1][$imgindex] . '=["\']' . preg_quote($url, '/') . '["\']/Ui',
                             $images[1][$imgindex] . '="cid:' . $cid . '"',
-                            $message
+                            (string) $message
                         );
                     }
                 }
@@ -4627,7 +4627,7 @@ class PHPMailer
         }
 
         return html_entity_decode(
-            trim(strip_tags(preg_replace('/<(head|title|style|script)[^>]*>.*?<\/\\1>/si', '', $html))),
+            trim(strip_tags((string) preg_replace('/<(head|title|style|script)[^>]*>.*?<\/\\1>/si', '', $html))),
             ENT_QUOTES,
             $this->CharSet
         );
@@ -5010,7 +5010,7 @@ class PHPMailer
                 openssl_pkey_free($privKey);
             }
 
-            return base64_encode($signature);
+            return base64_encode((string) $signature);
         }
         if (\PHP_MAJOR_VERSION < 8) {
             openssl_pkey_free($privKey);
@@ -5040,7 +5040,7 @@ class PHPMailer
         //That means this may break if you do something daft like put vertical tabs in your headers.
         $signHeader = preg_replace('/\r\n[ \t]+/', ' ', $signHeader);
         //Break headers out into an array
-        $lines = explode(self::CRLF, $signHeader);
+        $lines = explode(self::CRLF, (string) $signHeader);
         foreach ($lines as $key => $line) {
             //If the header is missing a :, skip it as it's invalid
             //This is likely to happen because the explode() above will also split
@@ -5057,7 +5057,7 @@ class PHPMailer
             //But then says to delete space before and after the colon.
             //Net result is the same as trimming both ends of the value.
             //By elimination, the same applies to the field name
-            $lines[$key] = trim($heading, " \t") . ':' . trim($value, " \t");
+            $lines[$key] = trim($heading, " \t") . ':' . trim((string) $value, " \t");
         }
 
         return implode(self::CRLF, $lines);

--- a/e107_handlers/vendor/phpmailer/phpmailer/src/SMTP.php
+++ b/e107_handlers/vendor/phpmailer/phpmailer/src/SMTP.php
@@ -309,7 +309,7 @@ class SMTP
             case 'html':
                 //Cleans up output a bit for a better looking, HTML-safe output
                 echo gmdate('Y-m-d H:i:s'), ' ', htmlentities(
-                    preg_replace('/[\r\n]+/', '', $str),
+                    (string) preg_replace('/[\r\n]+/', '', $str),
                     ENT_QUOTES,
                     'UTF-8'
                 ), "<br>\n";
@@ -326,7 +326,7 @@ class SMTP
                     str_replace(
                         "\n",
                         "\n                   \t                  ",
-                        trim($str)
+                        trim((string) $str)
                     )
                 ),
                 "\n";
@@ -843,7 +843,7 @@ class SMTP
         }
 
         //Some servers shut down the SMTP service here (RFC 5321)
-        if (substr($this->helo_rply, 0, 3) == '421') {
+        if (substr((string) $this->helo_rply, 0, 3) == '421') {
             return false;
         }
 
@@ -883,7 +883,7 @@ class SMTP
     protected function parseHelloFields($type)
     {
         $this->server_caps = [];
-        $lines = explode("\n", $this->helo_rply);
+        $lines = explode("\n", (string) $this->helo_rply);
 
         foreach ($lines as $n => $s) {
             //First 4 chars contain response code followed by - or space
@@ -1309,7 +1309,7 @@ class SMTP
 
                 //stream_select returns false when the `select` system call is interrupted
                 //by an incoming signal, try the select again
-                if (stripos($message, 'interrupted system call') !== false) {
+                if (stripos((string) $message, 'interrupted system call') !== false) {
                     $this->edebug(
                         'SMTP -> get_lines(): retrying stream_select',
                         self::DEBUG_LOWLEVEL

--- a/e107_handlers/vendor/ralouphie/getallheaders/src/getallheaders.php
+++ b/e107_handlers/vendor/ralouphie/getallheaders/src/getallheaders.php
@@ -18,8 +18,8 @@ if (!function_exists('getallheaders')) {
         );
 
         foreach ($_SERVER as $key => $value) {
-            if (substr($key, 0, 5) === 'HTTP_') {
-                $key = substr($key, 5);
+            if (substr((string) $key, 0, 5) === 'HTTP_') {
+                $key = substr((string) $key, 5);
                 if (!isset($copy_server[$key]) || !isset($_SERVER[$key])) {
                     $key = str_replace(' ', '-', ucwords(strtolower(str_replace('_', ' ', $key))));
                     $headers[$key] = $value;

--- a/e107_handlers/xml_class.php
+++ b/e107_handlers/xml_class.php
@@ -134,7 +134,7 @@ class parseXml extends xmlClass // BC with v1.x
 	function startElement ($p, $element, &$attrs)
 	{
 		$this -> start_tag = $element;
-		$this -> current_tag = strtolower($element);
+		$this -> current_tag = strtolower((string) $element);
 		if(!array_key_exists($this -> current_tag, $this -> counterArray))
 		{
 			$this -> counterArray[$this -> current_tag] = 0;
@@ -162,7 +162,7 @@ class parseXml extends xmlClass // BC with v1.x
 	 */
 	function characterData ($p, $data)
 	{
-		$data = trim ( rtrim ( $data ));
+		$data = trim ( rtrim ( (string) $data ));
 		$data = preg_replace('/&(?!amp;)/', '&amp;', $data);
 		if(!array_key_exists($this -> current_tag, $this -> xmlData))
 		{
@@ -389,7 +389,7 @@ class xmlClass
 	 */
 	public function setOptStringTags($string)
 	{
-		$this->stringTags = (array) explode(",", $string); 
+		$this->stringTags = (array) explode(",", (string) $string); 
 		return $this;
 	}
 
@@ -772,9 +772,9 @@ class xmlClass
 			
 		foreach($this->arrayTags as $p)
 		{
-			if(strpos($p,"/")!==false)
+			if(strpos((string) $p,"/")!==false)
 			{
-				list($vl,$sub) = explode("/",$p);	
+				list($vl,$sub) = explode("/",(string) $p);	
 			}
 			else
 			{
@@ -848,7 +848,7 @@ class xmlClass
 		
 		$xml = false;
 		
-		if (strpos($fname, '://') !== false)
+		if (strpos((string) $fname, '://') !== false)
 		{
 			$this->getRemoteFile($fname);
 			$this->_feedUrl = false; // clear it to avoid conflicts. 
@@ -926,10 +926,10 @@ class xmlClass
 		if($this->convertFilePaths)
 		{
 			$types = implode("|",$this->convertFileTypes);
-			$val = preg_replace_callback("#({e_.*?\.(".$types."))#i", array($this,'replaceFilePaths'), $val);
+			$val = preg_replace_callback("#({e_.*?\.(".$types."))#i", array($this,'replaceFilePaths'), (string) $val);
 		}
 
-		if((strpos($val,"<")!==FALSE) || (strpos($val,">")!==FALSE) || (strpos($val,"&")!==FALSE))
+		if((strpos((string) $val,"<")!==FALSE) || (strpos((string) $val,">")!==FALSE) || (strpos((string) $val,"&")!==FALSE))
 		{
 			return "<![CDATA[". $val."]]>";
 		}
@@ -978,7 +978,7 @@ class xmlClass
 				ksort($theprefs);
 				foreach($theprefs as $key=>$val)
 				{
-					if($type === 'core' && $this->modifiedPrefsOnly == true && (($val == $default[$key]) || in_array($key,$excludes) || strpos($key, 'e_') === 0))
+					if($type === 'core' && $this->modifiedPrefsOnly == true && (($val == $default[$key]) || in_array($key,$excludes) || strpos((string) $key, 'e_') === 0))
 					{
 						continue;
 					}
@@ -1074,7 +1074,7 @@ class xmlClass
 				while($row = e107::getDb()->fetch())
 				{
 
-					if($this->convertFilePaths == true && $eTable === 'core_media' && strpos($row['media_url'], '{e_MEDIA') !== 0)
+					if($this->convertFilePaths == true && $eTable === 'core_media' && strpos((string) $row['media_url'], '{e_MEDIA') !== 0)
 					{
 						continue;
 					}
@@ -1189,7 +1189,7 @@ class xmlClass
 				// var_dump(e107::getArrayStorage()->ReadArray($val['@value']));
 				// echo $val['@value'].'</pre>';
 			// }
-			$value = strpos($val['@value'], 'array (') === 0 ? e107::unserialize($val['@value']) : $val['@value'];
+			$value = strpos((string) $val['@value'], 'array (') === 0 ? e107::unserialize($val['@value']) : $val['@value'];
 			$pref[$name] = $value;
 
 			// $mes->add("Setting up ".$prefType." Pref [".$name."] => ".$value, E_MESSAGE_DEBUG);
@@ -1396,7 +1396,7 @@ class xmlClass
 	function getErrors($xml)
 	{
 		libxml_use_internal_errors(true);
-		$sxe = simplexml_load_string($xml);
+		$sxe = simplexml_load_string((string) $xml);
 		$errors = array();
 		if (!$sxe)
 		{
@@ -1570,7 +1570,7 @@ class XMLParse
         $parser = $this->parser;
         xml_parser_set_option($parser, XML_OPTION_CASE_FOLDING, 0);
         xml_parser_set_option($parser, XML_OPTION_SKIP_WHITE, 1);
-        if (!$res = (bool)xml_parse_into_struct($parser, $this->rawXML, $this->valueArray, $this->keyArray))
+        if (!$res = (bool)xml_parse_into_struct($parser, (string) $this->rawXML, $this->valueArray, $this->keyArray))
         {
             $this->isError = true;
             $this->error = 'error: '.xml_error_string(xml_get_error_code($parser)).' at line '.xml_get_current_line_number($parser);

--- a/e107_images/secimg.php
+++ b/e107_images/secimg.php
@@ -57,7 +57,7 @@ if(!isset($_GET['id']))
 
 $code = (int) $_GET['id'];
 
-if(!empty($_GET['clr']) && preg_match('/^[a-f0-9]{6}$/i', $_GET['clr'])) //hex color is valid
+if(!empty($_GET['clr']) && preg_match('/^[a-f0-9]{6}$/i', (string) $_GET['clr'])) //hex color is valid
 {
 	$color = $_GET['clr'];
 } 

--- a/e107_plugins/_blank/admin_config.php
+++ b/e107_plugins/_blank/admin_config.php
@@ -131,7 +131,7 @@ class plugin_blank_admin_ui extends e_admin_ui
 		protected $perPage = 20;
 
 		protected $batchDelete = true;
-		
+
 
 	//	protected \$sortField		= 'somefield_order';
 
@@ -311,8 +311,8 @@ class plugin_blank_admin_ui extends e_admin_ui
 			e107::getDebug()->log($pref);
 
 		}
-		
-		
+
+
 		public function custom1Page()
 		{
 			return "Hello World Customer Page 1!";
@@ -323,7 +323,7 @@ class plugin_blank_admin_ui extends e_admin_ui
 		{
 			return "Hello World Customer Page 2!";
 		}
-	
+
 		// left-panel help menu area. (replaces e_help.php used in old plugins)	
 		public function renderHelp()
 		{
@@ -342,13 +342,13 @@ class plugin_blank_admin_ui extends e_admin_ui
 
 class plugin_blank_admin_form_ui extends e_admin_form_ui
 {
-	
+
 	function blank_type($curVal,$mode) // not really necessary since we can use 'dropdown' - but just an example of a custom function.
 	{
 		$frm = e107::getForm();
-		
+
 		$types = array('type_1'=>"Type 1", 'type_2' => 'Type 2');
-		
+
 		if($mode == 'read')
 		{
 			return vartrue($types[$curVal]).' (custom!)';
@@ -366,7 +366,7 @@ class plugin_blank_admin_form_ui extends e_admin_form_ui
 
 		return $frm->select('blank_type', $types, $curVal);
 	}
-	
+
 }
 
 

--- a/e107_plugins/_blank/e_frontpage.php
+++ b/e107_plugins/_blank/e_frontpage.php
@@ -23,7 +23,7 @@ class _blank_frontpage // include plugin-folder in the name.
 	}
 
 
-	
+
 	// multiple
 	/*function config()
 	{

--- a/e107_plugins/_blank/e_related.php
+++ b/e107_plugins/_blank/e_related.php
@@ -23,11 +23,11 @@ class _blank_related // include plugin-folder in the name.
 	{
 		$sql = e107::getDb();
 		$items = array();
-			
+
 		$tag_regexp = "'(^|,)(".str_replace(",", "|", $tags).")(,|$)'";
-		
+
 		$query = "SELECT * FROM `#_blank` WHERE _blank_id != ".$parm['current']." AND _blank_keywords REGEXP ".$tag_regexp."  ORDER BY _blank_datestamp DESC LIMIT ".$parm['limit'];
-			
+
 		if($sql->gen($query))
 		{		
 			while($row = $sql->fetch())
@@ -40,7 +40,7 @@ class _blank_related // include plugin-folder in the name.
 					'image'			=> '{e_PLUGIN}_blank/images/image.png'
 				);
 			}
-			
+
 			return $items;
 	    }
 	//	elseif(ADMIN)

--- a/e107_plugins/_blank/e_search.php
+++ b/e107_plugins/_blank/e_search.php
@@ -47,7 +47,7 @@ class _blank_search extends e_search // include plugin-folder in the name.
 	{
 		$tp = e107::getParser();
 
-		preg_match("/([0-9]+)\.(.*)/", $row['blank_nick'], $user);
+		preg_match("/([0-9]+)\.(.*)/", (string) $row['blank_nick'], $user);
 
 		$res = array();
 	

--- a/e107_plugins/alt_auth/alt_auth_adminmenu.php
+++ b/e107_plugins/alt_auth/alt_auth_adminmenu.php
@@ -227,7 +227,7 @@ class alt_auth_admin extends alt_auth_base
 		if ($fieldsAdded) return;
 		$xFields = $this->euf->user_extended_get_fieldList('','user_extended_struct_name');
 	//	print_a($xFields);
-		$fields = explode(',',$pref['auth_extended']);
+		$fields = explode(',',(string) $pref['auth_extended']);
 		foreach ($fields as $f)
 		{
 			if (isset($xFields[$f]))
@@ -327,9 +327,9 @@ class alt_auth_admin extends alt_auth_base
 		// Now we can post everything
 		foreach($_POST as $k => $v)
 		{
-			if (strpos($k,$lprefix) === 0)
+			if (strpos((string) $k,$lprefix) === 0)
 			{
-				$v = base64_encode(base64_encode($v));
+				$v = base64_encode(base64_encode((string) $v));
 				if($sql -> select('alt_auth', '*', "auth_type='{$prefix}' AND auth_parmname='{$k}' "))
 				{
 					$sql -> update('alt_auth', "auth_parmval='{$v}' WHERE  auth_type='{$prefix}' AND auth_parmname='{$k}' ");
@@ -392,7 +392,7 @@ class alt_auth_admin extends alt_auth_base
 			$_login = new auth_login;
 			$log_result = defset('AUTH_UNKNOWN');
 			$pass_vars = array();
-			$val_name = trim(varset($_POST['nametovalidate']));
+			$val_name = trim((string) varset($_POST['nametovalidate']));
 
 			if(isset($_login->Available) && ($_login->Available === FALSE))
 			{	// Relevant auth method not available (e.g. PHP extension not loaded)
@@ -414,7 +414,7 @@ class alt_auth_admin extends alt_auth_base
 			if ($val_name)
 			{
 				$text .= LAN_ALT_49.": ".$val_name.'<br />'.LAN_ALT_50.": ";
-				if (varset($_POST['passtovalidate'])) $text .= str_repeat('*',strlen($_POST['passtovalidate'])); else $text .= LAN_ALT_51;
+				if (varset($_POST['passtovalidate'])) $text .= str_repeat('*',strlen((string) $_POST['passtovalidate'])); else $text .= LAN_ALT_51;
 			}
 			$text .= "</td><td>";
 

--- a/e107_plugins/alt_auth/alt_auth_conf.php
+++ b/e107_plugins/alt_auth/alt_auth_conf.php
@@ -67,7 +67,7 @@ if(isset($_POST['updateeufs']))
 	$authExtended = array();
 	foreach ($_POST['auth_euf_include'] as $au)
 	{
-		$authExtended[] = trim($tp->toDB($au));
+		$authExtended[] = trim((string) $tp->toDB($au));
 	}
 	$au = implode(',',$authExtended);
 	if ($au != $pref['auth_extended'])
@@ -108,7 +108,7 @@ if (isset($pref['auth_nouser']))
 $authlist = alt_auth_admin::alt_auth_get_authlist();
 if (isset($pref['auth_extended']))
 {
-	$authExtended = explode(',',$pref['auth_extended']);
+	$authExtended = explode(',',(string) $pref['auth_extended']);
 }
 else
 {

--- a/e107_plugins/alt_auth/alt_auth_login_class.php
+++ b/e107_plugins/alt_auth/alt_auth_login_class.php
@@ -71,7 +71,7 @@ class alt_auth_base
 		$parm = array();
 		while($row = $sql->fetch())
 		{
-			$parm[$row['auth_parmname']] = base64_decode(base64_decode($row['auth_parmval']));
+			$parm[$row['auth_parmname']] = base64_decode(base64_decode((string) $row['auth_parmval']));
 		}
 		return $parm;
 	}
@@ -114,7 +114,7 @@ class alt_login
 			{
 				$username = e107::getParser()->toDB($username);
 			}
-			$username = preg_replace("/\sOR\s|\=|\#/", "", $username);
+			$username = preg_replace("/\sOR\s|\=|\#/", "", (string) $username);
 			$username = substr($username, 0, e107::getPref('loginname_maxlength'));
 
 			$aa_sql = e107::getDb('aa');
@@ -296,9 +296,9 @@ class alt_login
 			case 'lcase' :
 				return $tp->ustrtolower($word);
 			case 'ucfirst' :
-				return ucfirst($word);						// TODO: Needs changing to utf-8 function
+				return ucfirst((string) $word);						// TODO: Needs changing to utf-8 function
 			case 'ucwords' :
-				return ucwords($word);						// TODO: Needs changing to utf-8 function
+				return ucwords((string) $word);						// TODO: Needs changing to utf-8 function
 			case 'none' :
 				return $word;
 		}

--- a/e107_plugins/alt_auth/e107db_auth.php
+++ b/e107_plugins/alt_auth/e107db_auth.php
@@ -116,9 +116,9 @@ class auth_login extends alt_auth_base
 		// Make an array of the fields we want from the source DB
 		foreach($this->conf as $k => $v)
 		{
-			if ($v && (strpos($k,'e107db_xf_') === 0))
+			if ($v && (strpos((string) $k,'e107db_xf_') === 0))
 			{
-				$sel_fields[] = substr($k,strlen('e107db_xf_'));
+				$sel_fields[] = substr((string) $k,strlen('e107db_xf_'));
 			}
 		}
 
@@ -172,7 +172,7 @@ class auth_login extends alt_auth_base
 		// Valid user - check he's in an appropriate class
 		if ($filterClass != e_UC_PUBLIC)
 		{
-			$tmp = explode(',', $row['user_class']);
+			$tmp = explode(',', (string) $row['user_class']);
 			if (!in_array($filterClass, $tmp))
 			{
 				$this->makeErrorText('Userc not found');
@@ -184,9 +184,9 @@ class auth_login extends alt_auth_base
 		// Now copy across any values we have selected
 		foreach($this->conf as $k => $v)
 		{
-			if ($v && (strpos($k,'e107db_xf_') === 0))
+			if ($v && (strpos((string) $k,'e107db_xf_') === 0))
 			{
-				$f = substr($k,strlen('e107db_xf_'));
+				$f = substr((string) $k,strlen('e107db_xf_'));
 				if (isset($row[$f])) $newvals[$f] = $row[$f];
 			}
 		}

--- a/e107_plugins/alt_auth/extended_password_handler.php
+++ b/e107_plugins/alt_auth/extended_password_handler.php
@@ -118,7 +118,7 @@ class ExtendedPasswordHandler extends UserHandler
 	 */
 	private function encode64($input, $count)
 	{
-		return base64_encode(substr($input, 0, $count));	// @todo - check this works OK
+		return base64_encode(substr((string) $input, 0, $count));	// @todo - check this works OK
 		/*
 		$output = '';
 		$i = 0;
@@ -149,7 +149,7 @@ class ExtendedPasswordHandler extends UserHandler
 	private function crypt_private($password, $stored_password, $password_type = self::PASSWORD_PHPBB_SALT)
 	{
 		$output = '*0';
-		if (substr($stored_password, 0, 2) == $output)
+		if (substr((string) $stored_password, 0, 2) == $output)
 		{
 			$output = '*1';
 		}
@@ -167,12 +167,12 @@ class ExtendedPasswordHandler extends UserHandler
 				$prefix = '';
 		}
 
-		if ($prefix != substr($stored_password, 0, 3))
+		if ($prefix != substr((string) $stored_password, 0, 3))
 		{
 			return $output;
 		}
 
-		$count_log2 = strpos($this->itoa64, $stored_password[3]);			// 4th character indicates hash depth count
+		$count_log2 = strpos((string) $this->itoa64, (string) $stored_password[3]);			// 4th character indicates hash depth count
 		if ($count_log2 < 7 || $count_log2 > 30)
 		{
 			return $output;
@@ -180,7 +180,7 @@ class ExtendedPasswordHandler extends UserHandler
 
 		$count = 1 << $count_log2;
 
-		$salt = substr($stored_password, 4, 8);						// Salt is characters 5..12
+		$salt = substr((string) $stored_password, 4, 8);						// Salt is characters 5..12
 		if (strlen($salt) != 8)
 		{
 			return $output;

--- a/e107_plugins/alt_auth/ldap_auth.php
+++ b/e107_plugins/alt_auth/ldap_auth.php
@@ -53,16 +53,16 @@ class auth_login extends alt_auth_base
 
 		foreach ($ldap as $row)
 		{
-			if ((strpos($row['auth_parmname'], 'ldap_xf_') === 0) && $ldap[$row['auth_parmname']]) // Attribute to copy on successful login
+			if ((strpos((string) $row['auth_parmname'], 'ldap_xf_') === 0) && $ldap[$row['auth_parmname']]) // Attribute to copy on successful login
 			{
-				$this->copyAttribs[substr($row['auth_parmname'], strlen('ldap_xf_'))] = $ldap[$row['auth_parmname']]; // Key = LDAP attribute. Value = e107 field name
+				$this->copyAttribs[substr((string) $row['auth_parmname'], strlen('ldap_xf_'))] = $ldap[$row['auth_parmname']]; // Key = LDAP attribute. Value = e107 field name
 			}
-			elseif ((strpos($row['auth_parmname'], 'ldap_pm_') === 0) && $ldap[$row['auth_parmname']] && ($ldap[$row['auth_parmname']] != 'none')) // Method to use to copy parameter
+			elseif ((strpos((string) $row['auth_parmname'], 'ldap_pm_') === 0) && $ldap[$row['auth_parmname']] && ($ldap[$row['auth_parmname']] != 'none')) // Method to use to copy parameter
 			{	// Any fields with non-null 'copy' methods
-				$this->copyMethods[substr($row['auth_parmname'], strlen('ldap_pm_'))] = $ldap[$row['auth_parmname']]; // Key = e107 field name. Value = copy method
+				$this->copyMethods[substr((string) $row['auth_parmname'], strlen('ldap_pm_'))] = $ldap[$row['auth_parmname']]; // Key = e107 field name. Value = copy method
 			}
 		}
-		$this->server = explode(',', $ldap['ldap_server']);
+		$this->server = explode(',', (string) $ldap['ldap_server']);
 		$this->serverType = $ldap['ldap_servertype'];
 		$this->dn = $ldap['ldap_basedn'];
 		$this->ou = $ldap['ldap_ou'];
@@ -232,7 +232,7 @@ class auth_login extends alt_auth_base
 			$ldap_attributes = array_values(array_unique($this->copyAttribs));
 			if ($this->serverType == "ActiveDirectory")
 			{	// If we are using AD then build up the full string from the fqdn
-				$altauth_tmp = explode('.', $this->dn);
+				$altauth_tmp = explode('.', (string) $this->dn);
 				$checkDn='';
 				foreach($altauth_tmp as $$altauth_dc)
 				{

--- a/e107_plugins/alt_auth/otherdb_auth.php
+++ b/e107_plugins/alt_auth/otherdb_auth.php
@@ -116,7 +116,7 @@ class auth_login extends alt_auth_base
 		// Make an array of the fields we want from the source DB
 		foreach($this->conf as $k => $v)
 		{
-			if ($v && (strpos($k,'otherdb_xf_') === 0))
+			if ($v && (strpos((string) $k,'otherdb_xf_') === 0))
 			{
 				$sel_fields[] = $v;
 			}
@@ -191,9 +191,9 @@ class auth_login extends alt_auth_base
 		// Now copy across any values we have selected
 		foreach($this->conf as $k => $v)
 		{
-			if ($v && (strpos($k,'otherdb_xf_') === 0) && isset($row[$v]))
+			if ($v && (strpos((string) $k,'otherdb_xf_') === 0) && isset($row[$v]))
 			{
-				$newvals[substr($k,strlen('otherdb_xf_'))] = $row[$v];
+				$newvals[substr((string) $k,strlen('otherdb_xf_'))] = $row[$v];
 			}
 		}
 

--- a/e107_plugins/alt_auth/radius_auth.php
+++ b/e107_plugins/alt_auth/radius_auth.php
@@ -51,11 +51,11 @@ class auth_login extends alt_auth_base
 		$this->copyAttribs = array();
 		$radius = $this->altAuthGetParams('radius');
 
-		$this->server = explode(',',$radius['radius_server']);
+		$this->server = explode(',',(string) $radius['radius_server']);
 		$this->port = 1812;								// Assume fixed port number for now - 1812 (UDP) is listed for servers, 1645 for authentification. (1646, 1813 for accounting)
 														// (A Microsoft app note says 1812 is the RFC2026-compliant port number. (http://support.microsoft.com/kb/230786)
 //		$this->port = 1645;
-		$this->secret = explode(',',$radius['radius_secret']);
+		$this->secret = explode(',',(string) $radius['radius_secret']);
 		if ((count($this->server) > 1)  && (count($this->secret) == 1))
 		{
 			$this->secret = array();
@@ -241,7 +241,7 @@ class auth_login extends alt_auth_base
 				default :
 					$attribs[$resa['attr']] = radius_cvt_string($resa['data']);		// Default to string type
 			}
-			printf("Got Attr: %d => %d Bytes %s\n", $resa['attr'], strlen($attribs[$resa['attr']]), $attribs[$resa['attr']]);
+			printf("Got Attr: %d => %d Bytes %s\n", $resa['attr'], strlen((string) $attribs[$resa['attr']]), $attribs[$resa['attr']]);
 		}
 
 		return AUTH_SUCCESS;

--- a/e107_plugins/banner/admin_banner.php
+++ b/e107_plugins/banner/admin_banner.php
@@ -55,7 +55,7 @@ class banner_admin extends e_admin_dispatcher
 {
 
 	protected $modes = array(	
-	
+
 		'main'	=> array(
 			'controller' 	=> 'banner_ui',
 			'path' 			=> null,
@@ -65,8 +65,8 @@ class banner_admin extends e_admin_dispatcher
 
 
 	);	
-	
-	
+
+
 	protected $adminMenu = array(
 
 		'main/list'			=> array('caption'=> LAN_MANAGE, 'perm' => 'P'),
@@ -80,7 +80,7 @@ class banner_admin extends e_admin_dispatcher
 	protected $adminMenuAliases = array(
 		'main/edit'	=> 'main/list'				
 	);	
-	
+
 	protected $menuTitle = 'Banners';
 }
 
@@ -90,7 +90,7 @@ class banner_admin extends e_admin_dispatcher
 
 class banner_ui extends e_admin_ui
 {
-			
+
 		protected $pluginTitle		= LAN_PLUGIN_BANNER_NAME;
 		protected $pluginName		= 'banner';
 		protected $table			= 'banner';
@@ -101,11 +101,11 @@ class banner_ui extends e_admin_ui
 	//	protected $sortField		= 'somefield_order';
 	//	protected $orderStep		= 10;
 		protected $tabs				= array(LAN_BASIC, LAN_ADVANCED); // Use 'tab'=>0  OR 'tab'=>1 in the $fields below to enable.
-		
+
 	//	protected $listQry      	= "SELECT * FROM `#tableName` WHERE field != '' "; // Example Custom Query. LEFT JOINS allowed. Should be without any Order or Limit.
-	
+
 		protected $listOrder		= 'banner_id DESC';
-	
+
 		protected $fields 		= array (
 		  'checkboxes'				=>   array ( 'title' => '', 		'type' => null, 'data' => null, 'width' => '5%', 'thclass' => 'center', 'forced' => '1', 'class' => 'center', 'toggle' => 'e-multiselect',  ),
 		  'banner_id' 				=>   array ( 'title' => LAN_ID, 	'type' => null, 'data' => 'int', 'width' => '2%', 'help' => '', 'readParms' => '', 'writeParms' => '', 'class' => 'left', 'thclass' => 'left',  ),
@@ -133,9 +133,9 @@ class banner_ui extends e_admin_ui
 		  'banner_ip' 				=>   array ( 'title' => LAN_IP, 		'type' => 'hidden', 'noedit'=>true, 'data' => 'str', 'width' => 'auto', 'help' => '', 'readParms' => '', 'writeParms' => '', 'class' => 'left', 'thclass' => 'left',  ),
 		  'options' 				=>   array ( 'title' => LAN_OPTIONS, 		'type' => null, 'data' => null, 'width' => '10%', 'thclass' => 'center last', 'class' => 'center last', 'forced' => '1',  ),
 		);
-		
+
 		protected $fieldpref = array('banner_id', 'banner_campaign', 'banner_image', 'banner_clickurl', 'banner_clicks', 'banner_active', 'click_percentage', 'banner_impressions' );
-		
+
 		/*
 		protected $prefs = array(
 			'banner_caption'		=> array('title'=> 'Banner_caption', 'type'=>'text', 'data' => 'string','help'=>'Help Text goes here'),
@@ -143,7 +143,7 @@ class banner_ui extends e_admin_ui
 			'banner_amount'			=> array('title'=> 'Banner_amount', 'type'=>'number', 'data' => 'string','help'=>'Help Text goes here'),
 			'banner_rendertype'		=> array('title'=> 'Banner_rendertype', 'type'=>'text', 'data' => 'string','help'=>'Help Text goes here'),		); 
 	*/
-	
+
 		public function init()
 		{
 
@@ -153,33 +153,33 @@ class banner_ui extends e_admin_ui
 			}*/
 		}
 
-		
+
 		// ------- Customize Create --------
 
 		public function beforeCreate($new_data, $old_data)
 		{
 		//	e107::getMessage()->addDebug(print_a($new_data,true)); 
-			
+
 			if(!empty($new_data['banner_clientname_sel']))
 			{
 				$new_data['banner_clientname'] = $new_data['banner_clientname_sel'];
-					
+
 			}
 
 			if(!empty($new_data['banner_campaign_sel']) && $new_data['banner_campaign_sel'] != '_new_')
 			{
 				$new_data['banner_campaign'] = $new_data['banner_campaign_sel'];
-					
+
 			}
 
 			if(!empty($new_data['banner_image_remote']))
 			{
 				$new_data['banner_image'] = $new_data['banner_image_remote'];
 			}
-			
+
 			return $new_data;
 		}
-	
+
 		public function afterCreate($new_data, $old_data, $id)
 		{
 			// do something
@@ -191,17 +191,17 @@ class banner_ui extends e_admin_ui
 			exit;
 		}		
 
-		
+
 		// ------- Customize Update --------
-		
+
 		public function beforeUpdate($new_data, $old_data, $id)
 		{
 			//	e107::getMessage()->addDebug(print_a($new_data,true));
-				
+
 			if(!empty($new_data['banner_clientname_sel']))
 			{
 				$new_data['banner_clientname'] = $new_data['banner_clientname_sel'];
-					
+
 			}
 
 			if(!empty($new_data['banner_campaign_sel']) && empty($new_data['banner_campaign']))
@@ -215,7 +215,7 @@ class banner_ui extends e_admin_ui
 			}
 
 			// e107::getMessage()->addDebug(print_a($new_data,true));
-				
+
 			return $new_data;
 		}
 
@@ -223,7 +223,7 @@ class banner_ui extends e_admin_ui
 		{
 			// do something	
 		}
-		
+
 		public function onUpdateError($new_data, $old_data, $id)
 		{
 			// do something		
@@ -282,8 +282,8 @@ class banner_ui extends e_admin_ui
 
 
 	}*/
-			
-	
+
+
 		public function menuPage()
 		{
 
@@ -295,19 +295,19 @@ class banner_ui extends e_admin_ui
 			$menu_pref = e107::getConfig('menu')->getPref('');
 			$frm = e107::getForm();
 			$mes = e107::getMessage();
-				
+
 			$in_catname = array();		// Notice removal
 			$all_catname = array();
-			
+
 			$array_cat_in = explode("|", $menu_pref['banner_campaign']);
-			
+
 			if (!$menu_pref['banner_caption'])
 			{
 				$menu_pref['banner_caption'] = BNRLAN_38;
 			}
-			
+
 			$category_total = $sql->select("banner", "DISTINCT(banner_campaign) as banner_campaign", "ORDER BY banner_campaign", "mode=no_where");
-			
+
 			while ($banner_row = $sql -> fetch())
 			{
 				$all_catname[] = $banner_row['banner_campaign'];
@@ -316,7 +316,7 @@ class banner_ui extends e_admin_ui
 					$in_catname[] = $banner_row['banner_campaign'];
 				}
 			}
-						
+
 			$text = "
 				<form method='post' action='".e_REQUEST_URI."' id='menu_conf_form'>
 					<fieldset id='core-banner-menu'>
@@ -337,7 +337,7 @@ class banner_ui extends e_admin_ui
 			";
 			if($all_catname)
 			{
-				
+
 				foreach($all_catname as $name)
 				{
 					$text .= "
@@ -346,7 +346,7 @@ class banner_ui extends e_admin_ui
 							</div>
 							";
 				}
-					
+
 				$text .= "
 						<div class='field-spacer control-group form-group'>
 						".$frm->admin_button('check_all', 'jstarget:multiaction_cat_active', 'checkall', LAN_CHECKALL)."
@@ -358,15 +358,15 @@ class banner_ui extends e_admin_ui
 			{
 				$text .= BNRLAN_40;
 			}
-			
-			
+
+
 			$renderTypes = array(BNRLAN_48,'1 - '.BNRLAN_45,'2 - '.BNRLAN_46);
-			
+
 				$renderTypes[3] = "3 - ".BNRLAN_47; //TODO 
-			
-			
+
+
 			$text .= "
-			
+
 										</td>
 									</tr>
 									<tr>
@@ -385,9 +385,9 @@ class banner_ui extends e_admin_ui
 						</fieldset>
 					</form>
 				";
-			
+
 				return $mes->render().$text; 
-			
+
 			//	$ns->tablerender(LAN_PLUGIN_BANNER_NAME.SEP.BNRLAN_36, $mes->render() . $text);
 			*/
 		}
@@ -397,9 +397,9 @@ class banner_ui extends e_admin_ui
 			$help_text = str_replace("[br]", "<br />", BNRLAN_HELP_02);
 			return array('caption' => LAN_HELP, 'text' => $help_text);
 		}
-			
+
 }
-				
+
 
 
 class banner_form_ui extends e_admin_form_ui
@@ -421,35 +421,35 @@ class banner_form_ui extends e_admin_form_ui
 
 			while ($banner_row = $sql->fetch())
 			{
-				if (strpos($banner_row['banner_campaign'], "^") !== FALSE) 
+				if (strpos((string) $banner_row['banner_campaign'], "^") !== FALSE) 
 				{
-					$campaignsplit = explode("^", $banner_row['banner_campaign']);
+					$campaignsplit = explode("^", (string) $banner_row['banner_campaign']);
 					$banner_row['banner_campaign'] = $campaignsplit[0];
 				}
-		
+
 				if ($banner_row['banner_campaign']) 
 				{
 					$this->campaigns[$banner_row['banner_campaign']] = $banner_row['banner_campaign'];
 				}
-				
+
 				if ($banner_row['banner_clientname']) 
 				{
 					$this->clients[$banner_row['banner_clientname']] = $banner_row['banner_clientname'];
 				}
-		
+
 				if ($banner_row['banner_clientlogin']) 
 				{
 					$this->logins[] = $banner_row['banner_clientlogin'];
 				}
-				
+
 				if ($banner_row['banner_clientpassword']) 
 				{
 					$this->passwords[] = $banner_row['banner_clientpassword'];
 				}
 			}
 		}	
-		
-		
+
+
 	}
 
 
@@ -467,7 +467,7 @@ class banner_form_ui extends e_admin_form_ui
 
 				$opts =   'media=banner&w=600&legacyPath={e_IMAGE}banners';
 
-				if(strpos($curVal,'http') === 0)
+				if(strpos((string) $curVal,'http') === 0)
 				{
 					$val1 = null;
 					$val2 = $curVal;
@@ -506,18 +506,18 @@ class banner_form_ui extends e_admin_form_ui
 		return null;
 	}
 
-	
+
 	// Custom Method/Function 
 	function banner_clientname($curVal,$mode)
 	{
 		$frm = e107::getForm();		
-		 		
+
 		switch($mode)
 		{
 			case 'read': // List Page
 				return $curVal;
 		//	break;
-			
+
 			case 'write': // Edit Page
 				$text = '';
 				if (count($this->clients)) 
@@ -527,15 +527,15 @@ class banner_form_ui extends e_admin_form_ui
 				}
 				else
 				{
-					
+
 					$text .= $frm->text('banner_clientname',$curVal);
 					$text .= "<span class='field-help'>".BNRLAN_29."</span>";
 				}
-				
+
 				return $text; 
 			//	return $frm->text('banner_clientname',$curVal);		
 			//break;
-			
+
 			case 'filter':
 			case 'batch':
 				return  $this->clients; 
@@ -545,22 +545,22 @@ class banner_form_ui extends e_admin_form_ui
 		return null;
 	}
 
-	
+
 	// Custom Method/Function 
 	function banner_clientlogin($curVal,$mode)
 	{
 		$frm = e107::getForm();		
-		 		
+
 		switch($mode)
 		{
 			case 'read': // List Page
 				return $curVal;
 			break;
-			
+
 			case 'write': // Edit Page
 				return $frm->text('banner_clientlogin',$curVal);		
 			break;
-			
+
 			case 'filter':
 			case 'batch':
 				return null;
@@ -574,7 +574,7 @@ class banner_form_ui extends e_admin_form_ui
 	function banner_impressions($curVal,$mode)
 	{
 		$frm = e107::getForm();		
-		 		
+
 		switch($mode)
 		{
 			case 'read': // List Page
@@ -583,11 +583,11 @@ class banner_form_ui extends e_admin_form_ui
 				$impressions_purchased = ($banner_row['banner_impurchased'] ? $banner_row['banner_impurchased'] : BANNERLAN_30);
 				return $curVal .' / '.$impressions_purchased;
 			break;
-			
+
 			case 'write': // Edit Page
 				return $frm->text('banner_impressions',$curVal);		
 			break;
-			
+
 			case 'filter':
 			case 'batch':
 				return  array();
@@ -596,18 +596,18 @@ class banner_form_ui extends e_admin_form_ui
 
 		return null;
 	}
-	
+
 	// Custom Method/Function 
 	function banner_campaign($curVal,$mode)
 	{
 		$frm = e107::getForm();		
-		 		
+
 		switch($mode)
 		{
 			case 'read': // List Page
 				return $curVal;
 			break;
-			
+
 			case 'write': // Edit Page
 				if (count($this->campaigns)) 
 				{
@@ -620,7 +620,7 @@ class banner_form_ui extends e_admin_form_ui
 				}
 				return $text; // $frm->text('banner_campaign',$curVal);		
 			break;
-			
+
 			case 'filter':
 			case 'batch':
 				return  $this->campaigns; 
@@ -629,8 +629,8 @@ class banner_form_ui extends e_admin_form_ui
 
 		return null;
 	}
-	
-	
+
+
 	// Custom Method/Function 
 	function click_percentage($curVal,$mode)
 	{
@@ -642,7 +642,7 @@ class banner_form_ui extends e_admin_form_ui
 		unset($curVal); // keep inspector happy.
 
 		$banner_row = $this->getController()->getListModel()->getData(); 
-		 
+
 	//	 return print_a($banner_row,true); 		
 		return ($banner_row['banner_clicks'] && $banner_row['banner_impressions'] ? round(($banner_row['banner_clicks'] / $banner_row['banner_impressions']) * 100,1)."%" : "-");
 
@@ -652,7 +652,7 @@ class banner_form_ui extends e_admin_form_ui
 
 
 }		
-		
+
 
 new banner_admin;
 

--- a/e107_plugins/banner/banner.php
+++ b/e107_plugins/banner/banner.php
@@ -35,7 +35,7 @@ if(e_QUERY)
 	$query_string = intval(e_QUERY);
 	$row = $sql->retrieve("banner", "*", "banner_id = '{$query_string}'"); // select the banner
 	$ip = e107::getIPHandler()->getIP();
-	$newip = (strpos($row['banner_ip'], "{$ip}^") !== FALSE) ? $row['banner_ip'] : "{$row['banner_ip']}{$ip}^"; // what does this do?
+	$newip = (strpos((string) $row['banner_ip'], "{$ip}^") !== FALSE) ? $row['banner_ip'] : "{$row['banner_ip']}{$ip}^"; // what does this do?
 	$sql->update("banner", "banner_clicks = banner_clicks + 1, `banner_ip` = '{$newip}' WHERE `banner_id` = '{$query_string}'");
 //	header("Location: {$row['banner_clickurl']}");
 	e107::redirect($row['banner_clickurl']);
@@ -113,7 +113,7 @@ if (isset($_POST['clientsubmit']))
 			
 			if ($row['banner_ip']) 
 			{
-				$tmp = explode("^", $row['banner_ip']);
+				$tmp = explode("^", (string) $row['banner_ip']);
 				$scArray['BANNER_TABLE_IP_LAN'] = (count($tmp)-1);
 				
 				for($a = 0; $a <= (count($tmp)-2); $a++) {

--- a/e107_plugins/banner/banner_menu.php
+++ b/e107_plugins/banner/banner_menu.php
@@ -91,7 +91,7 @@ if(!empty($menu_pref['banner_campaign']) /*&& !empty($menu_pref['banner_amount']
 		$seed = mt_rand(1,2000000000);
 		$time = time();
 	
-		$tmp = explode("|", $menu_pref['banner_campaign']); 
+		$tmp = explode("|", (string) $menu_pref['banner_campaign']); 
 		foreach($tmp as $v)
 		{
 			$filter[] = "banner_campaign=\"".$v."\""; 		

--- a/e107_plugins/banner/e_shortcode.php
+++ b/e107_plugins/banner/e_shortcode.php
@@ -63,7 +63,7 @@ class banner_shortcodes extends e_shortcode
 			return "<a href='" . e_HTTP . 'banner.php?' . $row['banner_id'] . "' rel='external'>" . BANNERLAN_39 . "</a>";
 		}
 
-		$fileext1 = substr(strrchr($row['banner_image'], '.'), 1);
+		$fileext1 = substr(strrchr((string) $row['banner_image'], '.'), 1);
 
 		$sql->update('banner', 'banner_impressions=banner_impressions+1 WHERE banner_id=' . (int) $row['banner_id']);
 
@@ -91,7 +91,7 @@ class banner_shortcodes extends e_shortcode
 			default:
 
 				$class = empty($parm['class']) ? "e-banner img-responsive img-fluid" : $parm['class'];
-				$ban_ret = $tp->toImage($row['banner_image'], array('class' => $class, 'alt' => basename($row['banner_image']), 'legacy' => '{e_IMAGE}banners'));
+				$ban_ret = $tp->toImage($row['banner_image'], array('class' => $class, 'alt' => basename((string) $row['banner_image']), 'legacy' => '{e_IMAGE}banners'));
 
 				break;
 		}

--- a/e107_plugins/blogcalendar_menu/blogcalendar_menu.php
+++ b/e107_plugins/blogcalendar_menu/blogcalendar_menu.php
@@ -130,7 +130,7 @@ if(false === $cached)
 			if (!isset($links[$xyear][$xmonth][$xday]))
 			{
 				$links[$xyear][$xmonth][$xday] = e107::getUrl()->create('news/list/day', 'id='.formatDate($xyear, $xmonth, $xday));//e_BASE."news.php?day.".formatDate($req_year, $req_month, $xday);
-	
+
 				$day_links[$xday] = e107::getUrl()->create('news/list/day', 'id='.formatDate($xyear, $xmonth, $xday));//e_BASE."news.php?day.".formatDate($req_year, $req_month, $xday);
 			}
 		}

--- a/e107_plugins/blogcalendar_menu/functions.php
+++ b/e107_plugins/blogcalendar_menu/functions.php
@@ -19,9 +19,9 @@ if (!defined('e107_INIT')) { exit; }
 // format a date as yyyymmdd
 function formatDate($year, $month, $day = "") {
 	$date = $year;
-	$date .= (strlen($month) < 2)?"0".$month:
+	$date .= (strlen((string) $month) < 2)?"0".$month:
 	$month;
-	$date .= (strlen($day) < 2 && $day != "")?"0".$day:
+	$date .= (strlen((string) $day) < 2 && $day != "")?"0".$day:
 	$day;
 	return $date;
 }

--- a/e107_plugins/chatbox_menu/chatbox_menu.php
+++ b/e107_plugins/chatbox_menu/chatbox_menu.php
@@ -44,10 +44,10 @@ if((isset($_POST['chat_submit']) || e_AJAX_REQUEST) && $_POST['cmessage'] !== ''
 	}
 	else
 	{
-		$nick = trim(preg_replace("#\[.*\]#s", '', $tp->toDB($_POST['nick'])));
+		$nick = trim((string) preg_replace("#\[.*\]#s", '', (string) $tp->toDB($_POST['nick'])));
 
 		$cmessage = $_POST['cmessage'];
-		$cmessage = preg_replace("#\[.*?\](.*?)\[/.*?\]#s", "\\1", $cmessage);
+		$cmessage = preg_replace("#\[.*?\](.*?)\[/.*?\]#s", "\\1", (string) $cmessage);
 
 
 		$fp = new floodprotect;

--- a/e107_plugins/chatbox_menu/chatbox_menu_shortcodes.php
+++ b/e107_plugins/chatbox_menu/chatbox_menu_shortcodes.php
@@ -54,7 +54,7 @@ class chatbox_menu_shortcodes extends e_shortcode
 	protected function getUserIdFromNick()
 	{
 
-		$temp = explode('.', $this->var['cb_nick']);
+		$temp = explode('.', (string) $this->var['cb_nick']);
 
 		return $temp[0];
 	}
@@ -68,7 +68,7 @@ class chatbox_menu_shortcodes extends e_shortcode
 	protected function getUserNameFromNick()
 	{
 
-		$temp = explode('.', $this->var['cb_nick'], 2);
+		$temp = explode('.', (string) $this->var['cb_nick'], 2);
 
 		return $temp[1];
 	}

--- a/e107_plugins/chatbox_menu/e_list.php
+++ b/e107_plugins/chatbox_menu/e_list.php
@@ -46,8 +46,8 @@ class list_chatbox_menu
 		{
 			while($row = $this->parent->e107->sql->fetch())
 			{
-				$cb_id = substr($row['cb_nick'] , 0, strpos($row['cb_nick'] , "."));
-				$cb_nick = substr($row['cb_nick'] , (strpos($row['cb_nick'] , ".")+1));
+				$cb_id = substr((string) $row['cb_nick'] , 0, strpos((string) $row['cb_nick'] , "."));
+				$cb_nick = substr((string) $row['cb_nick'] , (strpos((string) $row['cb_nick'] , ".")+1));
 				$cb_message = ($row['cb_blocked'] ? CHATBOX_L6 : str_replace("<br />", " ", $tp->toHTML($row['cb_message'])));
 		//	$rowheading = $this->parent->parse_heading($cb_message);
 

--- a/e107_plugins/chatbox_menu/e_rss.php
+++ b/e107_plugins/chatbox_menu/e_rss.php
@@ -8,7 +8,7 @@
  *
  *	RSS chatbox feed addon
  */
- 
+
 if (!defined('e107_INIT')) { exit; }
 
 // v2.x Standard 
@@ -20,7 +20,7 @@ class chatbox_menu_rss // plugin-folder + '_rss'
 	function config() 
 	{
 		$config = array();
-	
+
 		$config[] = array(
 			'name'			=> 'Chatbox Posts',
 			'url'			=> 'chatbox',
@@ -29,10 +29,10 @@ class chatbox_menu_rss // plugin-folder + '_rss'
 			'class'			=> '0',
 			'limit'			=> '9'
 		);
-		
+
 		return $config;
 	}
-	
+
 	/**
 	 * Compile RSS Data
 	 * @param $parms array	url, limit, id 
@@ -41,16 +41,16 @@ class chatbox_menu_rss // plugin-folder + '_rss'
 	function data($parms='')
 	{
 		$sql = e107::getDb();
-		
+
 		$rss = array();
 		$i=0;
-					
+
 		if($items = $sql->select('chatbox', "*", "cb_blocked=0 ORDER BY cb_datestamp DESC LIMIT 0,".$parms['limit']))
 		{
 
 			while($row = $sql->fetch())
 			{
-				$tmp						= explode(".", $row['cb_nick']);
+				$tmp						= explode(".", (string) $row['cb_nick']);
 				$rss[$i]['author']			= $tmp[1];
 				$rss[$i]['author_email']	= ''; 
 				$rss[$i]['link']			= "chatbox_menu/chat.php?".$row['cb_id'];
@@ -67,12 +67,12 @@ class chatbox_menu_rss // plugin-folder + '_rss'
 			}
 
 		}				
-					
+
 		return $rss;
 	}
-			
-		
-	
+
+
+
 }
 
 

--- a/e107_plugins/chatbox_menu/e_search.php
+++ b/e107_plugins/chatbox_menu/e_search.php
@@ -8,7 +8,7 @@
  * 
  * Chatbox e_search addon 
  */
- 
+
 
 if (!defined('e107_INIT')) { exit; }
 
@@ -17,7 +17,7 @@ if (!defined('e107_INIT')) { exit; }
 
 class chatbox_menu_search extends e_search // include plugin-folder in the name.
 {
-		
+
 	function config()
 	{	
 		$search = array(
@@ -28,10 +28,10 @@ class chatbox_menu_search extends e_search // include plugin-folder in the name.
 								'date'	=> array('type'	=> 'date', 		'text' => LAN_DATE_POSTED),
 								'author'=> array('type'	=> 'author',	'text' => LAN_SEARCH_61)
 							),
-							
+
 			'return_fields'	=> array('cb_id', 'cb_nick', 'cb_message', 'cb_datestamp'), 
 			'search_fields'	=> array('cb_nick' => '1', 'cb_message' => '1'), // fields and weights. 
-			
+
 			'order'			=> array('cb_datestamp' => 'DESC'),
 			'refpage'		=> 'chat.php'
 		);
@@ -47,10 +47,10 @@ class chatbox_menu_search extends e_search // include plugin-folder in the name.
 	{
 		$tp = e107::getParser();
 
-		preg_match("/([0-9]+)\.(.*)/", $row['cb_nick'], $user);
+		preg_match("/([0-9]+)\.(.*)/", (string) $row['cb_nick'], $user);
 
 		$res = array();
-	
+
 		$res['link'] 		= e_PLUGIN."chatbox_menu/chat.php?".$row['cb_id'].".fs";
 		$res['pre_title'] 	= LAN_SEARCH_7;
 		$res['title'] 		= $user[2];
@@ -58,7 +58,7 @@ class chatbox_menu_search extends e_search // include plugin-folder in the name.
 		$res['detail'] 		= $tp->toDate($row['cb_datestamp'], "long");
 
 		return $res;
-		
+
 	}
 
 
@@ -72,7 +72,7 @@ class chatbox_menu_search extends e_search // include plugin-folder in the name.
 		$tp = e107::getParser();
 
 		$qry = "";
-		
+
 		if (vartrue($parm['time']) && is_numeric($parm['time'])) 
 		{
 			$qry .= " cb_datestamp ".($parm['on'] == 'new' ? '>=' : '<=')." '".(time() - $parm['time'])."' AND";
@@ -82,10 +82,10 @@ class chatbox_menu_search extends e_search // include plugin-folder in the name.
 		{
 			$qry .= " cb_nick LIKE '%".$tp -> toDB($parm['author'])."%' AND";
 		}
-		
+
 		return $qry;
 	}
-	
+
 
 }
 

--- a/e107_plugins/comment_menu/comment_menu_shortcodes.php
+++ b/e107_plugins/comment_menu/comment_menu_shortcodes.php
@@ -43,7 +43,7 @@ class comment_menu_shortcodes extends e_shortcode
 	{
 		return e107::getParser()->toDate($this->var['comment_datestamp'], "relative");
 	}
-		
+
 	function sc_cm_heading($parm=null)
 	{
 		if(!empty($parm['limit'])) // new v2.1.5
@@ -57,7 +57,7 @@ class comment_menu_shortcodes extends e_shortcode
 
 		return e107::getParser()->toHTML($text,false,'TITLE');
 	}
-		
+
 	function sc_cm_url_pre()
 	{
 		return ($this->var['comment_url'] ? "<a href='".$this->var['comment_url']."'>" : "");
@@ -67,17 +67,17 @@ class comment_menu_shortcodes extends e_shortcode
 	{
 		return (!empty($this->var['comment_url'])) ? $this->var['comment_url'] : '#';
 	}
-		
+
 	function sc_cm_url_post()
 	{
 		return ($this->var['comment_url'] ? "</a>" : "");
 	}
-		
+
 	function sc_cm_type()
 	{
 		return $this->var['comment_type'];
 	}
-		
+
 	function sc_cm_author()
 	{
 		return $this->var['comment_author'];
@@ -95,8 +95,8 @@ class comment_menu_shortcodes extends e_shortcode
 
 		return e107::getParser()->toAvatar($data, $parm);
 	}
-	
-	
+
+
 	function sc_cm_comment($parm=null)
 	{
 		$menu_pref 	= e107::getConfig('menu')->getPref();
@@ -109,7 +109,7 @@ class comment_menu_shortcodes extends e_shortcode
 			$menu_pref['comment_characters'] = intval($parm['limit']);
 		}
 
-		
+
 		if($menu_pref['comment_characters'] > 0)
 		{
 			$COMMENT = strip_tags($tp->toHTML($this->var['comment_comment'], TRUE, "emotes_off, no_make_clickable", "", e107::getPref('menu_wordwrap')));
@@ -118,10 +118,10 @@ class comment_menu_shortcodes extends e_shortcode
 				$COMMENT = $tp->text_truncate($COMMENT, $menu_pref['comment_characters'],'').($this->var['comment_url'] ? " <a href='".$this->var['comment_url']."'>" : "").defset($menu_pref['comment_postfix'], $menu_pref['comment_postfix']).($this->var['comment_url'] ? "</a>" : "");
 			}
 		}
-		
+
 		return $COMMENT;	
 	}
-	
+
 }
 
 

--- a/e107_plugins/comment_menu/config.php
+++ b/e107_plugins/comment_menu/config.php
@@ -35,7 +35,7 @@ if (isset($_POST['update_menu']))
 		$temp['comment_caption'] = array();
 	}
 
-	
+
 	$tp = e107::getParser();
 	foreach($_POST as $key=>$value)
 	{
@@ -56,7 +56,7 @@ if (isset($_POST['update_menu']))
 	{
 		$temp['comment_title'] = 0;
 	}
-	
+
 	$menu_config->setPref($temp);
 
 	if($menu_config->save(false))

--- a/e107_plugins/download/download_shortcodes.php
+++ b/e107_plugins/download/download_shortcodes.php
@@ -551,7 +551,7 @@ class download_shortcodes extends e_shortcode
 
 	function sc_download_filename($parm = null)
 	{
-		return basename($this->var['download_url']);
+		return basename((string) $this->var['download_url']);
 
 	}
 
@@ -810,7 +810,7 @@ class download_shortcodes extends e_shortcode
 			$opts = array(
 				'legacy' => "{e_FILE}downloadimages/",
 				'class'  => 'download-image dl_image download-view-image img-responsive img-fluid ' . vartrue($parm['class']),
-				'alt'    => basename($this->var['download_image'])
+				'alt'    => basename((string) $this->var['download_image'])
 			);
 
 			return e107::getParser()->toImage($this->var['download_image'], $opts);
@@ -872,7 +872,7 @@ class download_shortcodes extends e_shortcode
 		/*
       	require_once(e_HANDLER."rate_class.php");
       	$rater = new rater;
-      	
+
       	$text = "
       		<table style='width:100%'>
       		<tr>

--- a/e107_plugins/download/e_rss.php
+++ b/e107_plugins/download/e_rss.php
@@ -84,7 +84,7 @@ class download_rss // plugin-folder + '_rss'
 		{
 			if($value['download_author'])
 			{
-				$nick = preg_replace("/[0-9]+\./", "", $value['download_author']);
+				$nick = preg_replace("/[0-9]+\./", "", (string) $value['download_author']);
 				$rss[$i]['author'] = $nick;
 			}
 

--- a/e107_plugins/download/handlers/NginxSecureLinkMd5Decorator.php
+++ b/e107_plugins/download/handlers/NginxSecureLinkMd5Decorator.php
@@ -32,7 +32,7 @@ class NginxSecureLinkMd5Decorator implements SecureLinkDecorator
 			$expiry = PHP_INT_MAX;
 		else
 			$expiry = time() + $expiry;
-		$url_parts = parse_url($url);
+		$url_parts = parse_url((string) $url);
 		$evaluation = str_replace(
 			self::supported_variables(),
 			array(
@@ -46,7 +46,7 @@ class NginxSecureLinkMd5Decorator implements SecureLinkDecorator
 		$query_string = $url_parts['query'];
 		parse_str($query_string, $query_args);
 		$query_args['md5'] = str_replace(array('+', '/', '='), array('-', '_', ''), base64_encode(md5($evaluation, true)));
-		if (strpos($prefs['download_security_expression'], '$secure_link_expires') !== false)
+		if (strpos((string) $prefs['download_security_expression'], '$secure_link_expires') !== false)
 			$query_args['expires'] = $expiry;
 		require_once(__DIR__ . '/../vendor/shim_http_build_url.php');
 		return http_build_url($url_parts, array('query' => http_build_query($query_args)));

--- a/e107_plugins/download/handlers/category_class.php
+++ b/e107_plugins/download/handlers/category_class.php
@@ -139,7 +139,7 @@ class downloadCategory
 	function print_cat($cat, $prefix,$postfix)
 	{
 		$text = "<tr><td>".$cat['download_category_id']."</td><td>".$cat['download_category_parent']."</td><td>";
-		$text .= $prefix.htmlspecialchars($cat['download_category_name']).$postfix."</td><td>".$cat['d_size']."</td>";
+		$text .= $prefix.htmlspecialchars((string) $cat['download_category_name']).$postfix."</td><td>".$cat['d_size']."</td>";
 		$text .= "<td>".$cat['d_count']."</td><td>".$cat['d_requests']."</td><td>".eShims::strftime('%H:%M %d-%m-%Y',$cat['d_last'])."</td>";
 		$text .= "</tr>";
 		return $text;

--- a/e107_plugins/download/handlers/download_class.php
+++ b/e107_plugins/download/handlers/download_class.php
@@ -127,16 +127,16 @@ class download
 		{
 			if (is_numeric($tmp[0]))	//legacy		// $tmp[0] at least must be valid
 			{
-				$parsed                 = preg_replace("#\W#", "", $tp->toDB($tmp[1]));
+				$parsed                 = preg_replace("#\W#", "", (string) $tp->toDB($tmp[1]));
 			   $this->qry['action'] 	= varset($parsed,'list');
 			   $this->qry['id'] 		= intval($tmp[2]);
 			   $this->qry['view'] 		= intval($tmp[3]);
-			   $this->qry['order'] 		= preg_replace("#\W#", "", $tp->toDB($tmp[4]));
-			   $this->qry['sort'] 		= preg_replace("#\W#", "", $tp->toDB($tmp[5]));
+			   $this->qry['order'] 		= preg_replace("#\W#", "", (string) $tp->toDB($tmp[4]));
+			   $this->qry['sort'] 		= preg_replace("#\W#", "", (string) $tp->toDB($tmp[5]));
 		   	}
 			elseif(!empty($tmp[1]))
 		   	{
-			   $this->qry['action'] 	= preg_replace("#\W#", "", $tp->toDB($tmp[0]));
+			   $this->qry['action'] 	= preg_replace("#\W#", "", (string) $tp->toDB($tmp[0]));
 			   $this->qry['id'] 		= intval($tmp[1]);
 			   $this->qry['error']		= intval(varset($tmp[2],0));
 			}	
@@ -148,7 +148,7 @@ class download
 		{
 			$this->qry['view'] 		= varset($_POST['view']) ? intval($_POST['view']) : 10;
 			$this->qry['order'] 	= varset($_POST['order']) && in_array("download_".$_POST['order'],$this->orderOptions) ? $_POST['order'] : 'datestamp';
-			$this->qry['sort'] 		= (strtolower($_POST['sort']) == 'asc') ? "asc" : 'desc';	
+			$this->qry['sort'] 		= (strtolower((string) $_POST['sort']) == 'asc') ? "asc" : 'desc';	
 		}	
 		
 
@@ -255,7 +255,7 @@ class download
 		$tp = e107::getParser();
 		$ns = e107::getRender();
 		$pref = e107::getPref();
-		
+
 
 	//	if ($cacheData = $e107cache->retrieve("download_cat".$maincatval,720)) // expires every 12 hours. //TODO make this an option
 		{
@@ -264,18 +264,18 @@ class download
 		}
 
 
-		
+
 		if(deftrue('BOOTSTRAP')) // v2.x 
 		{
 			$template = e107::getTemplate('download','download','categories');
-			
+
 			$DOWNLOAD_CAT_CAPTION		= $template['caption'];
 			$DOWNLOAD_CAT_TABLE_START 	= varset($template['start']);
 			$DOWNLOAD_CAT_PARENT_TABLE	= $template['parent'];
 			$DOWNLOAD_CAT_CHILD_TABLE	= $template['child'];
 			$DOWNLOAD_CAT_SUBSUB_TABLE	= $template['subchild'];
 			$DOWNLOAD_CAT_TABLE_END		= varset($template['end']);
-			
+
 //			$DL_VIEW_NEXTPREV			= varset($template['nextprev']);
 //			$DL_VIEW_PAGETITLE			= varset($template['pagetitle']);
 //			$DL_VIEW_CAPTION			= varset($template['caption'],"{DOWNLOAD_VIEW_CAPTION}");
@@ -291,7 +291,7 @@ class download
 
 
 			$template_name = 'download_template.php';
-			
+
 			if (is_readable(THEME."templates/".$template_name))
 			{
 				require_once(THEME."templates/".$template_name);
@@ -311,9 +311,9 @@ class download
 		$sc->wrapper('download/categories');
 		$sc->breadcrumb();
 		$sc->qry 	= $this->qry;	
-		
-	
-		
+
+
+
 		if(!defined("DL_IMAGESTYLE")){ define("DL_IMAGESTYLE","border:1px solid blue");}
 
 	   // Read in tree of categories which this user is allowed to see
@@ -324,20 +324,20 @@ class download
 
 			return $ns->tablerender(LAN_PLUGIN_DOWNLOAD_NAME, "<div class='alert alert-warning' style='text-align:center'>".LAN_NO_RECORDS_FOUND."</div>",'download-categories',true);
 		}
-				
+
 		$download_cat_table_string = "";
 		foreach($dlcat->cat_tree as $dlrow)  // Display main category headings, then sub-categories, optionally with sub-sub categories expanded
 		{
 			$sc->setVars($dlrow); 
 			$download_cat_table_string .= $tp->parseTemplate($DOWNLOAD_CAT_PARENT_TABLE, TRUE, vartrue($sc));
-			
+
 			foreach($dlrow['subcats'] as $dlsubrow)
 			{
 				$sc->dlsubrow = $dlsubrow;
-				
-				
+
+
 				$download_cat_table_string .= $tp->parseTemplate($DOWNLOAD_CAT_CHILD_TABLE, TRUE, $sc);
-				
+
 				foreach($dlsubrow['subsubcats'] as $dlsubsubrow)
 				{
 					$sc->dlsubsubrow = $dlsubsubrow;
@@ -348,20 +348,20 @@ class download
 
 	//    e107::getDebug()->log($dlcat->cat_tree);
 
-	  
+
 		$dl_text = $tp->parseTemplate($this->templateHeader, TRUE, $sc);
 		$dl_text .= $tp->parseTemplate($DOWNLOAD_CAT_TABLE_START, TRUE, $sc);
 		$dl_text .= $download_cat_table_string;
 		$dl_text .= $tp->parseTemplate($DOWNLOAD_CAT_TABLE_END, TRUE, $sc);
-	   
+
 		$caption = varset($DOWNLOAD_CAT_CAPTION) ? $tp->parseTemplate($DOWNLOAD_CAT_CAPTION, TRUE, $sc) : LAN_PLUGIN_DOWNLOAD_NAME;
-		
+
 		//ob_start();
-		
+
 		$dl_text .= $tp->parseTemplate($this->templateFooter, TRUE, $sc);
 
 
-	   
+
 		return $ns->tablerender($caption, $dl_text, 'download-categories',true);
 
 	  // $cache_data = ob_get_flush();
@@ -724,7 +724,7 @@ class download
 
 
 		   $this->qry['name'] = $dlrow['download_category_sef'];
-		   
+
 	   //	   define("e_PAGETITLE", LAN_PLUGIN_DOWNLOAD_NAME." / ".$dlrow['download_category_name']);
 		}
 		else
@@ -1072,7 +1072,7 @@ class download
 			$sc->setVars($dlrow);
 
 			
-			$array = explode(chr(1), $dlrow['download_mirror']);
+			$array = explode(chr(1), (string) $dlrow['download_mirror']);
 			
 			if (2 == varset($pref['mirror_order']))
 			{
@@ -1147,7 +1147,7 @@ class download
 		switch ($this->qry['error'])
 		{
 			case 1 :	// No permissions
-	            if (strlen($pref['download_denied']) > 0) 
+	            if (strlen((string) $pref['download_denied']) > 0) 
 	            {
 					$errmsg = $tp->toHTML($pref['download_denied'],true, 'DESCRIPTION');
 	   	      	} 
@@ -1224,7 +1224,7 @@ class download
          {
             if ($groupOnMain)
             {
-            	$boxinfo .= "<optgroup label='".htmlspecialchars($thiscat['download_category_name'])."'>";
+            	$boxinfo .= "<optgroup label='".htmlspecialchars((string) $thiscat['download_category_name'])."'>";
              	$scprefix = '';
             }
             else
@@ -1233,7 +1233,7 @@ class download
             	if ($currentID == $thiscat['download_category_id']) {
             	   $boxinfo .= " selected='selected'";
             	}
-               $boxinfo .= ">".htmlspecialchars($thiscat['download_category_name'])."</option>\n";
+               $boxinfo .= ">".htmlspecialchars((string) $thiscat['download_category_name'])."</option>\n";
              	$scprefix = '&nbsp;&nbsp;&nbsp;';
             }
             foreach ($thiscat['subcats'] as $sc)
@@ -1243,7 +1243,7 @@ class download
             	if ($currentID == $sc['download_category_id']) {
             	   $boxinfo .= " selected='selected'";
             	}
-               $boxinfo .= ">".$scprefix.htmlspecialchars($sc['download_category_name'])."</option>\n";
+               $boxinfo .= ">".$scprefix.htmlspecialchars((string) $sc['download_category_name'])."</option>\n";
                if ($incSubSub)
                {  // Sub-sub categories
                	foreach ($sc['subsubcats'] as $ssc)
@@ -1262,7 +1262,7 @@ class download
          else
          {
          	$sel = ($currentID == $thiscat['download_category_id']) ? " selected='selected'" : "";
-           	$boxinfo .= "<option value='".$thiscat['download_category_id']."' {$sel}>".htmlspecialchars($thiscat['download_category_name'])."</option>\n";
+           	$boxinfo .= "<option value='".$thiscat['download_category_id']."' {$sel}>".htmlspecialchars((string) $thiscat['download_category_name'])."</option>\n";
          }
       }
       $boxinfo .= "</select>\n";
@@ -1272,8 +1272,8 @@ class download
 
 function sort_download_mirror_order($a, $b)
 {
-   $a = explode(",", $a);
-   $b = explode(",", $b);
+   $a = explode(",", (string) $a);
+   $b = explode(",", (string) $b);
    if ($a[1] == $b[1]) {
       return 0;
    }

--- a/e107_plugins/download/includes/admin.php
+++ b/e107_plugins/download/includes/admin.php
@@ -260,9 +260,9 @@ class download_cat_form_ui extends e_admin_form_ui
 	public function download_category_icon($curVal,$mode)
 	{
 
-		if(!empty($curVal) && strpos($curVal, chr(1)))
+		if(!empty($curVal) && strpos((string) $curVal, chr(1)))
 		{
-			list($curVal,$tmp) = explode(chr(1),$curVal);
+			list($curVal,$tmp) = explode(chr(1),(string) $curVal);
 		}
 
 		switch($mode)
@@ -485,7 +485,7 @@ $columnInfo = array(
 			// Custom filter queries 
 			if(vartrue($_GET['filter_options']))
 			{
-				list($filter,$mode) = explode("__",$_GET['filter_options']);
+				list($filter,$mode) = explode("__",(string) $_GET['filter_options']);
 				
 				if($mode == 'missing')
 				{
@@ -594,13 +594,13 @@ $columnInfo = array(
             if($deleted_check)
             {
                 $sql = e107::getDb('mmcleanup');
-                if(strpos($deleted_data['download_url'], '{e_MEDIA_') === 0 && $sql->delete('core_media', "media_url='{$deleted_data['download_url']}'"))
+                if(strpos((string) $deleted_data['download_url'], '{e_MEDIA_') === 0 && $sql->delete('core_media', "media_url='{$deleted_data['download_url']}'"))
                 {
                     $mediaFile = e107::getParser()->replaceConstants($deleted_data['download_url']);
                     @unlink($mediaFile);
                     e107::getMessage()->addSuccess('Associated media record successfully erased');
                 }
-                if(strpos($deleted_data['download_image'], '{e_MEDIA_') === 0 && $sql->delete('core_media', "media_url='{$deleted_data['download_image']}'"))
+                if(strpos((string) $deleted_data['download_image'], '{e_MEDIA_') === 0 && $sql->delete('core_media', "media_url='{$deleted_data['download_image']}'"))
                 {
                     $mediaImage = e107::getParser()->replaceConstants($deleted_data['download_image']);
                     e107::getMessage()->addSuccess('Associated media image successfully erased');
@@ -650,9 +650,9 @@ $columnInfo = array(
 			$ns = e107::getRender();
 			$tp = e107::getParser();
 			$pref = e107::getPref();
-			
+
 			//global $pref;
-			
+
 			if ($sql->select('userclass_classes','userclass_id, userclass_name'))
 			{
 				$classList = $sql->db_getList();
@@ -678,7 +678,7 @@ $columnInfo = array(
 				{
 					$chk = "";
 				}
-		
+
 				$txt .= "
 					<input type='checkbox' name='download_limits' value='on'{$chk}/> ".DOWLAN_125."
 					</td>
@@ -690,7 +690,7 @@ $columnInfo = array(
 					<th class='fcaption'>".DOWLAN_108."</th>
 				</tr>
 			";
-		
+
 			if(is_array(vartrue($limitList)))
 			{
 				foreach($limitList as $row)
@@ -716,7 +716,7 @@ $columnInfo = array(
 			<div class='buttons-bar center'>
 			<input type='submit' class='btn btn-default btn-secondary button' name='updatelimits' value='".DOWLAN_115."'/>
 			</div>
-			
+
 			<table class='table adminlist'>
 			<tr>
 			<td colspan='4'><br/><br/></td>
@@ -733,15 +733,15 @@ $columnInfo = array(
 			</td>
 			</tr>
 			<tr>
-			
+
 			";
-		
+
 			$txt .= "</table>
 			<div class='buttons-bar center'>
 			<input type='submit' class='btn btn-default btn-secondary button' name='addlimit' value='".DOWLAN_114."'/>
 			</div></form>";
 			echo $txt;
-		
+
 		//	$ns->tablerender(DOWLAN_112, $txt);
 			// require_once(e_ADMIN.'footer.php');
 			// exit;
@@ -753,14 +753,14 @@ $columnInfo = array(
 		{
 			$mes = e107::getMessage();
 			$mes->addInfo("Deprecated Area - please use filter instead under 'Manage' ");
-			
+
 			global $pref;
 			$ns = e107::getRender();
 			$sql = e107::getDb();
 			$sql2 = e107::getDb('sql2');
 			$frm = e107::getForm();
 			$tp = e107::getParser();
-			
+
 		   if (isset($_POST['dl_maint'])) {
 		      switch ($_POST['dl_maint'])
 		      {
@@ -866,7 +866,7 @@ $columnInfo = array(
 		            else
 		            {
 		            	e107::getMessage()->addInfo(DOWLAN_174);
-		  
+
 		            }
 		            break;
 		         }
@@ -883,7 +883,7 @@ $columnInfo = array(
 		                     if (!$foundSome)
 							 {
 		   		              // $text .= $rs->form_open("post", e_SELF."?".e_QUERY, "myform");
-								 
+
 		                        $text .= '<form method="post" action="'.e_SELF.'?'.e_QUERY.'" id="myform">
 		                        		<table class="adminlist">';
 		                        $text .= '<tr>';
@@ -941,12 +941,12 @@ $columnInfo = array(
 		                     $text .= '</tr>';
 		                     $foundSome = true;
 		                  }
-		                  
+
 		                  $text .= '<tr>';
 		                  $text .= '<td>'.$row['download_id'].'</td>';
 		                  $text .= "<td><a href='".e_PLUGIN."download/download.php?view.".$row['download_id']."'>".$tp->toHTML($row['download_name']).'</a></td>';
 		                  $text .= '<td>'.$tp->toHTML($row['download_category_name']).'</td>';
-		                  if (strlen($row['download_url']) > 0) {
+		                  if (strlen((string) $row['download_url']) > 0) {
 		                     $text .= '<td>'.$row['download_url'].'</td>';
 		                  } else {
 		   					   $mirrorArray = download::makeMirrorArray($row['download_mirror'], TRUE);
@@ -998,7 +998,7 @@ $columnInfo = array(
 		                  $text .= '<tr>';
 		                  $text .= '<td>'.$row['download_id'].'</td>';
 		                  $text .= "<td><a href='".e_PLUGIN."download/download.php?view.".$row['download_id']."'>".$tp->toHTML($row['download_name']).'</a></td>';
-		                  if (strlen($row['download_url']) > 0) {
+		                  if (strlen((string) $row['download_url']) > 0) {
 		                     $text .= '<td>'.$tp->toHTML($row['download_url']).'</td>';
 		                  } else {
 		   					   $mirrorArray = download::makeMirrorArray($row['download_mirror'], TRUE);
@@ -1143,7 +1143,7 @@ $columnInfo = array(
 		      						".$eform->radio('dl_maint', 'log').$eform->label(DOWLAN_191, 'dl_maint', 'log')."
 		      					</td>
 		      				</tr>
-		
+
 		      				</tbody>
 		      			</table>
 		      			<div class='buttons-bar center'>
@@ -1153,7 +1153,7 @@ $columnInfo = array(
 		      	</form>
 		      	";
 		   }
-		   
+
 		   echo $text;
 		   // 	$ns->tablerender(DOWLAN_165.$title, $text);
 		}
@@ -1289,7 +1289,7 @@ $columnInfo = array(
 	            $download_image = $row['upload_ss'];
 	            $download_filesize = $row['upload_filesize'];
 	            $image_array[] = array("path" => "", "fname" => $row['upload_ss']);
-	            $download_author = substr($row['upload_poster'], (strpos($row['upload_poster'], ".")+1));
+	            $download_author = substr((string) $row['upload_poster'], (strpos((string) $row['upload_poster'], ".")+1));
 	         }
 	      }
 	
@@ -1321,7 +1321,7 @@ $columnInfo = array(
 	      {
 	         $fpath = str_replace(e_DOWNLOAD,"",$file_array[$counter]['path']).$file_array[$counter]['fname'];
 	         $selected = '';
-	         if (stripos($fpath, $download_url) !== false)
+	         if (stripos($fpath, (string) $download_url) !== false)
 	         {
 	            $selected = " selected='selected'";
 	            $found = 1;
@@ -1331,7 +1331,7 @@ $columnInfo = array(
 	         $counter++;
 	      }
 	
-	      if (preg_match("/http:|https:|ftp:/", $download_url))
+	      if (preg_match("/http:|https:|ftp:/", (string) $download_url))
 	      {
 	         $download_url_external = $download_url;
 	         $download_url = '';
@@ -1740,7 +1740,7 @@ $columnInfo = array(
 	         	}
 	         	else
 	         	{
-		            if (strpos($DOWNLOADS_DIRECTORY, "/") === 0 || strpos($DOWNLOADS_DIRECTORY, ":") >= 1)
+		            if (strpos((string) $DOWNLOADS_DIRECTORY, "/") === 0 || strpos((string) $DOWNLOADS_DIRECTORY, ":") >= 1)
 		            {
 		               $filesize = filesize($DOWNLOADS_DIRECTORY.$dlInfo['download_url']);
 		            }
@@ -1858,9 +1858,9 @@ $columnInfo = array(
 	         }
 	         for($a=0; $a<$mirrors; $a++)
 	         {
-	            $mid = trim($_POST['download_mirror_name'][$a]);
-	            $murl = trim($_POST['download_mirror'][$a]);
-	            $msize = trim($_POST['download_mirror_size'][$a]);
+	            $mid = trim((string) $_POST['download_mirror_name'][$a]);
+	            $murl = trim((string) $_POST['download_mirror'][$a]);
+	            $msize = trim((string) $_POST['download_mirror_size'][$a]);
 	            if ($mid && $murl)
 	            {
 	               $newMirrorArray[$mid] = array('id' => $mid, 'url' => $murl, 'requests' => 0, 'filesize' => $msize);
@@ -1961,24 +1961,24 @@ $columnInfo = array(
 			$tp 		= e107::getParser();
 			$mes 		= e107::getMessage();
 			$fl			= e107::getFile();
-			
+
 			$action		= $this->action;
 			$subAction	= $this->subAction;
 			$id			= $this->id;
-			
+
 			global $delete, $del_id, $admin_log;
-	
+
 	      require_once(e_HANDLER."form_handler.php");
 	      $frm = new e_form();
-		  
-		  
+
+
 	      if ($delete == "mirror")
 	      {
 	         $mes->addAuto($sql ->delete("download_mirror", "mirror_id=".$del_id), 'delete', DOWLAN_135);
 	         e107::getLog()->add('DOWNL_14','ID: '.$del_id,E_LOG_INFORMATIVE,'');
 	      }
-	
-	
+
+
 	      if (!$sql -> select("download_mirror"))
 	      {
 	   			$mes->addInfo(DOWLAN_144);
@@ -1986,7 +1986,7 @@ $columnInfo = array(
 	      }
 	      else
 	      {
-	
+
 	         $text = "<div>
 	         <form method='post' action='".e_SELF."?".e_QUERY."'>
 	         <table style='".ADMIN_WIDTH."' class='adminlist'>
@@ -1997,14 +1997,14 @@ $columnInfo = array(
 	         <td style='width: 30%; text-align: center;' class='forumheader'>".LAN_OPTIONS."</td>
 	         </tr>
 	         ";
-	
+
 	         $mirrorList = $sql -> db_getList();
-	
+
 	         foreach($mirrorList as $mirror)
 	         {
 	            extract($mirror);
 	            $text .= "
-	
+
 	            <tr>
 	            <td style='width: 10%; text-align: center;'>$mirror_id</td>
 	            <td style='width: 30%;'>".$tp -> toHTML($mirror_name)."</td>
@@ -2017,14 +2017,14 @@ $columnInfo = array(
 	            ";
 	         }
 	         $text .= "</table></form></div>";
-	
+
 	      }
-	
+
 	     // $ns -> tablerender(DOWLAN_138, $text);
 		  echo $text;
-	
+
 	      $imagelist = $fl->get_files(e_FILE.'downloadimages/');
-	
+
 	      if ($subAction == "edit" && !defined("SUBMITTED"))
 	      {
 	         $sql -> select("download_mirror", "*", "mirror_id='".intval($id)."' ");
@@ -2037,68 +2037,68 @@ $columnInfo = array(
 	         unset($mirror_name, $mirror_url, $mirror_image, $mirror_location, $mirror_description);
 	         $edit = FALSE;
 	      }
-	
+
 	      $text = "<div>
 	      <form method='post' action='".e_SELF."?".e_QUERY."' id='dataform'>\n
 	      <table class='table adminform'>
-	
+
 	      <tr>
 	      <td style='width: 30%;'>".DOWLAN_12."</td>
 	      <td style='width: 70%;'>
 	      <input class='form-control input-xxlarge' type='text' name='mirror_name' size='60' value='{$mirror_name}' maxlength='200'/>
 	      </td>
 	      </tr>
-	
+
 	      <tr>
 	      <td style='width: 30%;'>".DOWLAN_139."</td>
 	      <td style='width: 70%;'>
 	      <input class='form-control input-xxlarge' type='text' name='mirror_url' size='70' value='{$mirror_url}' maxlength='255'/>
 	      </td>
 	      </tr>
-	
+
 	      <tr>
 	      <td style='width: 30%;'>".DOWLAN_136."</td>
 	      <td style='width: 70%;'>
 	      <input class='form-control input-xxlarge' type='text' id='mirror_image' name='mirror_image' size='60' value='{$mirror_image}' maxlength='200'/>
-	
-	
+
+
 	      <br /><input class='btn btn-default btn-secondary button' type ='button' style='cursor:pointer' size='30' value='".DOWLAN_42."' onclick='expandit(this)'/>
 	      <div id='imagefile' style='display:none;{head}'>";
-	
+
 	      $text .= DOWLAN_140."<br/>";
 	      foreach($imagelist as $file)
 	      {
 	         $text .= "<a href=\"javascript:insertext('".$file['fname']."','mirror_image','imagefile')\"><img src='".e_FILE."downloadimages/".$file['fname']."' alt=''/></a> ";
 	      }
-	
+
 	      $text .= "</div>
 	      </td>
 	      </tr>
-	
+
 	      <tr>
 	      <td style='width: 30%;'>".DOWLAN_141."</td>
 	      <td style='width: 70%;'>
 	      <input class='form-control' type='text' name='mirror_location' size='60' value='$mirror_location' maxlength='200'/>
 	      </td>
 	      </tr>
-	
+
 	      <tr>
 	      <td style='width: 30%;'>".DOWLAN_18."</td>
 	      <td style='width: 70%;'>";
 	      $text .= $frm->bbarea('mirror_description',$mirror_description);
 	      $text .= "</td>
 	      </tr>
-	
+
 	      <tr>
 	      <td colspan='2' class='forumheader' style='text-align:center;'>
 	      ".($edit ? "<input class='btn btn-default btn-secondary button' type='submit' name='submit_mirror' value='".DOWLAN_142."'/><input type='hidden' name='id' value='{$mirror_id}'/>" : "<input class='btn button' type='submit' name='submit_mirror' value='".DOWLAN_143."'/>")."
 	      </td>
 	      </tr>
-	
+
 	      </table>
 	      </form>
 	      </div>";
-	
+
 	      $caption = ($edit ? DOWLAN_142 : DOWLAN_143);
 			echo $text;
 	      // $ns -> tablerender($caption, $text);
@@ -2408,7 +2408,7 @@ $columnInfo = array(
 		        return FALSE;
 			}
 		
-			$directory = dirname($newname);
+			$directory = dirname((string) $newname);
 			if (is_writable($directory))
 			{
 		         if (!rename($oldname,$newname))
@@ -2443,7 +2443,7 @@ $columnInfo = array(
 	      $ret = array();
 	      if ($source)
 	      {
-	         $mirrorTArray = explode(chr(1), $source);
+	         $mirrorTArray = explode(chr(1), (string) $source);
 	
 	         $count = 0;
 	         foreach($mirrorTArray as $mirror)
@@ -2561,7 +2561,7 @@ class download_main_admin_form_ui extends e_admin_form_ui
 				
 class download_mirror_ui extends e_admin_ui
 {
-			
+
 		protected $pluginTitle		= LAN_PLUGIN_DOWNLOAD_NAME;
 		protected $pluginName		= 'download';
 		protected $table			= 'download_mirror';
@@ -2572,11 +2572,11 @@ class download_mirror_ui extends e_admin_ui
 	//	protected $sortField		= 'somefield_order';
 	//	protected $orderStep		= 10;
 	//	protected $tabs			= array('Tabl 1','Tab 2'); // Use 'tab'=>0  OR 'tab'=>1 in the $fields below to enable. 
-		
+
 	//	protected $listQry      	= "SELECT * FROM #tableName WHERE field != '' "; // Example Custom Query. LEFT JOINS allowed. Should be without any Order or Limit.
-	
+
 		protected $listOrder		= 'mirror_id DESC';
-	
+
 		protected $fields 		= array (  'checkboxes' =>   array ( 'title' => '', 'type' => null, 'data' => null, 'width' => '5%', 'thclass' => 'center', 'forced' => '1', 'class' => 'center', 'toggle' => 'e-multiselect',  ),
 		  'mirror_id' 			=>   array ( 'title' => LAN_ID, 'data' => 'int', 'width' => '5%', 'help' => '', 'readParms' => '', 'writeParms' => '', 'class' => 'left', 'thclass' => 'left',  ),
 		  'mirror_name' 		=>   array ( 'title' => LAN_TITLE, 'type' => 'text', 'data' => 'str', 'width' => 'auto', 'inline' => true, 'help' => '', 'readParms' => '', 'writeParms' => '', 'class' => 'left', 'thclass' => 'left',  ),
@@ -2587,16 +2587,16 @@ class download_mirror_ui extends e_admin_ui
 		  'mirror_count' 		=>   array ( 'title' => 'Count', 'type' => 'hidden', 'data' => 'int', 'width' => 'auto', 'help' => '', 'readParms' => '', 'writeParms' => '', 'class' => 'center', 'thclass' => 'center',  ),
 		  'options' 			=>   array ( 'title' => LAN_OPTIONS, 'type' => null, 'data' => null, 'width' => '10%', 'thclass' => 'center last', 'class' => 'center last', 'forced' => '1',  ),
 		);		
-		
+
 		protected $fieldpref = array('mirror_name', 'mirror_url', 'mirror_image', 'mirror_location');
-		
-	
+
+
 		public function init()
 		{
 			// Set drop-down values (if any). 
-	
+
 		}
-	
+
 	/*	
 		// optional - override edit page. 
 		public function customPage()
@@ -2604,7 +2604,7 @@ class download_mirror_ui extends e_admin_ui
 			$ns = e107::getRender();
 			$text = 'Hello World!';
 			$ns->tablerender('Hello',$text);	
-			
+
 		}
 	*/
 			

--- a/e107_plugins/download/request.php
+++ b/e107_plugins/download/request.php
@@ -56,7 +56,7 @@ class download_request
 					{
 						self::check_download_limits();
 					}
-					$mirrorList = explode(chr(1), $row['download_mirror']);
+					$mirrorList = explode(chr(1), (string) $row['download_mirror']);
 					$mstr = "";
 					foreach($mirrorList as $mirror)
 					{
@@ -99,7 +99,7 @@ class download_request
 		}
 		else
 		{
-			$table = preg_replace("#\W#", "", $tp->toDB($tmp[0], true));
+			$table = preg_replace("#\W#", "", (string) $tp->toDB($tmp[0], true));
 			$id = intval($tmp[1]);
 			$type = "image";
 		}
@@ -165,7 +165,7 @@ class download_request
 					extract($row);
 					if($row['download_mirror'])
 					{
-						$array = explode(chr(1), $row['download_mirror']);
+						$array = explode(chr(1), (string) $row['download_mirror']);
 						$c = (count($array) - 1);
 						for($i = 1; $i < $c; $i++)
 						{
@@ -253,11 +253,11 @@ class download_request
 				}
 				else
 				{    // Download Access Denied.
-					if((!strpos($pref['download_denied'], ".php") &&
-						!strpos($pref['download_denied'], ".htm") &&
-						!strpos($pref['download_denied'], ".html") &&
-						!strpos($pref['download_denied'], ".shtml") ||
-						(strpos($pref['download_denied'], "signup.php") && USER == true)
+					if((!strpos((string) $pref['download_denied'], ".php") &&
+						!strpos((string) $pref['download_denied'], ".htm") &&
+						!strpos((string) $pref['download_denied'], ".html") &&
+						!strpos((string) $pref['download_denied'], ".shtml") ||
+						(strpos((string) $pref['download_denied'], "signup.php") && USER == true)
 					))
 					{
 						//	$goUrl = e107::getUrl()->create('download/index')."?action=error&id=1";
@@ -267,7 +267,7 @@ class download_request
 					}
 					else
 					{
-						e107::redirect(trim($pref['download_denied']));
+						e107::redirect(trim((string) $pref['download_denied']));
 						return;
 					}
 				}
@@ -325,7 +325,7 @@ class download_request
 
 	// $image = ($table == "upload" ? $upload_ss : $download_image);
 
-		if(strpos($image, "http") !== false)
+		if(strpos((string) $image, "http") !== false)
 		{
 			e107::redirect($image);
 			exit();

--- a/e107_plugins/download/vendor/shim_http_build_url.php
+++ b/e107_plugins/download/vendor/shim_http_build_url.php
@@ -42,7 +42,7 @@ if (!function_exists('http_build_url'))
 		}
 
 		// Parse the original URL
-		$parse_url = !is_array($url) ? parse_url($url) : $url;
+		$parse_url = !is_array($url) ? parse_url((string) $url) : $url;
 
 		// Scheme and Host are always replaced
 		if (isset($parts['scheme']))

--- a/e107_plugins/faqs/admin_config.php
+++ b/e107_plugins/faqs/admin_config.php
@@ -108,9 +108,9 @@ class faq_cat_ui extends e_admin_ui
 	public function init()
 	{
 		$sql = e107::getDb();
-		
+
 		$this->categories[0] = "(".LAN_ROOT.")";
-		
+
 		if($sql->select('faqs_info','*', 'faq_info_parent = 0 ORDER BY faq_info_title ASC'))
 		{
 			while ($row = $sql->fetch())
@@ -118,9 +118,9 @@ class faq_cat_ui extends e_admin_ui
 				$this->categories[$row['faq_info_id']] = $row['faq_info_title'];
 			}
 		}
-		
+
 		$this->fields['faq_info_parent']['writeParms'] = $this->categories;
-		
+
 		/*
 		if(e_AJAX_REQUEST) // ajax link sorting. 
 		{
@@ -134,8 +134,8 @@ class faq_cat_ui extends e_admin_ui
 					$c++;		
 				}	
 			}
-			
-		
+
+
 			exit;
 		}		
 		*/
@@ -281,7 +281,7 @@ class faq_main_ui extends e_admin_ui
 
 		if(!empty($faqOrder))
 		{
-			list($sortField,$sortASC) = explode("-",$faqOrder);
+			list($sortField,$sortASC) = explode("-",(string) $faqOrder);
 			$this->listOrder = $sortField." ".$sortASC;
 
 			if($sortField != 'faq_order')
@@ -316,7 +316,7 @@ class faq_main_ui extends e_admin_ui
 		// trim spaces
 		if(!empty($new_data['faq_tags']))
 		{
-			$new_data['faq_tags'] = implode(',', array_map('trim', explode(',', $new_data['faq_tags'])));
+			$new_data['faq_tags'] = implode(',', array_map('trim', explode(',', (string) $new_data['faq_tags'])));
 		}
 
 		$new_data['faq_order'] = 0;
@@ -330,7 +330,7 @@ class faq_main_ui extends e_admin_ui
 		// trim spaces
 		if(!empty($new_data['faq_tags']))
 		{
-			$new_data['faq_tags'] = implode(',', array_map('trim', explode(',', $new_data['faq_tags'])));
+			$new_data['faq_tags'] = implode(',', array_map('trim', explode(',', (string) $new_data['faq_tags'])));
 		}
 
 	//	e107::getMessage()->addInfo(print_a($new_data, true));

--- a/e107_plugins/faqs/controllers/e107.list.php
+++ b/e107_plugins/faqs/controllers/e107.list.php
@@ -91,7 +91,7 @@ class plugin_faqs_list_controller extends eControllerFront
 		$prevcat = "";
 		$sc = e107::getScBatch('faqs', true);
 		$sc->counter = 1;
-		$sc->tag = htmlspecialchars($tag, ENT_QUOTES, 'utf-8');
+		$sc->tag = htmlspecialchars((string) $tag, ENT_QUOTES, 'utf-8');
 		$sc->category = $category;
 
 		$text = $tp->parseTemplate($FAQ_START, true, $sc);

--- a/e107_plugins/faqs/e_search.php
+++ b/e107_plugins/faqs/e_search.php
@@ -7,7 +7,7 @@ if (!defined('e107_INIT')) { exit; }
 
 class faqs_search extends e_search // include plugin-folder in the name.
 {
-		
+
 	function config()
 	{	
 		$search = array(
@@ -18,7 +18,7 @@ class faqs_search extends e_search // include plugin-folder in the name.
 		//						'date'	=> array('type'	=> 'date', 		'text' => LAN_DATE_POSTED),
 		//						'author'=> array('type'	=> 'author',	'text' => LAN_SEARCH_61)
 		//					),
-							
+
 			'return_fields'	=> array('t.faq_question','t.faq_answer','t.faq_datestamp','x.faq_info_title','t.faq_id','x.faq_info_id','x.faq_info_title', 'x.faq_info_class','x.faq_info_sef'), 
 			'search_fields'	=> array('t.faq_question'=>1.0, 't.faq_answer'=>1.2, "x.faq_info_title"=>0.6, 't.faq_tags'=> 1.4), // fields and weights. 
 			'order'			=> array('t.faq_question' => 'DESC'),
@@ -39,11 +39,11 @@ class faqs_search extends e_search // include plugin-folder in the name.
 	    $res['link'] 		= $url = e107::url('faqs','category', $row); // e_PLUGIN . "faq/faq.php?cat." . $cat_id . "." . $link_id . "";
 	    $res['pre_title'] 	= $row['faq_info_title'] ? $row['faq_info_title'] .' | ' : "";
 	    $res['title'] 		= $row['faq_question'];
-	    $res['summary'] 	= substr($row['faq_answer'], 0, 100)."....  ";
+	    $res['summary'] 	= substr((string) $row['faq_answer'], 0, 100)."....  ";
 	    $res['detail'] 		= e107::getParser()->toDate($row['faq_datestamp'],'long');
 
 		return $res;
-		
+
 	}
 
 
@@ -57,7 +57,7 @@ class faqs_search extends e_search // include plugin-folder in the name.
 		$tp = e107::getParser();
 
 		$qry = " find_in_set(x.faq_info_class,'".USERCLASS_LIST."') AND ";
-		
+
 		/*
 		if (vartrue($parm['time']) && is_numeric($parm['time'])) 
 		{
@@ -68,10 +68,10 @@ class faqs_search extends e_search // include plugin-folder in the name.
 		{
 			$qry .= " cb_nick LIKE '%".$tp -> toDB($parm['author'])."%' AND";
 		}*/
-		
+
 		return $qry;
 	}
-	
+
 
 }
 // $search_info[]=array( 'sfile' => e_PLUGIN.'faq/search.php', 'qtype' => 'FAQ', 'refpage' => 'faq.php');

--- a/e107_plugins/faqs/faqs.php
+++ b/e107_plugins/faqs/faqs.php
@@ -362,7 +362,7 @@ class faq
 		}
 
 
-		list($orderBy, $ascdesc) = explode('-', vartrue($this->pref['orderby'],'faq_order-ASC'));
+		list($orderBy, $ascdesc) = explode('-', (string) vartrue($this->pref['orderby'],'faq_order-ASC'));
 
 		$query = "SELECT f.*,cat.* FROM #faqs AS f LEFT JOIN #faqs_info AS cat ON f.faq_parent = cat.faq_info_id WHERE cat.faq_info_class IN (".USERCLASS_LIST.") ".$insert." ORDER BY cat.faq_info_order, f.".$orderBy." ".$ascdesc." ";
 		
@@ -382,7 +382,7 @@ class faq
 		$prevcat = "";
 		$sc = e107::getScBatch('faqs', true);
 		$sc->counter = 1;
-		$sc->tag = htmlspecialchars(varset($tag), ENT_QUOTES, 'utf-8');
+		$sc->tag = htmlspecialchars((string) varset($tag), ENT_QUOTES, 'utf-8');
 		$sc->category = varset($category);
 
 		 if(!empty($_GET['id'])) // expand one specific FAQ.
@@ -576,7 +576,7 @@ class faq
 		$sql 	= e107::getDb();
 		$tp 	= e107::getParser();
 		//require_once (e_PLUGIN."faqs/faqs_shortcodes.php");
-		
+
 		$sc = e107::getScBatch('faqs',TRUE);
 
 		$sql->select("faqs", "*", "faq_id='$idx' LIMIT 1");
@@ -605,7 +605,7 @@ class faq
 			$table = "faq";
 			$query = ($pref['nested_comments'] ? "comment_item_id='$idx' AND (comment_type='$table' OR comment_type='3') AND comment_pid='0' ORDER BY comment_datestamp" : "comment_item_id='$idx' AND (comment_type='$table' OR comment_type='3') ORDER BY comment_datestamp");
 			unset($text);
-			
+
 			if (!is_object($sql2))
 			{
 				$sql2 = new db;
@@ -644,7 +644,7 @@ class faq
 	function faq_footer($id='')
 	{
         global $faqpref,$timing_start,$cust_footer, $CUSTOMPAGES, $CUSTOMHEADER, $CUSTOMHEADER;
-        
+
         $tp = e107::getParser();
 
         $text_menu .= "<div style='text-align:center;' ><br />
@@ -653,11 +653,11 @@ class faq
         if(check_class($faqpref['add_faq'])){
                 $text_menu .="[&nbsp;<a href='faqs.php?new.$id'>".LAN_FAQS_ASK_A_QUESTION."</a>&nbsp;]";
         }
-        
+
         $text_menu .="</div>";
 
 		$text_menu .= "<div style='text-align:center'><br />".$tp->parseTemplate("{SEARCH=faqs}")."</div>";
-       	
+
        	return $text_menu;
 
 		// require_once (FOOTERF);
@@ -686,7 +686,7 @@ class faq
 		while ($rw = $sql->fetch())
 		{
 			// list($pfaq_id, $pfaq_parent, $pfaq_question, $pfaq_answer, $pfaq_comment);
-			$rw['faq_question'] = substr($rw['faq_question'], 0, 50)." ... ";
+			$rw['faq_question'] = substr((string) $rw['faq_question'], 0, 50)." ... ";
 
 			$text .= "<tr>
 

--- a/e107_plugins/faqs/faqs_setup.php
+++ b/e107_plugins/faqs/faqs_setup.php
@@ -23,17 +23,17 @@ class faqs_setup
 	{
 		$sql = e107::getDb();
 		$mes = e107::getMessage();
-		
+
 		$query = "INSERT INTO #faqs (`faq_id`, `faq_parent`, `faq_question`, `faq_answer`, `faq_comment`, `faq_datestamp`, `faq_author`, `faq_order`) VALUES 
 			(1, 1, 'What is FAQs?', 'FAQs is a plugin that you can use on your e107 0.8+ website to manage Frequently Asked Questions', 0, 1230918231, 1, 0),
 			(2, 1, 'How can I use e107?', 'You can use e107 if you have a running server with PHP and MySQL installed. Read more about installation requirements.\r\n\r\ne107 is a Content Management System (CMS). You can use it to make consistent web pages. The advantage is you don''t have to write HTML or create CSS files. The programs of e107 take care of all the presentation through the theme. All your entered data is saved into a MySQL database.\r\n\r\ne107 has active plugin and theme resources which grow every day. The software is completely and totally free and always will be, you don''t even need to register anywhere to download it. There are hundreds of content management systems to choose from, if you''re not sure e107 suits your needs, head over to OpenSourceCMS and try a few out.\r\n\r\nWith e107 you are totally in control with a powerful but easy to understand Admin Area and you can add functionalities to your website by adding plugins. e107 has an easy step-by-step installation procedure to install it on your server. ', 0, 0, 1, 1),
 			(3, 1, 'What is a plugin?', 'A plugin is an additional program that integrates with the e107 core system.\r\n\r\nActually plugins are enhancements to the existing system. Some other CMS systems call it extensions, components or modules.\r\n\r\nAlready some core plugins are included in the full install package of e107.\r\n\r\nYou can activate them using Admin > Plugin Manager, and click on Install for the ones you want. They will appear in your Admin Area for configuration.\r\n\r\nThere are all kinds of plugins: small and large, core plugins and third party plugins. There are plugins for all kinds of purposes. ', 0, 123123123, 1, 2);
 		";
-		
+
 		$status = ($sql->gen($query)) ? E_MESSAGE_SUCCESS : E_MESSAGE_ERROR;
 		$mes->add(LAN_DEFAULT_TABLE_DATA.": faqs", $status);
 
-		
+
 		$query2 = "INSERT INTO #faqs_info (`faq_info_id`, `faq_info_title`, `faq_info_about`, `faq_info_parent`, `faq_info_class`, `faq_info_order`, `faq_info_icon`, `faq_info_metad`, `faq_info_metak`) VALUES 
 			(1, 'General', 'General Faqs', 0, 0, 0, '', '', ''),
 			(2, 'Misc', 'Other FAQs', 0, 0, 1, '', '', '');
@@ -46,7 +46,7 @@ class faqs_setup
 /*	
 	function uninstall_options()
 	{
-	
+
 	}
 
 

--- a/e107_plugins/faqs/faqs_shortcodes.php
+++ b/e107_plugins/faqs/faqs_shortcodes.php
@@ -230,28 +230,28 @@ class faqs_shortcodes extends e_shortcode
 	{
 	//	$tp = e107::getParser();
 	//	return $tp->toHTML($this->var['faq_info_title']);
-		
-		
+
+
 		$tp = e107::getParser();
 		$url = e107::url('faqs','category', $this->var); //@See faqs/e_url.php 
 		return "<a href='".$url."'>".$tp->toHTML($this->var['faq_info_title'])."</a>";	
 		/*
 
 		return "<a href='".e107::getUrl()->create('faqs/list/all', array('category' => $this->var['faq_info_id']))."'>".$tp->toHTML($this->var['faq_info_title'])."</a>";	
-		
-		
-		
+
+
+
 		$tp = e107::getParser();
 		if($parm == 'extend' && $this->tag)
 		{
 			return "<a href='".$this->sc_faq_current_tag('url')."'>".$tp->toHTML($this->var['faq_info_title'])." &raquo; ".$this->sc_faq_current_tag('raw')."</a>";
 		}
-		
+
 		if($parm == 'raw')
 		{
 			return $tp->toHTML($this->var['faq_info_title']);	
 		}
-		
+
 		return "<a href='".e107::getUrl()->create('faqs/list/all', array('category' => $this->var['faq_info_id']))."'>".$tp->toHTML($this->var['faq_info_title'])."</a>";	
 	*/
 	}

--- a/e107_plugins/featurebox/admin_config.php
+++ b/e107_plugins/featurebox/admin_config.php
@@ -201,7 +201,7 @@ class fb_category_ui extends e_admin_ui
 			$msg = e107::getMessage();
 			$msg->addError('Layout <strong>'.vartrue($templates[$new_data['fb_category_template']], 'n/a').'</strong> is in use by another category. Layout should be unique per category. ');
 			$msg->addError($mod == 'create' ? LAN_CREATED_FAILED : LAN_UPDATED_FAILED);
-			
+
 			return (!E107_DEBUG_LEVEL); // suppress messages (TRUE) only when not in debug mod
 		}
 		return false;

--- a/e107_plugins/featurebox/e_rss.php
+++ b/e107_plugins/featurebox/e_rss.php
@@ -11,7 +11,7 @@ class featurebox_rss // plugin-folder + '_rss'
 	function config() 
 	{
 		$config = array();
-	
+
 		$config[] = array(
 			'name'			=> LAN_PLUGIN_FEATUREBOX_NAME,
 			'url'			=> 'featurebox',
@@ -20,10 +20,10 @@ class featurebox_rss // plugin-folder + '_rss'
 			'class'			=> '0',
 			'limit'			=> '9'
 		);
-		
+
 		return $config;
 	}
-	
+
 	/**
 	 * Compile RSS Data
 	 * @param $parms array	url, limit, id 
@@ -32,10 +32,10 @@ class featurebox_rss // plugin-folder + '_rss'
 	function data($parms='')
 	{
 		$sql = e107::getDb();
-		
+
 		$rss = array();
 		$i=0;
-					
+
 		if($items = $sql->select('featurebox', "*", "fb_class = '0' LIMIT 0,".$parms['limit']))		
 		{			
 			while($row = $sql->fetch())
@@ -56,10 +56,10 @@ class featurebox_rss // plugin-folder + '_rss'
 			}
 
 		}				
-					
+
 		return $rss;
 	}
-	
+
 }
 
 /* OLD V1 CODE

--- a/e107_plugins/featurebox/e_shortcode.php
+++ b/e107_plugins/featurebox/e_shortcode.php
@@ -86,7 +86,7 @@ class featurebox_shortcodes// must match the plugin's folder name. ie. [PLUGIN_F
 		
 		if(vartrue($tmpl['js']))
 		{		
-			$tmp = explode(',', $tmpl['js']);
+			$tmp = explode(',', (string) $tmpl['js']);
 			
 			foreach($tmp as $file)
 			{

--- a/e107_plugins/featurebox/includes/item.php
+++ b/e107_plugins/featurebox/includes/item.php
@@ -84,7 +84,7 @@ class plugin_featurebox_item extends e_model
 		
 		if(empty($url)) return '';
 
-		parse_str($parm, $parm);
+		parse_str((string) $parm, $parm);
 				
 		if(vartrue($parm['href']))
 		{
@@ -175,7 +175,7 @@ class plugin_featurebox_item extends e_model
 		{
 			return '';
 		}
-		parse_str($parm, $parm);
+		parse_str((string) $parm, $parm);
 		$att = ($parm['aw']) ? "aw=".$parm['aw'] : 'aw=100&ah=60';
 		$src = e107::getParser()->thumbUrl($this->get('fb_image'),$att);
 			

--- a/e107_plugins/featurebox/includes/tree.php
+++ b/e107_plugins/featurebox/includes/tree.php
@@ -40,7 +40,7 @@ class plugin_featurebox_tree extends e_tree_model
 		
 		$order = $this->getParam('random') ? ' ORDER BY rand()' : ' ORDER BY fb_order ASC';
 		$limit = $this->getParam('limit') ? ' LIMIT '.intval($this->getParam('from'), 0).','.intval($this->getParam('limit')) : '';
-		$ids = $this->getParam('ids') ? preg_replace('/[^0-9,]/', '', $this->getParam('ids')) : '';
+		$ids = $this->getParam('ids') ? preg_replace('/[^0-9,]/', '', (string) $this->getParam('ids')) : '';
 		$where = $ids ? ' AND fb_id IN('.$ids.')' : '';
 		$qry = 'SELECT SQL_CALC_FOUND_ROWS * FROM #featurebox WHERE fb_category='.intval($id).' AND fb_class IN('.USERCLASS_LIST.')'.$where.$order.$limit;
 		$this->setParam('db_query', $qry);

--- a/e107_plugins/forum/e_event.php
+++ b/e107_plugins/forum/e_event.php
@@ -43,7 +43,7 @@ class forum_event
 		echo('hola');
 		print_a($data);*/
 		e107::getDb()->update('user_extended', "user_plugin_forum_viewed = NULL WHERE user_extended_id = ".$data['user_id']);
-		
+
 	}
 
 	function forum_eventnewpost($data) // Remove thread id from user_plugin_forum_viewed when a new reply is posted

--- a/e107_plugins/forum/e_list.php
+++ b/e107_plugins/forum/e_list.php
@@ -125,7 +125,7 @@ class list_forum
 					{
 						if($row['thread_lastuser'][0] == "0")
 						{
-							$LASTPOST = substr($row['thread_lastuser'], 2);
+							$LASTPOST = substr((string) $row['thread_lastuser'], 2);
 						}
 						//else
 						//	{

--- a/e107_plugins/forum/e_menu.php
+++ b/e107_plugins/forum/e_menu.php
@@ -12,7 +12,7 @@
 if (!defined('e107_INIT')) { exit; }
 
 //v2.x Standard for extending menu configuration within Menu Manager. (replacement for v1.x config.php)
-	
+
 class forum_menu
 {
 	function __construct()
@@ -37,7 +37,7 @@ class forum_menu
 		$fields['postfix']      = array('title'=> LAN_FORUM_MENU_007, 'type'=>'text', 'writeParms'=>array('size'=>'mini','default' => '...'));
 		$fields['scroll']        = array('title'=> LAN_FORUM_MENU_014, 'type'=>'text', 'writeParms'=>array('size'=>'mini','pattern'=>'[0-9]*'), 'help'=>LAN_FORUM_MENU_015);
 		$fields['layout']       = array('title'=> LAN_TEMPLATE, 'type'=>'dropdown', 'writeParms'=>array('optArray'=>$layouts[0]));
-		
+
         return $fields;
 
 	}

--- a/e107_plugins/forum/forum.php
+++ b/e107_plugins/forum/forum.php
@@ -507,7 +507,7 @@ class forum_front
 
 		if(!empty($forumList['subs']) && is_array($forumList['subs'][$f['forum_id']]))
 		{
-			$lastPost = explode('.', $f['forum_lastpost_info']);
+			$lastPost = explode('.', (string) $f['forum_lastpost_info']);
 			$lastpost_datestamp = reset($lastPost);
 			$ret = $this->parse_subs($forumList, $f['forum_id'], $lastpost_datestamp);
 
@@ -557,7 +557,7 @@ class forum_front
 			$ret['text'] .= "<a href='{$suburl}'>" . $tp->toHTML($sub['forum_name']) . '</a>';
 			$ret['threads'] += $sub['forum_threads'];
 			$ret['replies'] += $sub['forum_replies'];
-			$tmp = explode('.', $sub['forum_lastpost_info']);
+			$tmp = explode('.', (string) $sub['forum_lastpost_info']);
 
 			if($tmp[0] > $lastpost_datestamp)
 			{

--- a/e107_plugins/forum/forum_class.php
+++ b/e107_plugins/forum/forum_class.php
@@ -101,17 +101,17 @@ class e107forum
 		$tp = e107::getParser();
 		$this->userViewed = array();
 		$this->modArray = array();
-		
+
 		if($update === false)
 		{
 			$this->loadPermList();
 		}
-		
+
 		$this->prefs = e107::getPlugConfig('forum');
 		if(!$this->prefs->get('postspage')) {
 			$this->setDefaults();
 		}
-		
+
 		$this->getForumData();
 //		var_dump($this->prefs);
 
@@ -1189,7 +1189,7 @@ class e107forum
 			$tmp = $sql->fetch();
 			if($tmp)
 			{
-				if(trim($tmp['thread_options']) != '')
+				if(trim((string) $tmp['thread_options']) != '')
 				{
 					$tmp['thread_options'] = unserialize($tmp['thread_options']);
 				}
@@ -1346,7 +1346,7 @@ class e107forum
 			$viewed = $tmp['user_plugin_forum_viewed'];
 			unset($tmp);
 		}
-		return explode(',', $viewed);
+		return explode(',', (string) $viewed);
 	}
 
 
@@ -1598,7 +1598,7 @@ class e107forum
 	{
 		global $currentUser;
 
-		$_tmp = preg_split('#\,+#', $currentUser['user_plugin_forum_viewed']);
+		$_tmp = preg_split('#\,+#', (string) $currentUser['user_plugin_forum_viewed']);
 		if(!is_array($threadId)) { $threadId = array($threadId); }
 		foreach($threadId as $tid)
 		{
@@ -1827,7 +1827,7 @@ class e107forum
 		}
 		else
 		{
-			$tmp = explode(".", $post_info['thread_user'], 2);
+			$tmp = explode(".", (string) $post_info['thread_user'], 2);
 			return $tmp[1];
 		}
 	}
@@ -2382,7 +2382,7 @@ class e107forum
 			if($forumInfo['forum_sub'])
 			{
 				$search 	= array('{SUBPARENT_TITLE}', '{SUBPARENT_HREF}');
-				$replace 	= array(ltrim($forumInfo['sub_parent'], '*'), e107::url('forum', 'forum', array('forum_id'=>$forumInfo['forum_sub'],'forum_sef'=>$forumInfo['parent_sef'])));
+				$replace 	= array(ltrim((string) $forumInfo['sub_parent'], '*'), e107::url('forum', 'forum', array('forum_id'=>$forumInfo['forum_sub'],'forum_sef'=>$forumInfo['parent_sef'])));
 				$FORUM_CRUMB['subparent']['value'] = str_replace($search, $replace, $FORUM_CRUMB['subparent']['value']);
 			}
 			else
@@ -2391,7 +2391,7 @@ class e107forum
 			}
 
 			$search 	= array('{FORUM_TITLE}', '{FORUM_HREF}');
-			$replace 	= array(ltrim($forumInfo['forum_name'], '*'), e107::url('forum', 'forum', $forumInfo));
+			$replace 	= array(ltrim((string) $forumInfo['forum_name'], '*'), e107::url('forum', 'forum', $forumInfo));
 			$FORUM_CRUMB['forum']['value'] = str_replace($search, $replace, $FORUM_CRUMB['forum']['value']);
 
 			if(isset($threadInfo['thread_id']))
@@ -2420,12 +2420,12 @@ class e107forum
 
 			if($forumInfo['sub_parent'])
 			{
-				$forum_sub_parent = (substr($forumInfo['sub_parent'], 0, 1) == '*' ? substr($forumInfo['sub_parent'], 1) : $forumInfo['sub_parent']);
+				$forum_sub_parent = (substr((string) $forumInfo['sub_parent'], 0, 1) == '*' ? substr((string) $forumInfo['sub_parent'], 1) : $forumInfo['sub_parent']);
 				$BREADCRUMB .= "<a class='forumlink' href='".e_PLUGIN_ABS."forum/forum_viewforum.php?{$forumInfo['forum_sub']}'>{$forum_sub_parent}</a>".$dfltsep;
 			}
 
 			$tmpFname = $forumInfo['forum_name'];
-			if(substr($tmpFname, 0, 1) == "*") { $tmpFname = substr($tmpFname, 1); }
+			if(substr((string) $tmpFname, 0, 1) == "*") { $tmpFname = substr((string) $tmpFname, 1); }
 
 			if ($forum_href)
 			{
@@ -2435,7 +2435,7 @@ class e107forum
 				$BREADCRUMB .= $tmpFname;
 			}
 
-			if(strlen($thread_title))
+			if(strlen((string) $thread_title))
 			{
 				$BREADCRUMB .= $dfltsep.$thread_title;
 			}
@@ -2454,20 +2454,20 @@ class e107forum
 		
 		if($forumInfo['sub_parent'])
 		{
-				$forum_sub_parent = (substr($forumInfo['sub_parent'], 0, 1) == '*' ? substr($forumInfo['sub_parent'], 1) : $forumInfo['sub_parent']);
+				$forum_sub_parent = (substr((string) $forumInfo['sub_parent'], 0, 1) == '*' ? substr((string) $forumInfo['sub_parent'], 1) : $forumInfo['sub_parent']);
 		}
 		
 		$breadcrumb[]	= array('text'=>$tp->toHTML($forumInfo['parent_name'])		, 'url'=> e107::url('forum', 'index')."#".$frm->name2id($forumInfo['parent_name']));
 	
 		if($forumInfo['forum_sub'])
 		{
-			$breadcrumb[]	= array('text'=> ltrim($forumInfo['sub_parent'], '*')		, 'url'=> e107::url('forum','forum', array('forum_sef'=> $forumInfo['sub_parent_sef'])));
-			$breadcrumb[]	= array('text'=>ltrim($forumInfo['forum_name'], '*')		, 'url'=> (defset('e_PAGE') !='forum_viewforum.php') ? e107::url('forum', 'forum', $forumInfo) : null);
+			$breadcrumb[]	= array('text'=> ltrim((string) $forumInfo['sub_parent'], '*')		, 'url'=> e107::url('forum','forum', array('forum_sef'=> $forumInfo['sub_parent_sef'])));
+			$breadcrumb[]	= array('text'=>ltrim((string) $forumInfo['forum_name'], '*')		, 'url'=> (defset('e_PAGE') !='forum_viewforum.php') ? e107::url('forum', 'forum', $forumInfo) : null);
 
 		}
 		else
 		{
-			$breadcrumb[]	= array('text'=>ltrim($forumInfo['forum_name'], '*')		, 'url'=> (defset('e_PAGE') !='forum_viewforum.php') ? e107::url('forum', 'forum', $forumInfo) : null);
+			$breadcrumb[]	= array('text'=>ltrim((string) $forumInfo['forum_name'], '*')		, 'url'=> (defset('e_PAGE') !='forum_viewforum.php') ? e107::url('forum', 'forum', $forumInfo) : null);
 		}
 
 		if(vartrue($forumInfo['thread_name']))
@@ -2520,7 +2520,7 @@ class e107forum
 			{
 				$sql->delete('polls', 'poll_datestamp='.$threadId);
 			} 
-	
+
 			// decrement user post counts
 			if ($postCount = $this->threadGetUserPostcount($threadId))
 			{
@@ -2557,7 +2557,7 @@ class e107forum
 			{	
 				$sql->delete('forum_track', 'track_thread='.$threadId);
 			}
-			
+
 			// update forum with correct thread/reply counts
 			$sql->update('forum', "forum_threads=GREATEST(forum_threads-1,0), forum_replies=GREATEST(forum_replies-{$threadInfo['thread_total_replies']},0) WHERE forum_id=".$threadInfo['thread_forum_id']);
 

--- a/e107_plugins/forum/forum_mod.php
+++ b/e107_plugins/forum/forum_mod.php
@@ -17,7 +17,7 @@ function forum_thread_moderate($p)
 	$sql = e107::getDb();
 	foreach ($p as $key => $val)
 	{
-		if (preg_match("#(.*?)_(\d+)_x#", $key, $matches))
+		if (preg_match("#(.*?)_(\d+)_x#", (string) $key, $matches))
 		{
 			$act = $matches[1];
 			$id = (int)$matches[2];

--- a/e107_plugins/forum/forum_post.php
+++ b/e107_plugins/forum/forum_post.php
@@ -64,7 +64,7 @@ class forum_post_handler
 		$forum = new e107forum();
 		$this->forumObj = $forum;
 
-		$this->action   = trim($_GET['f']); // action: rp|quote|nt|edit etc.
+		$this->action   = trim((string) $_GET['f']); // action: rp|quote|nt|edit etc.
 		$this->id       = (int) $_GET['id']; // forum thread/topic id.
 		$this->post     = (int) $_GET['post']; // post ID if needed.
 
@@ -687,7 +687,7 @@ class forum_post_handler
 			//$template = str_replace("{".$old."}", "{".$new."}", $template);
 			$reg = '/\{'.$old.'((?:=|:)?[^\}]*)\}/';  // handle variations.
 			$repl = '{'.$new.'$1}';
-			$template = preg_replace($reg,$repl, $template);
+			$template = preg_replace($reg,$repl, (string) $template);
 
 		}
 
@@ -793,9 +793,9 @@ class forum_post_handler
 
 		foreach($fList as $f)
 		{
-			if(substr($f['forum_name'], 0, 1) != '*')
+			if(substr((string) $f['forum_name'], 0, 1) != '*')
 			{
-				$f['sub_parent'] = ltrim($f['sub_parent'], '*');
+				$f['sub_parent'] = ltrim((string) $f['sub_parent'], '*');
 				$for_name = $f['forum_parent'].' &gg; ';
 				$for_name .= ($f['sub_parent'] ? $f['sub_parent'].' &gg; ' : '');
 				$for_name .= $f['forum_name'];
@@ -1142,7 +1142,7 @@ class forum_post_handler
 
 		$fp = new floodprotect;
 
-		if ((isset($_POST['newthread']) && trim($_POST['subject']) == '') || trim($_POST['post']) == '')
+		if ((isset($_POST['newthread']) && trim((string) $_POST['subject']) == '') || trim((string) $_POST['post']) == '')
 		{
 			message_handler('ALERT', 5);
 		}
@@ -1347,7 +1347,7 @@ class forum_post_handler
 		{
 			$newThreadTitle = '['.LAN_FORUM_5021.']';
 		}
-		elseif($posted['rename_thread'] == 'rename' && trim($posted['newtitle']) != '')
+		elseif($posted['rename_thread'] == 'rename' && trim((string) $posted['newtitle']) != '')
 		{
 			$newThreadTitle = $tp->toDB($posted['newtitle']);
 			$newThreadTitleType = 1;
@@ -1495,13 +1495,13 @@ class forum_post_handler
 				$postVals['post_attachments'] = e107::serialize($newValues);
 				// $postVals['post_attachments'] = implode(',', $attachments);
 			}
-			
+
 			//Allows directly overriding the method of adding files (or other data) as attachments
 			if($attachmentsPosted = $this->processAttachmentsPosted($this->data['post_attachments']))
 			{
 				$postVals['post_attachments'] = $attachmentsPosted;
 			}	
-      
+
 			$postVals['post_edit_datestamp']    = time();
 			$postVals['post_edit_user']         = USERID;
 			$postVals['post_entry']             = $_POST['post'];
@@ -1649,7 +1649,7 @@ class forum_post_handler
 						$_thumb = '';
 						$_fname = '';
 						$fpath = '';
-						if(strpos($upload['type'], 'image') !== false)
+						if(strpos((string) $upload['type'], 'image') !== false)
 						{
 							$_type = 'img';
 
@@ -1742,9 +1742,9 @@ class forum_post_handler
 	//Allows directly overriding the method of adding files (or other data) as attachments
 	function processAttachmentsPosted($existingValues = '')
 	{		
-		if(isset($_POST['post_attachments_json']) && trim($_POST['post_attachments_json']))
+		if(isset($_POST['post_attachments_json']) && trim((string) $_POST['post_attachments_json']))
 		{
-			$postedAttachments = json_decode($_POST['post_attachments_json'], true);
+			$postedAttachments = json_decode((string) $_POST['post_attachments_json'], true);
 			$attachmentsJsonErrors = json_last_error();
 			if($attachmentsJsonErrors === JSON_ERROR_NONE)
 			{

--- a/e107_plugins/forum/forum_setup.php
+++ b/e107_plugins/forum/forum_setup.php
@@ -95,7 +95,7 @@ class forum_setup
 		{
 			e107::getRedirect()->go(e_PLUGIN_ABS.'forum/forum_update.php'); //Redirect upgrade to customized upgrade routine
 		}
-		
+
 		//header('Location: '.e_PLUGIN.'forum/forum_update.php');
 	}
 

--- a/e107_plugins/forum/forum_stats.php
+++ b/e107_plugins/forum/forum_stats.php
@@ -277,7 +277,7 @@ class forumStats
 			}
 			else
 			{
-				$tmp = explode(chr(1), $ma['thread_anon']);
+				$tmp = explode(chr(1), (string) $ma['thread_anon']);
 				$uinfo = $tp->toHTML($tmp[0]);
 			}
 
@@ -326,7 +326,7 @@ class forumStats
 			}
 			else
 			{
-				$tmp = explode(chr(1), $ma['thread_anon']);
+				$tmp = explode(chr(1), (string) $ma['thread_anon']);
 				$uinfo = $tp->toHTML($tmp[0]);
 			}
 

--- a/e107_plugins/forum/forum_update.php
+++ b/e107_plugins/forum/forum_update.php
@@ -340,9 +340,9 @@ function step4()
 	$old_prefs = array();
 	foreach($pref as $k => $v)
 	{
-		if(substr($k, 0, 6) == 'forum_')
+		if(substr((string) $k, 0, 6) == 'forum_')
 		{
-			$nk = substr($k, 6);
+			$nk = substr((string) $k, 6);
 			$mes->addDebug("Converting $k to $nk");
 			$old_prefs[$nk] = $v;
 			$coreConfig->remove($k);
@@ -391,7 +391,7 @@ function step4()
 			$userId = (int) $row['user_id'];
 
 			$viewed = $row['user_viewed'];
-			$viewed = trim($viewed, '.');
+			$viewed = trim((string) $viewed, '.');
 			$tmp = preg_split('#\.+#', $viewed);
 			$viewed = implode(',', $tmp);
 
@@ -933,7 +933,7 @@ function step10_ajax()//TODO
 
 			//	if (preg_match_all('#\[link=(.*?)\]\[img.*?\]({e_FILE}.*?)\[/img\]\[/link\]#ms', $post['post_entry'], $matches, PREG_SET_ORDER))
 
-			if(preg_match_all('#\[link=([^\]]*?)\]\s*?\[img.*?\](({e_FILE}|e107_files|\.\./\.\./e107_files)[^\]]*)\[/img\]\s*?\[/link\]#ms', $post['post_entry'], $matches, PREG_SET_ORDER))
+			if(preg_match_all('#\[link=([^\]]*?)\]\s*?\[img.*?\](({e_FILE}|e107_files|\.\./\.\./e107_files)[^\]]*)\[/img\]\s*?\[/link\]#ms', (string) $post['post_entry'], $matches, PREG_SET_ORDER))
 			{
 				foreach($matches as $match)
 				{
@@ -950,7 +950,7 @@ function step10_ajax()//TODO
 				}
 			}
 
-			if(preg_match_all('#\[lightbox=([^\]]*?)\]\s*?\[img.*?\](({e_FILE}|e107_files|\.\./\.\./e107_files)[^\]]*)\[/img\]\s*?\[/lightbox\]#ms', $post['post_entry'], $matches, PREG_SET_ORDER))
+			if(preg_match_all('#\[lightbox=([^\]]*?)\]\s*?\[img.*?\](({e_FILE}|e107_files|\.\./\.\./e107_files)[^\]]*)\[/img\]\s*?\[/lightbox\]#ms', (string) $post['post_entry'], $matches, PREG_SET_ORDER))
 			{
 				foreach($matches as $match)
 				{
@@ -993,7 +993,7 @@ function step10_ajax()//TODO
 			;
 
 			//	if (preg_match_all('#\[img.*?\]({e_FILE}.*?_FT\d+_.*?)\[/img\]#ms', $post['post_entry'], $matches, PREG_SET_ORDER))
-			if(preg_match_all('#\[img[^\]]*?\]\s*?(({e_FILE}|e107_files|\.\./\.\./e107_files)[^\[]*)\s*?\[/img\]#ms', $post['post_entry'], $matches, PREG_SET_ORDER))
+			if(preg_match_all('#\[img[^\]]*?\]\s*?(({e_FILE}|e107_files|\.\./\.\./e107_files)[^\[]*)\s*?\[/img\]#ms', (string) $post['post_entry'], $matches, PREG_SET_ORDER))
 			{
 				foreach($matches as $match)
 				{
@@ -1038,7 +1038,7 @@ function step10_ajax()//TODO
 
 
 			//	if (preg_match_all('#\[file=({e_FILE}.*?)\](.*?)\[/file\]#ms', $post['post_entry'], $matches, PREG_SET_ORDER))
-			if(preg_match_all('#\[file=(({e_FILE}|e107_files|\.\./\.\./e107_files)[^\]]*)#ms', $post['post_entry'], $matches, PREG_SET_ORDER))
+			if(preg_match_all('#\[file=(({e_FILE}|e107_files|\.\./\.\./e107_files)[^\]]*)#ms', (string) $post['post_entry'], $matches, PREG_SET_ORDER))
 			{
 				foreach($matches as $match)
 				{
@@ -1523,8 +1523,8 @@ class forumUpgrade
 		 * thread_sef
 		 */
 
-		$detected = mb_detect_encoding($post['thread_name']); // 'ISO-8859-1'
-		$threadName = iconv($detected, 'UTF-8', $post['thread_name']);
+		$detected = mb_detect_encoding((string) $post['thread_name']); // 'ISO-8859-1'
+		$threadName = iconv($detected, 'UTF-8', (string) $post['thread_name']);
 
 		$thread = array();
 		$thread['thread_id'] = $post['thread_id'];
@@ -1579,7 +1579,7 @@ class forumUpgrade
 			return 0;
 		}
 
-		list($num, $name) = explode(".", $string, 2);
+		list($num, $name) = explode(".", (string) $string, 2);
 
 		return intval($num);
 
@@ -1591,8 +1591,8 @@ class forumUpgrade
 
 		global $forum;
 
-		$detected = mb_detect_encoding($post['thread_thread']); // 'ISO-8859-1'
-		$postEntry = iconv($detected, 'UTF-8', $post['thread_thread']);
+		$detected = mb_detect_encoding((string) $post['thread_thread']); // 'ISO-8859-1'
+		$postEntry = iconv($detected, 'UTF-8', (string) $post['thread_thread']);
 
 		$newPost = array();
 		$newPost['post_id'] = $post['thread_id'];
@@ -1630,7 +1630,7 @@ class forumUpgrade
 	function getUserInfo($info)
 	{
 
-		$tmp = explode('.', $info);
+		$tmp = explode('.', (string) $info);
 		$id = (int) $tmp[0];
 
 		// Set default values
@@ -1641,9 +1641,9 @@ class forumUpgrade
 		);
 
 		// Check if post is done anonymously (ID = 0, and there should be a chr(1) value between the username and IP address)
-		if(strpos($info, chr(1)) !== false && $id == 0)
+		if(strpos((string) $info, chr(1)) !== false && $id == 0)
 		{
-			$anon = explode(chr(1), $info);
+			$anon = explode(chr(1), (string) $info);
 			$anon_name = explode('.', $anon[0]);
 
 			$ret['anon_name'] = $anon_name[1];
@@ -1729,8 +1729,8 @@ class forumUpgrade
 		$oldThumb = '';
 		if($attachment['thumb'])
 		{
-			$tmp = explode('/', $attachment['thumb']);
-			$fileInfo = pathinfo($attachment['thumb']);
+			$tmp = explode('/', (string) $attachment['thumb']);
+			$fileInfo = pathinfo((string) $attachment['thumb']);
 
 			$oldThumb = str_replace('{e_FILE}', e_FILE, $attachment['thumb']);
 			//			$newThumb 	= e_PLUGIN.'forum/attachments/thumb/'.$tmp[1];

--- a/e107_plugins/forum/forum_uploads.php
+++ b/e107_plugins/forum/forum_uploads.php
@@ -30,7 +30,7 @@ if(!empty($_POST['delete']) && is_array($_POST['delete']))
 {
 	foreach(array_keys($_POST['delete']) as $fname)
 	{
-		$f = explode("_", $fname);
+		$f = explode("_", (string) $fname);
 		if($f[1] == USERID)
 		{
 			$path = e_UPLOAD.e107::getParser()->filter($fname,'w');
@@ -82,7 +82,7 @@ if(is_array($fileList))
 			{
 				foreach($threadList as $tinfo)
 				{
-					if(strpos($tinfo['thread_thread'], $finfo['fname']) != FALSE)
+					if(strpos((string) $tinfo['thread_thread'], (string) $finfo['fname']) != FALSE)
 					{
 						$found = $tinfo;
 						break;

--- a/e107_plugins/forum/forum_viewforum.php
+++ b/e107_plugins/forum/forum_viewforum.php
@@ -218,7 +218,7 @@ function init()
 	$forumInfo['forum_name'] = $tp->toHTML($forumInfo['forum_name'], true, 'no_hook, emotes_off');
 	$forumInfo['forum_description'] = $tp->toHTML($forumInfo['forum_description'], true, 'no_hook');
 
-	$_forum_name = (substr($forumInfo['forum_name'], 0, 1) == '*' ? substr($forumInfo['forum_name'], 1) : $forumInfo['forum_name']);
+	$_forum_name = (substr((string) $forumInfo['forum_name'], 0, 1) == '*' ? substr((string) $forumInfo['forum_name'], 1) : $forumInfo['forum_name']);
 
 	e107::title($_forum_name . ' / ' . LAN_FORUM_1001);
 	// define('e_PAGETITLE', $_forum_name . ' / ' . LAN_FORUM_1001);
@@ -294,7 +294,7 @@ function init()
 
 	if($pages)
 	{
-		if(strpos($FORUM_VIEW_START, 'THREADPAGES') !== false || strpos($FORUM_VIEW_END, 'THREADPAGES') !== false)
+		if(strpos((string) $FORUM_VIEW_START, 'THREADPAGES') !== false || strpos((string) $FORUM_VIEW_END, 'THREADPAGES') !== false)
 		{
 			// issue #3087 url need to be decoded first (because the [FROM] get's encoded in url())
 			// and to encode the full url to not loose the id param when being used in the $forumSCvars['parms']
@@ -311,9 +311,9 @@ function init()
 	}
 
 //XXX  What is this?
-	if(!empty($forumInfo['forum_name']) && (substr($forumInfo['forum_name'], 0, 1) == '*'))
+	if(!empty($forumInfo['forum_name']) && (substr((string) $forumInfo['forum_name'], 0, 1) == '*'))
 	{
-		$forum_info['forum_name'] = substr($forum_info['forum_name'], 1);
+		$forum_info['forum_name'] = substr((string) $forum_info['forum_name'], 1);
 		$container_only = true;
 	}
 	else
@@ -321,9 +321,9 @@ function init()
 		$container_only = false;
 	}
 
-	if(!empty($forum_info['sub_parent']) && (substr($forum_info['sub_parent'], 0, 1) == '*'))
+	if(!empty($forum_info['sub_parent']) && (substr((string) $forum_info['sub_parent'], 0, 1) == '*'))
 	{
-		$forum_info['sub_parent'] = substr($forum_info['sub_parent'], 1);
+		$forum_info['sub_parent'] = substr((string) $forum_info['sub_parent'], 1);
 	}
 
 //----$forum->set_crumb(true, '', $fVars); // set $BREADCRUMB (and $BACKLINK)
@@ -494,12 +494,12 @@ function init()
 		}
 
 
-		if(substr($_TEMPLATE, 0, 4) == '<tr>') // Inject id into table row. //XXX Find a better way to do this without placing in template. .
+		if(substr((string) $_TEMPLATE, 0, 4) == '<tr>') // Inject id into table row. //XXX Find a better way to do this without placing in template. .
 		{
 
 			$threadId = $thread_info['thread_id'];
 
-			$_TEMPLATE = "<tr id='thread-{$threadId}'>" . substr($_TEMPLATE, 4);
+			$_TEMPLATE = "<tr id='thread-{$threadId}'>" . substr((string) $_TEMPLATE, 4);
 		}
 
 		return $tp->parseTemplate($_TEMPLATE, true, $sc);

--- a/e107_plugins/forum/forum_viewtopic.php
+++ b/e107_plugins/forum/forum_viewtopic.php
@@ -362,7 +362,7 @@ $forumstring = $forstr . $forthr . vartrue($forrep) . $forend;
 
 //If last post came after USERLV and not yet marked as read, mark the thread id as read
 //---- Orphan $currentUser???
-$threadsViewed = explode(',', $currentUser['user_plugin_forum_viewed']);
+$threadsViewed = explode(',', (string) $currentUser['user_plugin_forum_viewed']);
 
 if ($thread->threadInfo['thread_lastpost'] > defset('USERLV') && !in_array($thread->threadId, $threadsViewed))
 {
@@ -473,7 +473,7 @@ function forumjump()
 function rpg($user_join, $user_forums)
 {
 	global $FORUMTHREADSTYLE;
-	if (strpos($FORUMTHREADSTYLE, '{RPG}') === false)
+	if (strpos((string) $FORUMTHREADSTYLE, '{RPG}') === false)
 	{
 		return '';
 	}
@@ -688,7 +688,7 @@ class e107ForumThread
 			return;
 		}
 
-		$function = trim($_GET['f']);
+		$function = trim((string) $_GET['f']);
 		switch ($function)
 		{
 			case 'post':

--- a/e107_plugins/forum/languages/English/English_front.php
+++ b/e107_plugins/forum/languages/English/English_front.php
@@ -451,9 +451,9 @@ define("FORLAN_104", "Thread not found");
 define("FORLAN_105", "Moderator: Split");
 define("FORLAN_BY", "by");
 define("FORLAN_HIDDEN", "HIDDEN - LOGIN AND REPLY TO REVEAL");	
-	
+
 define("LAN_06", "Joined");	
-	
+
 define("LAN_30", "Welcome");
 define("LAN_31", "There are no new posts ");
 define("LAN_32", "There is 1 new post ");
@@ -498,37 +498,37 @@ define("LAN_398", "Closed");
 define("LAN_399", "Restricted");
 define("LAN_400", "This forum can only be browsed by registered members");
 define("LAN_401", "Members only");
-	
+
 define("LAN_402", "This forum is read only");
-	
+
 define("LAN_403", "No posts yet");
 define("LAN_404", "posts");
 
-	
+
 define("LAN_406", "This forum is restricted to administrators only");
 define("LAN_407", "This forum is restricted to members only");
 define("LAN_408", "This is a read-only forum");
 define("LAN_409", "This is a class restricted forum");
 define("LAN_410", "Welcome guest");
-	
+
 define("LAN_411", "thread");
 define("LAN_412", "reply");
 define("LAN_413", "threads");
 define("LAN_414", "replies");
 define("LAN_415", "user is browsing the forums at the moment");
 define("LAN_416", "users are browsing the forums at the moment");
-	
+
 define("LAN_417", "member");
 define("LAN_418", "guest");
 define("LAN_419", "members");
 define("LAN_420", "guests");
-	
+
 define("LAN_421", "Show new posts");
 define("LAN_422", "New posts since your last visit");
 define("LAN_423", "Posted by");
 define("LAN_424", "New threads");
 define("LAN_425", "Re:");
-	
+
 //v.616
 define("LAN_426", "Who"s Online: ");
 define("LAN_427", "View detailed list.");
@@ -541,7 +541,7 @@ define("LAN_433", "Forum Rules");
 define("LAN_434", "Return to forums");
 define("LAN_435", "My Profile");
 define("LAN_436", " (Will open a new window.)");
-	
+
 define("LAN_437", "register");
 define("LAN_438", "and login.");
 define("LAN_439", "here");
@@ -552,7 +552,7 @@ define("LAN_441", "View forum statistics");
 define("FORLAN_21", "Threads");
 define("FORLAN_22", "Last Post");
 define("FORLAN_23", "Poll");
-	
+
 define("FORLAN_441", "No rules defined.");
 define("FORLAN_442", "My Uploads");
 define("FORLAN_443", "[user deleted]");

--- a/e107_plugins/forum/shortcodes/batch/forum_shortcodes.php
+++ b/e107_plugins/forum/shortcodes/batch/forum_shortcodes.php
@@ -178,7 +178,7 @@ class forum_shortcodes extends e_shortcode
 			    foreach(array_keys($listuserson) as $uinfo)
 			//	foreach($listuserson as $uinfo => &$pinfo)
 				{
-					list($oid, $oname) = explode(".", $uinfo, 2);
+					list($oid, $oname) = explode(".", (string) $uinfo, 2);
 					$c ++;
 					$text .= "<a href='".e_HTTP."user.php?id.$oid'>$oname</a>".($c == MEMBERS_ONLINE ? "." :", ");
 				}
@@ -250,7 +250,7 @@ class forum_shortcodes extends e_shortcode
 
 			if(defined('USERVIEWED') && defset('USERVIEWED') != "")
 			{
-				$tmp = explode(".", USERVIEWED); // List of numbers, separated by single period
+				$tmp = explode(".", (string) USERVIEWED); // List of numbers, separated by single period
 				$total_read_threads = count($tmp);
 			}
 			/*
@@ -433,9 +433,9 @@ class forum_shortcodes extends e_shortcode
 
 	function sc_forumname($parm = null)
 	{
-		if(substr($this->var['forum_name'], 0, 1) == '*')
+		if(substr((string) $this->var['forum_name'], 0, 1) == '*')
 		{
-			$this->var['forum_name'] = substr($this->var['forum_name'], 1);
+			$this->var['forum_name'] = substr((string) $this->var['forum_name'], 1);
 		}
 
 		$this->var['forum_name'] = e107::getParser()->toHTML($this->var['forum_name'], true, 'no_hook');
@@ -523,7 +523,7 @@ class forum_shortcodes extends e_shortcode
 
 		global $forum;
 
-		list($lastpost_datestamp, $lastpost_thread) = explode('.', $this->var['forum_lastpost_info']);
+		list($lastpost_datestamp, $lastpost_thread) = explode('.', (string) $this->var['forum_lastpost_info']);
 
 		// e107::getDebug()->log($this->var);
 
@@ -575,7 +575,7 @@ class forum_shortcodes extends e_shortcode
 
 		$datestamp = !empty($this->var['thread_lastpost']) ? $this->gen->convert_date($this->var['thread_lastpost'], 'forum') : '';
 
-  
+
 		if(!empty($this->var['user_name']))
 		{
 			return $author_name.'<br />'.$datestamp;

--- a/e107_plugins/forum/shortcodes/batch/post_shortcodes.php
+++ b/e107_plugins/forum/shortcodes/batch/post_shortcodes.php
@@ -203,7 +203,7 @@ class plugin_forum_post_shortcodes extends e_shortcode
 		}
 		elseif($this->var['action'] == 'quote')
 		{
-			$post = preg_replace('#\[hide].*?\[/hide]#s', '', trim($this->var['post_entry']));
+			$post = preg_replace('#\[hide].*?\[/hide]#s', '', trim((string) $this->var['post_entry']));
 			$quoteName = ($this->var['user_name'] ? $this->var['user_name'] : $this->var['post_user_anon']);
 			$text = $tp->toText("[quote={$quoteName}]\n".$post."\n[/quote]\n",true);
 			$text .= "\n\n";
@@ -374,10 +374,10 @@ class plugin_forum_post_shortcodes extends e_shortcode
 		$text = "
 		<ul class='nav nav-tabs'>
 		<li class='active'><a href='#type' data-toggle='tab' data-bs-toggle='tab'>".LAN_FORUM_3025."</a></li>";
-		
+
 		$text .= ($poll) ? "<li><a href='#poll' data-toggle='tab' data-bs-toggle='tab'>".LAN_FORUM_1016."</a></li>\n" : "";
 		$text .= ($attach) ? "<li><a href='#attach' data-toggle='tab' data-bs-toggle='tab'>".LAN_FORUM_3012."</a></li>\n" : "";
-		
+
 		$text .= "
 		</ul>
 				<div class='tab-content text-left'>
@@ -390,15 +390,15 @@ class plugin_forum_post_shortcodes extends e_shortcode
 						</div>
 					</div>
 				";
-				
+
 		if($poll)
 		{
 			$text .= "<div class='tab-pane' id='poll'>
 						".$poll."
 					</div>";	
-			
+
 		}
-					
+
 		if($attach)
 		{
 			$text .= "
@@ -406,11 +406,11 @@ class plugin_forum_post_shortcodes extends e_shortcode
 						".$attach."
 					</div>";	
 		}			
-										
+
 		$text .= "			
 		</div>";
-		
-			
+
+
 		return $text;*/
 		
 		

--- a/e107_plugins/forum/shortcodes/batch/view_shortcodes.php
+++ b/e107_plugins/forum/shortcodes/batch/view_shortcodes.php
@@ -277,9 +277,9 @@ class plugin_forum_view_shortcodes extends e_shortcode
 	function sc_forum_name($parm = null)
 	{
 
-		if(substr($this->var['forum_name'], 0, 1) === '*')
+		if(substr((string) $this->var['forum_name'], 0, 1) === '*')
 		{
-			$this->var['forum_name'] = substr($this->var['forum_name'], 1);
+			$this->var['forum_name'] = substr((string) $this->var['forum_name'], 1);
 		}
 
 		$this->var['forum_name'] = e107::getParser()->toHTML($this->var['forum_name'], true, 'no_hook');
@@ -442,7 +442,7 @@ class plugin_forum_view_shortcodes extends e_shortcode
 					}
 					else
 					{
-						list($date, $user, $name) = explode("_", $file, 3);
+						list($date, $user, $name) = explode("_", (string) $file, 3);
 					}
 
 					switch($type)
@@ -1354,7 +1354,7 @@ class plugin_forum_view_shortcodes extends e_shortcode
 							<input type='submit' data-token='" . e_TOKEN . "' data-forum-insert='" . $ajaxInsert . "' data-forum-post='" . $this->var['thread_forum_id'] . "' data-forum-thread='" . $this->var['thread_id'] . "' data-forum-action='quickreply' name='reply' value='" . LAN_FORUM_2007 . "' class='btn btn-success button' />
 							<input type='hidden' name='thread_id' value='" . $this->var['thread_id'] . "' />
 						</div>
-	
+
 						</form>";
 				}
 				else
@@ -1371,7 +1371,7 @@ class plugin_forum_view_shortcodes extends e_shortcode
 							<input type='submit' data-token='" . e_TOKEN . "' data-forum-insert='" . $ajaxInsert . "' data-forum-post='" . $this->var['thread_forum_id'] . "' data-forum-thread='" . $this->var['thread_id'] . "' data-forum-action='quickreply' name='reply' value='" . LAN_FORUM_2006 . "' class='btn btn-success button' />
 							<input type='hidden' name='thread_id' value='" . $this->var['thread_id'] . "' />
 						</div>
-	
+
 						</form>";
 
 					return $text;

--- a/e107_plugins/forum/shortcodes/batch/viewforum_shortcodes.php
+++ b/e107_plugins/forum/shortcodes/batch/viewforum_shortcodes.php
@@ -122,7 +122,7 @@
 			</button>
 		    	<ul class="dropdown-menu pull-right float-right dropdown-menu-end">
 		    	';
-			
+
 			//--	foreach($jumpList as $key => $val)
 			foreach($jumpList as $val)
 			{
@@ -508,7 +508,7 @@
 			if($this->var['forum_lastpost_info'])
 			{
 				//	global $gen;
-				$tmp = explode('.', $this->var['forum_lastpost_info']);
+				$tmp = explode('.', (string) $this->var['forum_lastpost_info']);
 			//	$lp_url = e107::getUrl()->create('forum/thread/last', array('id' => $tmp[1]));
 				$lp_url = $threadUrl = e107::url('forum','topic',$this->var, array('query'=>array('last'=>1)));
 

--- a/e107_plugins/forum/templates/forum_viewforum_template.php
+++ b/e107_plugins/forum/templates/forum_viewforum_template.php
@@ -298,7 +298,7 @@ $FORUM_VIEWFORUM_TEMPLATE['header'] 			= "<div class=' row-fluid'><div>{BREADCRU
 													<col class='hidden-xs' style='width:8%' />
 													<col class='hidden-xs' style='width:20%' />
 													</colgroup>
-												
+
 													{SUBFORUMS}";
 
 

--- a/e107_plugins/gallery/admin_gallery.php
+++ b/e107_plugins/gallery/admin_gallery.php
@@ -562,7 +562,7 @@ class gallery_cat_admin_ui extends e_admin_ui
 		$cats = array();
 		foreach($categories as $k => $var)
 		{
-			$id = preg_replace("/[^0-9]/", '', $k);
+			$id = preg_replace("/[^0-9]/", '', (string) $k);
 			$cats[$id] = $var['media_cat_title'];
 		}
 

--- a/e107_plugins/gallery/shortcodes/batch/gallery_shortcodes.php
+++ b/e107_plugins/gallery/shortcodes/batch/gallery_shortcodes.php
@@ -10,16 +10,16 @@ if (!defined('e107_INIT')) { exit; }
 
 /*
 // SEE e_shortcode.php instead. 
-  
- 
+
+
 class gallery_shortcodes extends e_shortcode
 {
-	
+
 	public $total = 0;
 	public $amount = 3;
 	public $from = 0;
 	public $curCat = null;
-			
+
 	function sc_gallery_caption($parm='')
 	{
 		$tp = e107::getParser();
@@ -28,7 +28,7 @@ class gallery_shortcodes extends e_shortcode
 		$text .= "</a>";
 		return $text;
 	}
-	
+
 	function sc_gallery_thumb($parm='')
 	{
 		$tp = e107::getParser();
@@ -38,7 +38,7 @@ class gallery_shortcodes extends e_shortcode
 		$text .= "</a>";
 		return $text;	
 	}
-	
+
 	function sc_gallery_cat_title($parm='')
 	{
 		$tp = e107::getParser();
@@ -47,7 +47,7 @@ class gallery_shortcodes extends e_shortcode
 		$text .= "</a>";
 		return $text;	
 	}
-	
+
 	function sc_gallery_cat_thumb($parm='')
 	{
 		$att = ($parm) ?$parm : 'aw=190&ah=150';
@@ -56,7 +56,7 @@ class gallery_shortcodes extends e_shortcode
 		$text .= "</a>";
 		return $text;		
 	}
-	
+
 	function sc_gallery_nextprev($parm='')
 	{
 		$url = e_SELF."?cat=".$this->curCat."--AMP--frm=--FROM--";
@@ -64,7 +64,7 @@ class gallery_shortcodes extends e_shortcode
 		$text .= e107::getParser()->parseTemplate("{NEXTPREV=".$parm."}");
 		return $text;	
 	}
-	
-	
+
+
 }
 */

--- a/e107_plugins/gsitemap/admin_config.php
+++ b/e107_plugins/gsitemap/admin_config.php
@@ -26,18 +26,18 @@ class gsitemap_adminArea extends e_admin_dispatcher
 {
 
 	protected $modes = array(	
-	
+
 		'main'	=> array(
 			'controller' 	=> 'gsitemap_ui',
 			'path' 			=> null,
 			'ui' 			=> 'gsitemap_form_ui',
 			'uipath' 		=> null
 		),
-		
+
 
 	);	
-	
-	
+
+
 	protected $adminMenu = array(
 
 		'main/list'			=> array('caption'=> 'LAN_MANAGE', 'perm' => 'P'),
@@ -46,23 +46,23 @@ class gsitemap_adminArea extends e_admin_dispatcher
 		// 'main/div0'        => array('divider'=> true),
 		 'main/import'		=> array('caption'=> 'LAN_IMPORT', 'perm' => 'P'),
 		 'main/instructions' => array('caption'=> 'GSLAN_53', 'perm' => 'P', 'icon'=>'fa-info-circle'),
-		
+
 	);
 
 	protected $adminMenuAliases = array(
 		'main/edit'	=> 'main/list'				
 	);	
-	
+
 	protected $menuTitle = 'LAN_PLUGIN_GSITEMAP_NAME';
 }
 
 
 
 
-				
+
 class gsitemap_ui extends e_admin_ui
 {
-			
+
 		protected $pluginTitle		= 'LAN_PLUGIN_GSITEMAP_NAME';
 		protected $pluginName		= 'gsitemap';
 	//	protected $eventName		= 'gsitemap-gsitemap'; // remove comment to enable event triggers in admin. 		
@@ -78,11 +78,11 @@ class gsitemap_ui extends e_admin_ui
 	//	protected $treePrefix      = 'somefield_title';
 
 		protected $tabs				= array(LAN_GENERAL,LAN_ADVANCED); // Use 'tab'=>0  OR 'tab'=>1 in the $fields below to enable.
-		
+
 	//	protected $listQry      	= "SELECT * FROM `#tableName` WHERE field != '' "; // Example Custom Query. LEFT JOINS allowed. Should be without any Order or Limit.
-	
+
 		protected $listOrder		= 'gsitemap_id DESC';
-	
+
 		protected $fields 		= array (
 			'checkboxes'              => array (  'title' => '',  'type' => null,  'data' => null,  'width' => '5%',  'thclass' => 'center',  'forced' => true,  'class' => 'center',  'toggle' => 'e-multiselect',  'readParms' =>  array (),  'writeParms' =>  array (),),
 			'gsitemap_id'             => array (  'title' => 'LAN_ID',  'type'=>'number', 'data' => 'int',  'width' => '5%',  'help' => '',  'readParms' =>  array (),  'writeParms' =>  array (),  'class' => 'left',  'thclass' => 'left',),
@@ -99,9 +99,9 @@ class gsitemap_ui extends e_admin_ui
 			'gsitemap_active'         => array (  'title' => LAN_VISIBILITY,  'type' => 'userclass',  'data' => 'int',  'width' => 'auto',  'filter' => true,  'help' => '',  'readParms' =>  array (),  'writeParms' =>  array (),  'class' => 'left',  'thclass' => 'left',),
 			'options'                 => array (  'title' => LAN_OPTIONS,  'type' => null,  'data' => null,  'width' => '10%',  'thclass' => 'center last',  'class' => 'center last',  'forced' => true,  'readParms' =>  array (),  'writeParms' =>  array (),),
 		);		
-		
+
 		protected $fieldpref = array('gsitemap_name','gsitemap_url','gsitemap_lastmod','gsitemap_freq','gsitemap_priority');
-		
+
 
 	//	protected $preftabs        = array('General', 'Other' );
 		protected $prefs = array(
@@ -118,7 +118,7 @@ class gsitemap_ui extends e_admin_ui
 												"never"		=>	LAN_NEVER
 											);
 
-	
+
 		public function init()
 		{
 			// This code may be removed once plugin development is complete. 
@@ -126,7 +126,7 @@ class gsitemap_ui extends e_admin_ui
 			{
 				e107::getMessage()->addWarning("This plugin is not yet installed. Saving and loading of preference or table data will fail.");
 			}
-			
+
 			// Set drop-down values (if any). 
 			$this->fields['gsitemap_table']['writeParms']['optArray'] = array('gsitemap_table_0','gsitemap_table_1', 'gsitemap_table_2'); // Example Drop-down array. 
 			$this->fields['gsitemap_cat']['writeParms']['optArray'] = array('gsitemap_cat_0','gsitemap_cat_1', 'gsitemap_cat_2'); // Example Drop-down array. 
@@ -145,12 +145,12 @@ class gsitemap_ui extends e_admin_ui
 	 */
 
 		// ------- Customize Create --------
-		
+
 		public function beforeCreate($new_data,$old_data)
 		{
 			return $new_data;
 		}
-	
+
 		public function afterCreate($new_data, $old_data, $id)
 		{
 			// do something
@@ -160,10 +160,10 @@ class gsitemap_ui extends e_admin_ui
 		{
 			// do something		
 		}		
-		
-		
+
+
 		// ------- Customize Update --------
-		
+
 		public function beforeUpdate($new_data, $old_data, $id)
 		{
 			return $new_data;
@@ -173,12 +173,12 @@ class gsitemap_ui extends e_admin_ui
 		{
 			// do something	
 		}
-		
+
 		public function onUpdateError($new_data, $old_data, $id)
 		{
 			// do something		
 		}		
-		
+
 		// left-panel help menu area. (replaces e_help.php used in old plugins)
 		public function renderHelp()
 		{
@@ -334,9 +334,9 @@ class gsitemap_ui extends e_admin_ui
 			}
 
 			$text.="</select>&nbsp;&nbsp;&nbsp;".GSLAN_10."
-	
-		
-			
+
+
+
 			<select class='tbox' name='import_freq' >\n";
 			foreach($this->freqList as $k=>$fq)
 			{
@@ -345,9 +345,9 @@ class gsitemap_ui extends e_admin_ui
 			}
 
 			$text .= "</select> <br /><br />
-	
+
 			</div>
-			
+
 			</td>
 			</tr>
 			</tbody>
@@ -422,7 +422,7 @@ $text = "
 			return $text;
 
 		}
-			
+
 	/*	
 		// optional - a custom page.  
 		public function customPage()
@@ -430,11 +430,11 @@ $text = "
 			$text = 'Hello World!';
 			$otherField  = $this->getController()->getFieldVar('other_field_name');
 			return $text;
-			
-		}
-		
 
-	
+		}
+
+
+
 	 // Handle batch options as defined in gsitemap_form_ui::gsitemap_lastmod;  'handle' + action + field + 'Batch'
 	 // @important $fields['gsitemap_lastmod']['batch'] must be true for this method to be detected. 
 	 // @param $selected
@@ -461,7 +461,7 @@ $text = "
 
 	}
 
-	
+
 	 // Handle batch options as defined in gsitemap_form_ui::gsitemap_freq;  'handle' + action + field + 'Batch'
 	 // @important $fields['gsitemap_freq']['batch'] must be true for this method to be detected. 
 	 // @param $selected
@@ -488,7 +488,7 @@ $text = "
 
 	}
 
-	
+
 	 // Handle filter options as defined in gsitemap_form_ui::gsitemap_lastmod;  'handle' + action + field + 'Filter'
 	 // @important $fields['gsitemap_lastmod']['filter'] must be true for this method to be detected. 
 	 // @param $selected
@@ -497,7 +497,7 @@ $text = "
 	{
 
 		$this->listOrder = 'gsitemap_lastmod ASC';
-	
+
 		switch($type)
 		{
 			case 'customfilter_1':
@@ -515,7 +515,7 @@ $text = "
 
 	}
 
-	
+
 	 // Handle filter options as defined in gsitemap_form_ui::gsitemap_freq;  'handle' + action + field + 'Filter'
 	 // @important $fields['gsitemap_freq']['filter'] must be true for this method to be detected. 
 	 // @param $selected
@@ -524,7 +524,7 @@ $text = "
 	{
 
 		$this->listOrder = 'gsitemap_freq ASC';
-	
+
 		switch($type)
 		{
 			case 'customfilter_1':
@@ -541,9 +541,9 @@ $text = "
 
 
 	}
-	
-		
-		
+
+
+
 	*/
 	function importLink()
 	{
@@ -555,7 +555,7 @@ $text = "
 
 		foreach ($_POST['importid'] as $import)
 		{
-			list($name, $url, $type, $plugin, $table, $id) = explode("^", $import);
+			list($name, $url, $type, $plugin, $table, $id) = explode("^", (string) $import);
 
 			$insert = array(
 				'gsitemap_id'       => 0,
@@ -591,24 +591,24 @@ $text = "
 	}
 
 }
-				
+
 
 
 class gsitemap_form_ui extends e_admin_form_ui
 {
 
-	
+
 	// Custom Method/Function 
 	function gsitemap_priority($curVal,$mode)
 	{
 
-		 		
+
 		switch($mode)
 		{
 			case 'read': // List Page
 				return $curVal;
 			break;
-			
+
 			case 'write': // Edit Page
 			case 'batch':
 			case 'filter':
@@ -627,44 +627,44 @@ class gsitemap_form_ui extends e_admin_form_ui
 
 				return ($mode === 'write') ? $text : $array;
 			break;
-			
+
 
 		}
-		
+
 		return null;
 	}
 
-	
+
 	// Custom Method/Function 
 	function gsitemap_freq($curVal,$mode)
 	{
 
-		 		
+
 		switch($mode)
 		{
 			case 'read': // List Page
 				return $curVal;
 			break;
-			
+
 			case 'write': // Edit Page
 				return $this->text('gsitemap_freq',$curVal, 255, 'size=large');
 			break;
-			
+
 			case 'filter':
 				return array('customfilter_1' => 'Custom Filter 1', 'customfilter_2' => 'Custom Filter 2');
 			break;
-			
+
 			case 'batch':
 				return array('custombatch_1' => 'Custom Batch 1', 'custombatch_2' => 'Custom Batch 2');
 			break;
 		}
-		
+
 		return null;
 	}
 
 }		
-		
-		
+
+
 new gsitemap_adminArea();
 
 require_once(e_ADMIN."auth.php");
@@ -694,7 +694,7 @@ class gsitemap
 	{
 		$mes = e107::getMessage();
 
-		
+
 
 		$this->freq_list = array
 		(
@@ -756,15 +756,15 @@ class gsitemap
 
 	function showList()
 	{
-		
+
 		$mes 	= e107::getMessage();
 		$sql 	= e107::getDb();
 		$ns 	= e107::getRender();
 		$tp 	= e107::getParser();
 		$frm 	= e107::getForm();
-		
+
 		$gen = new convert;
-		
+
 		$count = $sql->select("gsitemap", "*", "gsitemap_id !=0 ORDER BY gsitemap_order ASC");
 
 		if (!$count)
@@ -774,9 +774,9 @@ class gsitemap
 			".GSLAN_39."<br /><br />"
 			.$frm->admin_button('import',LAN_YES)."
 			</form>";
-			
+
 			$mes->addInfo($text);
-			
+
 			$ns->tablerender(GSLAN_24, $mes->render());
 			return;
 		}
@@ -834,7 +834,7 @@ class gsitemap
 		}
 
 		$text .= "</tbody></table>\n</form>";
-		
+
 		$ns->tablerender(GSLAN_24, $mes->render(). $text);
 	}
 
@@ -843,7 +843,7 @@ class gsitemap
 	{
 		$sql = e107::getDb();
 		$tp = e107::getParser();
-		
+
 		$e_idt = array_keys($_POST['edit']);
 
 		if($sql->select("gsitemap", "*", "gsitemap_id='".$e_idt[0]."' "))
@@ -864,10 +864,10 @@ class gsitemap
 		$sql 	= e107::getDb();
 		$ns 	= e107::getRender();
 		$mes 	= e107::getMessage();
-		
-		
+
+
 		$count = $sql->select("gsitemap", "*", "gsitemap_id !=0 ORDER BY gsitemap_id ASC");
-		
+
 		$text = "
 		<form action='".e_SELF."' id='form' method='post'>
 		<table class='table adminform'>
@@ -951,7 +951,7 @@ class gsitemap
 		$log = e107::getLog();
 		$sql = e107::getDb();
 		$tp  = e107::getParser();
-		
+
 		$gmap = array(
 			'gsitemap_name' 	=> $tp->toDB($_POST['gsitemap_name']),
 			'gsitemap_url' 		=> $tp->toDB($_POST['gsitemap_url']), 
@@ -967,11 +967,11 @@ class gsitemap
 		{
 			// Add where statement to update query 
 			$gmap['WHERE'] = "gsitemap_id= ".intval($_POST['gsitemap_id']); 
-			
+
 			if($sql->update("gsitemap", $gmap))
 			{
 				$this->message = LAN_UPDATED; 	
-				
+
 				// Log update
 				$log->addArray($gmap)->save('GSMAP_04');
 			}
@@ -986,7 +986,7 @@ class gsitemap
 		{
 			$gmap['gsitemap_img'] = vartrue($_POST['gsitemap_img']);
 			$gmap['gsitemap_cat'] = vartrue($_POST['gsitemap_cat']);
-			
+
 			if($sql->insert('gsitemap', $gmap))
 			{
 				$this->message = LAN_CREATED;
@@ -1006,7 +1006,7 @@ class gsitemap
 	{
 		$log = e107::getLog();
 		$sql = e107::getDb();
-		
+
 		$d_idt = array_keys($_POST['delete']);
 
 		if($sql->delete("gsitemap", "gsitemap_id='".$d_idt[0]."'"))
@@ -1045,7 +1045,7 @@ function admin_config_adminmenu()
 	$var['import']['text'] = GSLAN_23;
 	$var['import']['link'] = e_SELF."?import";
 	$var['import']['perm'] = "0";
-	
+
 	show_admin_menu(LAN_PLUGIN_GSITEMAP_NAME, $action, $var);
 }*/
 

--- a/e107_plugins/hero/admin_config.php
+++ b/e107_plugins/hero/admin_config.php
@@ -57,7 +57,7 @@ class hero_adminArea extends e_admin_dispatcher
 				
 class hero_ui extends e_admin_ui
 {
-			
+
 		protected $pluginTitle		= 'Hero';
 		protected $pluginName		= 'hero';
 
@@ -73,11 +73,11 @@ class hero_ui extends e_admin_ui
 	//	protected $treePrefix      = 'somefield_title';
 
 		protected $tabs				= array(LAN_GENERAL, LAN_ADVANCED); // Use 'tab'=>0  OR 'tab'=>1 in the $fields below to enable.
-		
+
 	//	protected $listQry      	= "SELECT * FROM `#tableName` WHERE field != '' "; // Example Custom Query. LEFT JOINS allowed. Should be without any Order or Limit.
-	
+
 		protected $listOrder		= 'hero_order';
-	
+
 		protected $fields 		= array (
 		   'checkboxes'         =>   array ( 'title' => '', 'type' => null, 'data' => null, 'width' => '5%', 'thclass' => 'center', 'forced' => '1', 'class' => 'center', 'toggle' => 'e-multiselect',  ),
 		  'hero_id'           =>   array ( 'title' => LAN_ID, 'type' => null, 'data' => 'int', 'width' => '5%', 'help' => '', 'readParms' => '', 'writeParms' => '', 'class' => 'left', 'thclass' => 'left',  ),
@@ -95,9 +95,9 @@ class hero_ui extends e_admin_ui
 
 	        'options'             =>   array ( 'title' => LAN_OPTIONS, 'type' => null, 'data' => null, 'width' => '10%', 'thclass' => 'center last', 'class' => 'center last', 'forced' => '1',  ),
 		);		
-		
+
 		protected $fieldpref = array('hero_media', 'hero_bg', 'hero_title', 'hero_description', 'hero_bullets', 'hero_button1');
-		
+
 
 	//	protected $preftabs        = array('General', 'Other' );
 		protected $prefs = array(
@@ -106,7 +106,7 @@ class hero_ui extends e_admin_ui
 			'slide_interval'    => array('title'=>LAN_HERO_ADMIN_011, 'type'=>'dropdown', 'data'=>'int', 'writeParms'=>array('optArray'=>array())),
 		);
 
-	
+
 		public function init()
 		{
 			// Set drop-down values (if any).
@@ -147,14 +147,14 @@ class hero_ui extends e_admin_ui
 		}
 		*/
 		// ------- Customize Create --------
-		
+
 		public function beforeCreate($new_data,$old_data)
 		{
 			$new_data = $this->processGlyph($new_data);
 
 			return $new_data;
 		}
-	
+
 		public function afterCreate($new_data, $old_data, $id)
 		{
 			// do something
@@ -164,10 +164,10 @@ class hero_ui extends e_admin_ui
 		{
 			// do something		
 		}		
-		
-		
+
+
 		// ------- Customize Update --------
-		
+
 		public function beforeUpdate($new_data, $old_data, $id)
 		{
 			$new_data = $this->processGlyph($new_data);
@@ -179,7 +179,7 @@ class hero_ui extends e_admin_ui
 		{
 			foreach($new_data['hero_bullets'] as $key=>$row)
 			{
-				if(!empty($row['icon']) && strpos($row['icon'],".glyph")===false)
+				if(!empty($row['icon']) && strpos((string) $row['icon'],".glyph")===false)
 				{
 					$new_data['hero_bullets'][$key]['icon'] = $row['icon'].".glyph";
 				}
@@ -194,12 +194,12 @@ class hero_ui extends e_admin_ui
 		{
 			// do something	
 		}
-		
+
 		public function onUpdateError($new_data, $old_data, $id)
 		{
 			// do something		
 		}		
-		
+
 		// left-panel help menu area. 
 		public function renderHelp()
 		{
@@ -209,7 +209,7 @@ class hero_ui extends e_admin_ui
 			return array('caption'=>$caption,'text'=> $text);
 
 		}
-			
+
 	/*	
 		// optional - a custom page.  
 		public function customPage()
@@ -217,12 +217,12 @@ class hero_ui extends e_admin_ui
 			$text = 'Hello World!';
 			$otherField  = $this->getController()->getFieldVar('other_field_name');
 			return $text;
-			
+
 		}
-		
-	
-		
-		
+
+
+
+
 	*/
 			
 }

--- a/e107_plugins/import/admin_import.php
+++ b/e107_plugins/import/admin_import.php
@@ -73,24 +73,24 @@ class import_admin extends e_admin_dispatcher
 	protected $adminMenuAliases = array(
 		'main/edit'	=> 'main/list'				
 	);	
-	
+
 	protected $menuTitle = LAN_PLUGIN_IMPORT_NAME;
 }
 
 
 class import_main_ui extends e_admin_ui
 {
-	
+
 	protected $pluginTitle			= LAN_PLUGIN_IMPORT_NAME;
 	protected $pluginName			= 'import';
 	protected $table				= false;
-	
+
 	protected $providers			= array(); // the different types of import. 
 	protected $deleteExisting		= false; // delete content from existing table during import. 
 	protected $selectedTables		= array(); // User selection of what tables to import. eg. news, pages etc. 
 	protected $importClass			= null;
 	protected $checked_class_list	= '';
-	
+
 	// Definitions of available areas to import
 	protected $importTables = array(
 		'users' 		=> array('message' => LAN_CONVERT_25, 			'classfile' => 'import_user_class.php', 'classname' => 'user_import'),
@@ -111,23 +111,23 @@ class import_main_ui extends e_admin_ui
 
 	//	'polls' 		=> array('message' => LAN_CONVERT_27)
 	);	
-	
+
 		// without any Order or Limit. 
 
-		
-		
+
+
 	function init()
 	{
 		$fl = e107::getFile();
-		
+
 		$importClassList = $fl->get_files(e_PLUGIN.'import/providers', "^.+?_import_class\.php$", "standard", 1);
-		
+
 		foreach($importClassList as $file)
 		{
 
 
 			$tag = str_replace('_class.php','',$file['fname']);
-			
+
 			$key = str_replace("_import_class.php","",$file['fname']);
 
 			if($key === 'template')
@@ -136,34 +136,34 @@ class import_main_ui extends e_admin_ui
 			}
 
 			include_once($file['path'].$file['fname']);		// This will set up the variables
-			
+
 			$this->providers[$key] = $this->getMeta($tag);
 
 			if(!empty($_GET['type']))
 			{
 				$this->importClass = filter_var($_GET['type'])."_import";
 			}
-			
+
 		}	
 
 
 		uksort($this->providers,'strcasecmp');
 
-		
+
 	}	
-	
-	
+
+
 	function help()
 	{
-		
+
 		return "Some help text for admin-ui";	
-		
+
 	}
-	
-	
-	
-	
-	
+
+
+
+
+
 	function getMeta($class_name)
 	{
 		if(class_exists($class_name))
@@ -175,68 +175,68 @@ class import_main_ui extends e_admin_ui
 		{
 			e107::getMessage()->addDebug("Missing class: ".$class_name);	
 		}
-		
+
 	}
 
-	
-	
-		
-	
+
+
+
+
 	// After selection - decide where to route things. 	
 	function importPage()
 	{
-		
+
 	//	print_a($_POST);
-	
+
 		if(!empty($_POST['import_delete_existing_data']))
 		{
 			$this->deleteExisting = varset($_POST['import_delete_existing_data'],0);
 		}
-		
+
 		if(!empty($_POST['classes_select']))
 		{
 			$this->checked_class_list = implode(',',$_POST['classes_select']);
 		}
-		
+
 		if(!empty($_POST['createUserExtended'])) //TODO 
 		{
 			$this->createUserExtended = true; 
 		}
-		
+
 		if(!empty($_POST['selectedTables']))
 		{
 			$this->selectedTables = $_POST['selectedTables'];
 		}
-			
+
 		if(!empty($_POST['runConversion'])) // default method. 
 		{
 			$this->runConversion($_POST['import_source']);
 			return;	
 		}
-		
-				
 
-		
+
+
+
 		$this->showImportOptions($_GET['type']);	
-		
+
 	}
-	
-	
-	
-	
-	
-	
-	
-			
-		
+
+
+
+
+
+
+
+
+
 	function listPage()
 	{
 		$mes = e107::getMessage();
 		$frm = e107::getForm();
-		
+
 		$tableCount = 0;
 	//	$mes->addDebug(print_a($this->providers,true));
-		
+
 		$text = "
 			<form method='get' action='".e_SELF."' id='core-import-form'>
 				<fieldset id='core-import-select-type'>
@@ -267,98 +267,98 @@ class import_main_ui extends e_admin_ui
 		                	$text .= "<th class='center'>".$val['message']."</th>";
 							$tableCount++;
 		 				}
-		
+
 						$text.="
 						<th class='center'>".LAN_OPTIONS."</th>
-		
+
 					</tr>
 					</thead>
 					<tbody>";
 					/*
 					$text .= "
-		
+
 					<tr>
 					<td><img src='".e_PLUGIN."import/images/csv.png' alt='' style='float:left;height:32px;width:32px;margin-right:4px'>CSV</td>
 					<td class='center'>".ADMIN_TRUE_ICON."</td>";
-					
+
 					for ($i=0; $i < $tableCount-1; $i++) 
 					{ 
 						$text .= "<td>&nbsp;</td>";	
 					}
-		
-					
+
+
 					$text .= "<td class='center middle'>".$frm->admin_button('import_type', 'csv', 'other',"Select")."</td></tr>";
 					*/
-		
+
 		        foreach ($this->providers as $k=>$info)
 				{
 					$title = $info['title'];
-					
-					$iconFile = e_PLUGIN."import/images/".str_replace("_import","",strtolower($k)).".png";		
-					
+
+					$iconFile = e_PLUGIN."import/images/".str_replace("_import","",strtolower((string) $k)).".png";		
+
 					$icon = (file_exists($iconFile)) ? "<img src='{$iconFile}' alt='' style='float:left;height:32px;width:32px;margin-right:8px'>" : "";
-					
+
 		          	$text .= "<!-- $title -->
 					<tr><td >".$icon.$title."<div class='smalltext'>".$info['description']."</div></td>\n";
-		
+
 					 foreach($this->importTables as $key=>$val)
 					 {
 					 	if(vartrue($val['nolist'])){ continue; }
 		 			 	$text .= "<td class='center'>".(in_array($key,$info['supported']) ? defset('ADMIN_TRUE_ICON') : "&nbsp;")."</td>\n";
 					 }
-		
+
 		             $text .= "
 					 	<td class='center middle'>";
-						
+
 						$text .= $frm->admin_button('type', $k, 'other',LAN_CONVERT_64);
 					// 	$text .= $frm->admin_button('import_type', $k, 'other',"Select");
-						
+
 						$text .= "
 					 	</td>
 					 </tr>";
 				}
-		
-		
+
+
 				$text .= "
 						</tbody>
 					</table>
 					<div class='buttons-bar center'>
 						".$frm->hidden('trigger_import',1)."
-						
+
 					</div>
 				</fieldset>
 			</form>";
-		
+
 			echo $mes->render().$text; 
 			// $ns->tablerender(LAN_PLUGIN_IMPORT_NAME, $mes->render().$text);
-		
+
 	}
 
 
-	
-	
-	
+
+
+
 	function runConversion($import_source)
 	{
 		$frm = e107::getForm();	
 		$ns = e107::getRender();	
 		$mes = e107::getMessage();
-		
+
 		$abandon = TRUE;
-	
+
 	 	switch ($import_source)
 		{
 			case 'csv' : 
-			
+
 			break;
-	
+
 			case 'db' :
 				if($this->dbImport() == false)
 				{
 					$abandon = true;
 				}
 			break;
-			
+
 			case 'rss' :
 				if($this->rssImport() == false)
 				{
@@ -366,14 +366,14 @@ class import_main_ui extends e_admin_ui
 				}
 			break;
 		}
-		
-		
+
+
 //		if ($msg)
 //		{
 //			$mes->add($msg, E_MESSAGE_INFO); //  $ns -> tablerender(LAN_CONVERT_30, $msg);
 //			$msg = '';
 //		}
-	
+
 		if ($abandon)
 		{
 		//	unset($_POST['do_conversion']);
@@ -384,9 +384,9 @@ class import_main_ui extends e_admin_ui
 			</div>
 			</form>";
 			echo $mes->render(). $text;
-			
+
 		//	$ns -> tablerender(LAN_CONVERT_30,$mes->render(). $text);
-			
+
 		}
 	}
 
@@ -395,7 +395,7 @@ class import_main_ui extends e_admin_ui
 
 	function renderConfig()
 	{
-		
+
 	}
 
 
@@ -403,18 +403,18 @@ class import_main_ui extends e_admin_ui
 
 
 
-	
-		
+
+
 	function showImportOptions($type='csv')
 	{
 		global $csv_names, $e_userclass;
 		$mode = $this->importClass;
-		
+
 		$frm = e107::getForm();
 		$ns = e107::getRender();
-		
+
 		$mes = e107::getMessage();
-		
+
 		if (class_exists($mode))
 		{
 			$mes->addDebug("Class Available: ".$mode);   
@@ -424,10 +424,10 @@ class import_main_ui extends e_admin_ui
 				return;
 			}
 		}
-	
+
 		$message = "<strong>".LAN_CONVERT_05."</strong>";
 		$mes->add($message, E_MESSAGE_WARNING);
-	
+
 		$text = "
 		<form method='post' action='".e_SELF."?action=main&action=import&type=".$type."'>
 	    <table class='table adminform'>
@@ -435,9 +435,9 @@ class import_main_ui extends e_admin_ui
 	    		<col class='col-label' />
 	    		<col class='col-control' />
 	    	</colgroup>";
-	
-		
-	
+
+
+
 		/*
 		if($mode == "csv")
 		{
@@ -453,28 +453,28 @@ class import_main_ui extends e_admin_ui
 		  	$text .= "</select>\n
 			  </td>
 			</tr>
-	
+
 			<tr>
 			<td>".LAN_CONVERT_36."</td>
 			<td><input class='tbox' type='text' name='csv_data_file' size='30' value='{$csv_data_file}' maxlength='100' /></td>
 			</tr>
-	
+
 			<tr><td>".LAN_CONVERT_17."
 			</td>
 			<td>
-	
+
 			<input type='hidden' name='import_source' value='csv' />
 			<input type='checkbox' name='csv_pw_not_encrypted' value='1'".($csv_pw_not_encrypted ? " checked='checked'" : '')."/>
 			<span class='smallblacktext'>".LAN_CONVERT_18."</span></td>
 			</tr>
 			";
-	
+
 		}
 		else
 		*/
-		
+
 		$importType = $proObj->title;
-		
+
 		if($proObj->sourceType == 'db' || !$proObj->sourceType) // STANDARD db Setup 
 		{
 	    	$databases = $this->getDatabases();
@@ -509,10 +509,10 @@ class import_main_ui extends e_admin_ui
 			<input type='hidden' name='import_source' value='db' />
 	  		</td>
 			</tr>";
-	
+
 		}
-	
-	
+
+
 		if(method_exists($proObj,"config")) // Config Found in Class - render options from it. 
 		{
 			if($ops  = $proObj->config())
@@ -528,8 +528,8 @@ class import_main_ui extends e_admin_ui
 				}
 			}
 		}
-	
-	
+
+
 		if($proObj->sourceType)
 		{
 			$text .= "<input type='hidden' name='import_source' value='".$proObj->sourceType."' />\n";	
@@ -538,40 +538,40 @@ class import_main_ui extends e_admin_ui
 		{
 			$text .= "<input type='hidden' name='import_source' value='db' />";	
 		}
-			
-	
-	
-	
+
+
+
+
 	//	if($mode != 'csv')
 		{
 			$text .= "
 			<tr>
 			<td >$importType ".LAN_CONVERT_24."</td>
 			<td>";
-	
+
 			$defCheck = (count($proObj->supported)==1) ? true : false;
 	   	  	foreach ($this->importTables as $k => $v)
 		  	{
 				if(in_array($k, $proObj->supported)) // display only the options supported.
 				{
 					$text .= $frm->checkbox('selectedTables['.$k.']', $k, $defCheck,array('label'=>$v['message'])); 	
-						
-					
+
+
 					//$text .= "<input type='checkbox' name='import_block_{$k}' id='import_block_{$k}' value='1' {$defCheck} />&nbsp;".$v['message'];
 					// $text .= "<br />";
 				}
 		  	}
 		  	$text .= "</td></tr>";		
 		}
-	
-	
+
+
 		$text .= "
 			<tr>
 				<td>".LAN_CONVERT_38."".$frm->help(LAN_CONVERT_39)."</td>
 				<td>".$frm->radio_switch('import_delete_existing_data', $_POST['import_delete_existing_data'])."
 				</td>
 			</tr>";
-		
+
 		//TODO 
 		/*
 		if(in_array('users',$proObj->supported))
@@ -583,7 +583,7 @@ class import_main_ui extends e_admin_ui
 			</tr>";	
 		}
 		*/
-		
+
 		if(varset($proObj->defaultClass) !== false)
 		{
 			$text .= "
@@ -592,31 +592,31 @@ class import_main_ui extends e_admin_ui
 	  		$text .= $e_userclass->vetted_tree('classes_select',array($e_userclass,'checkbox'), varset($_POST['classes_select']),'main,admin,classes,matchclass, no-excludes');
 	  		$text .= "</td></tr>";
 		}
-	 	
+
 	  	$action = varset($proObj->action,'runConversion');
 	  	$text .= "</table>
 		<div class='buttons-bar center'>".$frm->admin_button($action,LAN_CONTINUE, 'execute').
-		
+
 		$frm->admin_button('back',LAN_CANCEL, 'cancel')."
 		<input type='hidden' name='db_import_type' value='$mode' />
 		<input type='hidden' name='import_type' value='".$mode."' />
 		</div>
 		</form>";
-	
+
 		// Now a little bit of JS to initialise some of the display divs etc
 	//  	$temp = '';
 	//  	if(varset($import_source)) { $temp .=  "disp('{$import_source}');"; }
 	//  	if (varset($current_db_type)) $temp .= " flagbits('{$current_db_type}');";
 	//  	if (varset($temp)) $text .= "<script> {$temp}</script>";
-		
+
 		$this->addTitle($importType); 
 		echo $mes->render().$text; 
-		
+
 	//  	$ns -> tablerender(LAN_PLUGIN_IMPORT_NAME.SEP.$importType, $mes->render().$text);
-	
+
 	}
-	
-	
+
+
 	private function getDatabases()
 	{
 		$tmp = e107::getDb()->gen("SHOW DATABASES");
@@ -644,41 +644,41 @@ class import_main_ui extends e_admin_ui
 
 	}
 
-	
-		
+
+
 	function rssImport()
 	{
 		global $current_db_type;
-		
+
 		$mes = e107::getMessage();
 		$mes->addDebug("Loading: RSS");	
-		
+
 		if(!varset($_POST['runConversion']))
 		{
 			$mes->addWarning("Under Construction"); 	
 		}	
-		
+
 		return $this->dbImport('xml');
-		
+
 	}
-	
-	
-	
+
+
+
 	/** MAIN IMPORT AREA */
 	function dbImport($mode='db')
 	{
-		
+
 		$mes = e107::getMessage();
 		$tp = e107::getParser();
-		
+
 		$mes->addDebug("dbImport(): Loading: ".$this->importClass);
-		
+
 		if(!is_array($this->importTables))
 		{
 			$mes->addError("dbImport(): No areas selected for import");  // db connect failed
 			return false;	
 		}
-		
+
 		if (class_exists($this->importClass))
 		{
 			$mes->addDebug("dbImport(): Converter Class Available: ".$this->importClass);   
@@ -689,10 +689,10 @@ class import_main_ui extends e_admin_ui
 		{
 			$mes->addError(LAN_CONVERT_42. "[".$this->importClass."]");
 			$mes->addDebug("dbImport(): Class NOT Available: ".$this->importClass);   
-			
+
 			return false;
 		}
-		
+
 
 		if($mode == 'db') // Don't do DB check on RSS/XML 
 		{
@@ -701,7 +701,7 @@ class import_main_ui extends e_admin_ui
 				$mes->addError(LAN_CONVERT_41);
 				return false;
 			}
-		
+
 			$result = $converter->database($tp->filter($_POST['dbParamDatabase']),  $tp->filter($_POST['dbParamPrefix']));
 
 		//	$result = $converter->database($tp->filter($_POST['dbParamDatabase']),  $tp->filter($_POST['dbParamPrefix']), true);
@@ -712,24 +712,24 @@ class import_main_ui extends e_admin_ui
 				return false;
 			}	
 		}	
-		
-	
+
+
 		if(vartrue($converter->override))
 		{
 			$mes->addDebug("dbImport(): Override Active!" );
 			return;
 		}	
-		
-		
-		
+
+
+
 		// Return 
 		foreach($this->selectedTables as $k => $tm)
 		{
 			$v = $this->importTables[$k];
-			
+
 			$loopCounter = 0;
 			$errorCounter = 0;
-				
+
 			if (is_readable($v['classfile'])) // Load our class for either news, pages etc. 
 			{
 				$mes->addDebug("dbImport(): Including File: ".$v['classfile']);
@@ -740,52 +740,52 @@ class import_main_ui extends e_admin_ui
 				$mes->addError(LAN_CONVERT_45.': '.$v['classfile']);   // can't read class file.
 				return false;
 			}
-			
+
 			$mes->addDebug("dbImport(): Importing: ".$k);
-			
+
 			$exporter = new $v['classname'];		// Writes the output data
-	
+
 		  	if(is_object($exporter))
 			{
 				$mes->addDebug("dbImport(): Exporter Class Initiated: ".$v['classname']);	
-				
+
 				if(is_object($exporter->helperClass))
 				{
 					$mes->addDebug("dbImport(): Initiated Helper Class");		
 					$converter->helperClass = $exporter->helperClass;
 				}
-				
+
 			}
 			else
 			{
 				$mes->addDebug("dbImport(): Couldn't Initiate Class: ".$v['classname']);		
 			}
-			
-			
+
+
 		  	$result = $converter->setupQuery($k, !$this->deleteExisting);
-							
+
 			if ($result !== true)
 			{
 				$mes->addError(LAN_CONVERT_44.' '.$k);   // couldn't set query
 				break;
 			}
-					
-		
-		  
-				 				 	
+
+
+
+
 			if($k == 'users')  // Do any type-specific default setting
 			{
 				$mes->addDebug("dbImport(): Overriding Default for user_class: ".$this->checked_class_list);	
 				$exporter->overrideDefault('user_class', $this->checked_class_list);
 			//	break;
 			}
-					
+
 			if ($this->deleteExisting == true)
 			{
 				$mes->addDebug("dbImport(): Emptying target table. ");
 				$exporter->emptyTargetDB();		// Clean output DB - reasonably safe now	
 			} 
-					
+
 			while ($row = $converter->getNext($exporter->getDefaults(),$mode))
 			{
 				$loopCounter++;
@@ -799,35 +799,35 @@ class import_main_ui extends e_admin_ui
 					$mes->addError($msg);   // couldn't set query
 				}
 			}
-					
+
 			$converter->endQuery(); 
-					
+
 			unset($exporter);
-					
-					
+
+
 			$msg = str_replace(array('[x]','[y]', '[z]','[w]'),
 			array($loopCounter,$loopCounter-$errorCounter,$errorCounter, $k),LAN_CONVERT_47);
 			$mes->addSuccess($msg);   // couldn't set query				
 		}
-		
-		
-		
-		
-		
-		
-		
-		
-		
-		
+
+
+
+
+
+
+
+
+
+
 		return true;
-		
+
 		// $abandon = FALSE;	
 	}
 
-	
-	
-	
-	
+
+
+
+
 }
 
 
@@ -991,7 +991,7 @@ $msg = '';
 if(isset($_POST['do_conversion']))
 {
 	$abandon = TRUE;
-	
+
  	switch ($import_source)
 	{
 		case 'csv' : 
@@ -1002,7 +1002,7 @@ if(isset($_POST['do_conversion']))
 			{
 				$msg = LAN_CONVERT_37.' '.$csv_options[$current_csv];	
 			} 
-		  
+
 		  	if (!$msg)
 		  	{
 				$field_list = explode(',',$csv_formats[$current_csv]);
@@ -1072,7 +1072,7 @@ if(isset($_POST['do_conversion']))
 				$abandon = true;
 			}
 		break;
-		
+
 		case 'rss' :
 			if(rssImport() == false)
 			{
@@ -1107,27 +1107,27 @@ if(isset($_POST['do_conversion']))
 function rssImport()
 {
 	global $current_db_type, $db_import_blocks, $import_delete_existing_data,$db_blocks_to_import;
-	
+
 	$mes = e107::getMessage();
 	$mes->addDebug("Loading: RSS");	
 	if(!varset($_POST['do_conversion']))
 	{
 		$mes->addWarning("Under Construction"); 	
 	}	
-	
+
 	return dbImport('xml');
-	
+
 }
 
 function dbImport($mode='db')
 {
 	global $current_db_type, $db_import_blocks, $import_delete_existing_data,$db_blocks_to_import;
-	
+
 	$mes = e107::getMessage();
-	
+
 	// if (IMPORT_DEBUG) echo "Importing: {$current_db_type}<br />";
 	$mes->addDebug("Loading: ".$current_db_type);
-	
+
 	if (class_exists($current_db_type))
 	{
 		$mes->addDebug("Class Available: ".$current_db_type);   
@@ -1139,7 +1139,7 @@ function dbImport($mode='db')
 		$mes->addError(LAN_CONVERT_42. "[".$current_db_type."]");
 		return false;
 	}
-	
+
 	if($mode == 'db') // Don't do DB check on RSS/XML 
 	{
 		if (!isset($_POST['dbParamHost']) || !isset($_POST['dbParamUsername']) || !isset($_POST['dbParamPassword']) || !isset($_POST['dbParamDatabase']))
@@ -1147,7 +1147,7 @@ function dbImport($mode='db')
 			$mes->addError(LAN_CONVERT_41);
 			return false;
 		}
-	
+
 		$result = $converter->db_Connect($_POST['dbParamHost'],	$_POST['dbParamUsername'], $_POST['dbParamPassword'], $_POST['dbParamDatabase'],  $_POST['dbParamPrefix']);
 		if ($result !== TRUE)
 		{
@@ -1166,7 +1166,7 @@ function dbImport($mode='db')
 	{
 		return;
 	}
-		
+
 
 
 	foreach ($db_import_blocks as $k => $v)
@@ -1175,7 +1175,7 @@ function dbImport($mode='db')
 		{
 			$loopCounter = 0;
 			$errorCounter = 0;
-			
+
 			if (is_readable($v['classfile']))
 			{
 				require_once($v['classfile']);
@@ -1190,30 +1190,30 @@ function dbImport($mode='db')
 			{
 				//if (IMPORT_DEBUG) echo "Importing: {$k}<br />";
 				$mes->addDebug("Importing: ".$k);
-				
+
 			  	$result = $converter->setupQuery($k,!$import_delete_existing_data);
-						
+
 			  	if ($result !== TRUE)
 			  	{
 					$mes->addError(LAN_CONVERT_44.' '.$k);   // couldn't set query
 					//	$msg .= "Prefix = ".$converter->DBPrefix;
 					break;
 			  	}
-				
+
 			  	$exporter = new $v['classname'];		// Writes the output data
-			 				 	
+
 				switch ($k)  // Do any type-specific default setting
 				{
 					case 'users' :
 					  $exporter->overrideDefault('user_class',$checked_class_list);
 					  break;
 				}
-				
+
 			  	if ($import_delete_existing_data)
 				{
 					$exporter->emptyTargetDB();		// Clean output DB - reasonably safe now	
 				} 
-				
+
 				while ($row = $converter->getNext($exporter->getDefaults(),$mode))
 				{
 					$loopCounter++;
@@ -1227,12 +1227,12 @@ function dbImport($mode='db')
 						$mes->addError($msg);   // couldn't set query
 					}
 				}
-				
+
 				$converter->endQuery(); 
-				
+
 				unset($exporter);
-				
-				
+
+
 				$msg = str_replace(array('--LINES--','--USERS--', '--ERRORS--','--BLOCK--'),
 				array($loopCounter,$loopCounter-$errorCounter,$errorCounter, $k),LAN_CONVERT_47);
 				$mes->addSuccess($msg);   // couldn't set query
@@ -1240,13 +1240,13 @@ function dbImport($mode='db')
 			else
 			  {
 			  		$mes->addDebug("Error: _POST['import_block_{$k}'] = ".$_POST['import_block_{$k}']);   // cou
-					
+
 			  }
 		  }
 		  else
 		  {
 		  		$mes->addDebug("\$db_blocks_to_import doesn't contain key: ".$k);   // cou
-				
+
 		  }
 		}
 
@@ -1275,13 +1275,13 @@ function csv_split(&$data,$delim=',',$enveloper='')
   $enclosed = false;
 // $fldcount=0;
 // $linecount=0;
-  for($i=0, $iMax = strlen($data); $i< $iMax; $i++)
+  for($i=0, $iMax = strlen((string) $data); $i< $iMax; $i++)
   {
 	$c=$data[$i];
 	switch($c)
 	{
 	  case $enveloper :
-		if($enclosed && ($i<strlen($data)) && ($data[$i+1]==$enveloper))
+		if($enclosed && ($i<strlen((string) $data)) && ($data[$i+1]==$enveloper))
 		{
 		  $fldval .= $c;
 		  $i++; //skip next char
@@ -1332,7 +1332,7 @@ function headerjs()
   $texts = "var db_options = new Array();\n";
   $blocks = "var block_names = new Array();\n";
   $comments = "var comment_text = new Array();\n";
-  
+
   $i = 0;
   foreach ($db_import_blocks as $it => $val)
   {
@@ -1375,7 +1375,7 @@ function headerjs()
 		return;
 	  }
 	}
-	
+
 	function flagbits(type)
 	{
 	  var i,j;

--- a/e107_plugins/import/import_classes.php
+++ b/e107_plugins/import/import_classes.php
@@ -293,7 +293,7 @@ class base_import_class
 		{
 				$text .= "<tr>
 					<td style='width:50%;'>".$k."</td>
-					<td>".htmlentities($v)."</td>
+					<td>".htmlentities((string) $v)."</td>
 				</tr>";
 
 
@@ -327,8 +327,8 @@ class base_import_class
 	  $bbphpbb = (strpos($options,'phpbb') !== FALSE) ? TRUE : FALSE;		// Strip values as phpbb
 	  $nextchar = 0;
 	  $loopcount = 0;
-	 
-	  while ($nextchar < strlen($value))
+
+	  while ($nextchar < strlen((string) $value))
 	  {
 	    $firstbit = '';
 	    $middlebit = '';
@@ -336,11 +336,11 @@ class base_import_class
 	    $loopcount++;
 		if ($loopcount > 10) return 'Max depth exceeded';
 	    unset($bbword);
-	    $firstcode = strpos($value,'[',$nextchar);
+	    $firstcode = strpos((string) $value,'[',$nextchar);
 	    if ($firstcode === FALSE) return $value;   	// Done if no square brackets
-	    $firstend = strpos($value,']',$firstcode);
+	    $firstend = strpos((string) $value,']',$firstcode);
 	    if ($firstend === FALSE) return $value;		// Done if no closing bracket
-	    $bbword = substr($value,$firstcode+1,$firstend - $firstcode - 1);	// May need to process this more if parameter follows
+	    $bbword = substr((string) $value,$firstcode+1,$firstend - $firstcode - 1);	// May need to process this more if parameter follows
 		$bbparam = '';
 		$temp = strpos($bbword,'=');
 		if ($temp !== FALSE)
@@ -350,8 +350,8 @@ class base_import_class
 		}
 	    if (($bbword) && ($bbword == trim($bbword)))
 	    {
-	      $laststart = strpos($value,'[/'.$bbword,$firstend);    // Find matching end
-		  $lastend   = strpos($value,']',$laststart);
+	      $laststart = strpos((string) $value,'[/'.$bbword,$firstend);    // Find matching end
+		  $lastend   = strpos((string) $value,']',$laststart);
 		  if (($laststart === FALSE) || ($lastend === FALSE))
 		  {   //  No matching end character
 		    $nextchar = $firstend;	// Just move scan pointer along 
@@ -359,9 +359,9 @@ class base_import_class
 		  else
 		  {  // Got a valid bbcode pair here
 		    $firstbit = '';
-		    if ($firstcode > 0) $firstbit = substr($value,0,$firstcode);
-		    $middlebit = substr($value,$firstend+1,$laststart - $firstend-1);
-		    $lastbit = substr($value,$lastend+1,strlen($value) - $lastend);
+		    if ($firstcode > 0) $firstbit = substr((string) $value,0,$firstcode);
+		    $middlebit = substr((string) $value,$firstend+1,$laststart - $firstend-1);
+		    $lastbit = substr((string) $value,$lastend+1,strlen((string) $value) - $lastend);
 		    // Process bbcodes here
 			if ($bblower) $bbword = strtolower($bbword);
 			if ($bbphpbb && (strpos($bbword,':') !== FALSE)) $bbword = substr($bbword,0,strpos($bbword,':'));

--- a/e107_plugins/import/import_user_class.php
+++ b/e107_plugins/import/import_user_class.php
@@ -136,7 +136,7 @@ class user_import
 	// On error, if $just_strip true, returns 'processed' name; otherwise returns FALSE
 	function vetUserName($name, $just_strip = FALSE)
 	{
-		$temp_name = trim(preg_replace('/&nbsp;|\#|\=|\$/', "", strip_tags($name)));
+		$temp_name = trim((string) preg_replace('/&nbsp;|\#|\=|\$/', "", strip_tags((string) $name)));
 		if (($temp_name == $name) || $just_strip) return $temp_name;
 		return FALSE;
 	}
@@ -168,7 +168,7 @@ class user_import
 				{
 					e107::getMessage()->addDebug("Removing user-field due to missing user-extended field {$k} ");	
 				}			
-				
+
 				unset($userRecord[$k]);			// And always delete from the original data record
 			}
 		}
@@ -191,8 +191,8 @@ class user_import
 			return 5;
 		}
 		
-		if (trim($userRecord['user_name']) == '') $userRecord['user_name'] = trim($userRecord['user_loginname']);
-		if (trim($userRecord['user_loginname']) == '') $userRecord['user_loginname'] = trim($userRecord['user_name']);
+		if (trim((string) $userRecord['user_name']) == '') $userRecord['user_name'] = trim((string) $userRecord['user_loginname']);
+		if (trim((string) $userRecord['user_loginname']) == '') $userRecord['user_loginname'] = trim((string) $userRecord['user_name']);
 		
 		foreach ($this->userMandatory as $k)
 		{
@@ -201,7 +201,7 @@ class user_import
 				e107::getMessage()->addDebug("Failed userMandatory on {$k}");
 				return 3;
 			}
-			
+
 			//if (strlen($userRecord[$k]) < 3)
 		//	{
 			//	e107::getMessage()->addDebug("Failed userMandatory length on {$k}");

--- a/e107_plugins/import/providers/PHPNuke_import_class.php
+++ b/e107_plugins/import/providers/PHPNuke_import_class.php
@@ -140,7 +140,7 @@ class PHPNuke_import extends base_import_class
 		$target['user_name']        = $source['name'];
 		$target['user_loginname']   = $source['username'];
 		$target['user_password']    = $source['user_password']; //MD5
-		$target['user_join']        = strtotime($source['user_regdate']);
+		$target['user_join']        = strtotime((string) $source['user_regdate']);
 		$target['user_email']       = $source['user_email'];
 		$target['user_hideemail']   = !$source['user_viewemail'];
 	    $target['user_image']       = $source['user_avatar'];

--- a/e107_plugins/import/providers/blogger_import_class.php
+++ b/e107_plugins/import/providers/blogger_import_class.php
@@ -33,11 +33,11 @@ class blogger_import extends rss_import
 	public $description	= 'Import up to 500 items from yourblog.blogspot.com';
 	public $supported	=  array('news');
 	public $mprefix		= false;
-	
+
 	public $cleanupHtml = false;
 	public $defaultClass = false;
 
-	
+
 	/*
 	 If the first 500 posts of your blog feed are here:
 
@@ -59,9 +59,9 @@ class blogger_import extends rss_import
 
 		if(vartrue($_POST['bloggerUrl']))
 		{			
-			$this->feedUrl = rtrim($_POST['bloggerUrl'],"/")."/feeds/posts/default?max-results=999&alt=rss";	
+			$this->feedUrl = rtrim((string) $_POST['bloggerUrl'],"/")."/feeds/posts/default?max-results=999&alt=rss";	
 		}
-		
+
 		if(vartrue($_POST['bloggerCleanup']))
 		{
 			$this->cleanupHtml = true;
@@ -75,18 +75,18 @@ class blogger_import extends rss_import
 			return;
 		}
 	}
-		
-	
+
+
 	function config()
 	{
 		$var[0]['caption']	= "Blogger URL";
 		$var[0]['html'] 	= e107::getForm()->text('bloggerUrl', $_POST['bloggerUrl'],255, 'size=xxlarge'); //  "<input class='tbox' type='text' name='bloggerUrl' size='120' value='{$_POST['bloggerUrl']}' maxlength='250' />";
 		$var[0]['help']		= "eg. http://blogname.blogspot.com";
-		
+
 		$var[1]['caption']	= "Cleanup HTML in content";
 		$var[1]['html'] 	= e107::getForm()->checkbox('bloggerCleanup',1, $_POST['bloggerCleanup']); // "<input class='tbox' type='checkbox' name='bloggerCleanup' value='1' />";
 		$var[1]['help']		= "Tick to enable";
-		
+
 		return $var;
 	}
 
@@ -153,18 +153,18 @@ class blogger_import extends rss_import
 
 				if(!empty($source['link'][0]))
 				{
-					return str_replace(".html","", basename($source['link'][0]));
+					return str_replace(".html","", basename((string) $source['link'][0]));
 				}
 
 				return "";
 			break;
-			
+
 			default:
 				return $source[$type][0];
 			break;
 		}		
-		
-		
+
+
 	}
 
 

--- a/e107_plugins/import/providers/coppermine_import_class.php
+++ b/e107_plugins/import/providers/coppermine_import_class.php
@@ -70,9 +70,9 @@ class coppermine_import extends base_import_class
 	$target['user_login'] 		= $source['user_name'];
 	$target['user_password'] 	= $source['user_password'];
 	$target['user_email'] 		= $source['user_email'];
-	$target['user_join'] 		= strtotime($source['user_regdate']);
-	$target['user_lastvisit'] 	= strtotime($source['user_lastvisit']);
-	
+	$target['user_join'] 		= strtotime((string) $source['user_regdate']);
+	$target['user_lastvisit'] 	= strtotime((string) $source['user_lastvisit']);
+
 	switch ($source['user_group'])
 	{
 	  case 1 : 		// Admin
@@ -85,7 +85,7 @@ class coppermine_import extends base_import_class
 		$target['user_ban'] = 2;
 		break;
 	}
-	
+
 	return $target;
 
 	/* Unused fields:

--- a/e107_plugins/import/providers/drupal_import_class.php
+++ b/e107_plugins/import/providers/drupal_import_class.php
@@ -428,7 +428,7 @@ class drupal_import extends base_import_class
 		// Strip a slash from the end of URL.
 		$base_url = rtrim($base_url, '/');
 		// Strip slashes from the beginning and end of path.
-		$base_path = trim($this->basePath, '/');
+		$base_path = trim((string) $this->basePath, '/');
 		// Append slashes to the beginning and end of path if it's not empty.
 		$base_path = !empty($base_path) ? '/' . $base_path . '/' : '/';
 		// Replace file schema with the real path.

--- a/e107_plugins/import/providers/e107_import_class.php
+++ b/e107_plugins/import/providers/e107_import_class.php
@@ -139,7 +139,7 @@ class e107_import extends base_import_class
 	private function checkHtml($text)
 	{
 		$tp = e107::getParser();
-		if($tp->isHtml($text) && strpos($text,'[html]')!==0)
+		if($tp->isHtml($text) && strpos((string) $text,'[html]')!==0)
 		{
 			return "[html]".$text."[/html]";
 		}

--- a/e107_plugins/import/providers/html_import_class.php
+++ b/e107_plugins/import/providers/html_import_class.php
@@ -37,7 +37,7 @@ class html_import extends base_import_class
 	function init()
 	{
 		$this->feedUrl	= vartrue($_POST['siteUrl'],false);
-		$this->feedUrl 	= rtrim($this->feedUrl,"/");
+		$this->feedUrl 	= rtrim((string) $this->feedUrl,"/");
 
 		if(!extension_loaded("tidy")) 
 		{
@@ -250,7 +250,7 @@ class html_import extends base_import_class
 		
 		if($file == '')	{ $file = "index.html";	} // just for local file, not url. 
 			
-		$path		= md5($this->feedUrl);
+		$path		= md5((string) $this->feedUrl);
 		$local_file = $path."/".$file; 
 		$this->localPath = e_TEMP.$path."/"; 
 		
@@ -327,7 +327,7 @@ class html_import extends base_import_class
 	 */
 	function copyNewsData(&$target, &$source)
 	{
-		
+
 		if(!$content = $this->process('content_encoded',$source))
 		{
 			$body = $this->process('description',$source);	
@@ -336,14 +336,14 @@ class html_import extends base_import_class
 		{
 			$body = $content;
 		}
-				
+
 		$body 								= $this->saveImages($body,'news');
 		$keywords 							= $this->process('category',$source);
-			
-				
+
+
 		if(!vartrue($source['title'][0]))
 		{
-			list($title,$newbody) = explode("<br />",$body,2);
+			list($title,$newbody) = explode("<br />",(string) $body,2);
 			$title = strip_tags($title);
 			if(trim($newbody)!='')
 			{
@@ -354,14 +354,14 @@ class html_import extends base_import_class
 		{
 			$title = $source['title'][0];
 		}
-		
+
 		$target['news_title']					= $title;
 		//	$target['news_sef']					= $source['post_name'];
 		$target['news_body']					= "[html]".$body."[/html]";
 		//	$target['news_extended']			= '';
 		$target['news_meta_keywords']			= implode(",",$keywords);
 		//	$target['news_meta_description']	= '';
-		$target['news_datestamp']				= strtotime($source['pubDate'][0]);
+		$target['news_datestamp']				= strtotime((string) $source['pubDate'][0]);
 		//	$target['news_author']				= $source['post_author'];
 		//	$target['news_category']			= '';
 		//	$target['news_allow_comments']		= ($source['comment_status']=='open') ? 1 : 0;
@@ -374,11 +374,11 @@ class html_import extends base_import_class
 		//	$target['news_thumbnail']			= '';
 		//	$target['news_sticky']				= '';
 
-		
+
 		return $target;  // comment out to debug 
-		
+
 		$this->renderDebug($source,$target);
-		
+
 		// DEBUG INFO BELOW. 		
 		
 	}
@@ -439,7 +439,7 @@ class html_import extends base_import_class
 		$target['page_text']			= "[html]".$body."[/html]";
 	//	$target['page_metakeys']		= '';
 	//	$target['page_metadscr']		= '';
-		$target['page_datestamp']		= strtotime($source['pubDate'][0]);
+		$target['page_datestamp']		= strtotime((string) $source['pubDate'][0]);
 	//	$target['page_author']			= $source['post_author'];
 	//	$target['page_category']		= '',
 	//	$target['page_comment_flag']	= ($source['comment_status']=='open') ? 1 : 0;
@@ -495,12 +495,12 @@ class html_import extends base_import_class
 		
 		
 	//	echo htmlentities($body);
-		preg_match_all("/(((http:\/\/www)|(http:\/\/)|(www))[-a-zA-Z0-9@:%_\+.~#?&\/\/=]+)\.(jpg|jpeg|gif|png|svg)/im",$body,$matches);
+		preg_match_all("/(((http:\/\/www)|(http:\/\/)|(www))[-a-zA-Z0-9@:%_\+.~#?&\/\/=]+)\.(jpg|jpeg|gif|png|svg)/im",(string) $body,$matches);
 		$fl = e107::getFile();
 			
 		if(is_array($matches[0]))
 		{
-			$relPath = 'images/'.md5($this->feedUrl);
+			$relPath = 'images/'.md5((string) $this->feedUrl);
 			
 			if(!is_dir(e_MEDIA.$relPath))
 			{

--- a/e107_plugins/import/providers/livejournal_import_class.php
+++ b/e107_plugins/import/providers/livejournal_import_class.php
@@ -23,7 +23,7 @@ require_once('rss_import_class.php');
 class livejournal_import extends rss_import
 {
 
-	
+
 	public $title		= 'LiveJournal';
 	public $description	= 'Import up to 500 items from yourblog.livejournal.com';
 	public $supported	= array('news');
@@ -38,47 +38,47 @@ class livejournal_import extends rss_import
 	function init()
 	{
 		$mes = e107::getMessage();
-	
+
 		if(vartrue($_POST['siteUrl']))
 		{
-			$domain = preg_replace("/https?:\/\//i",'',$_POST['siteUrl']);
+			$domain = preg_replace("/https?:\/\//i",'',(string) $_POST['siteUrl']);
 			list($site,$dom,$tld) = explode(".",$domain);
-									
+
 			$this->feedUrl = "http://".$site.".livejournal.com/data/rss";	
 		}
-		
+
 		if(vartrue($_POST['siteCleanup']))
 		{
 			$this->cleanupHtml = true;
 		}	
-		
+
 		$mes->addDebug("LiveJournal Feed:".$this->feedUrl);
 	}
-		
-	
+
+
 	function config()
 	{
 		$var[0]['caption']	= "Your LiveJournal URL";
 		$var[0]['html'] 	= "<input class='tbox' type='text' name='siteUrl' size='80' value='{$_POST['bloggerUrl']}' maxlength='250' />";
 		$var[0]['help']		= "eg. http://blogname.livejournal.com";
-		
+
 		$var[1]['caption']	= "Cleanup HTML in content";
 		$var[1]['html'] 	= "<input class='tbox' type='checkbox' name='siteCleanup' size='80' value='1' />";
 		$var[1]['help']		= "Tick to enable";
-		
+
 		return $var;
 	}
 
 	function process($type,$source)
 	{
-				
+
 		switch ($type) 
 		{
 			case 'description':
 				$body = $source[$type][0];
 				if($this->cleanupHtml == TRUE)
 				{
-					$body = preg_replace("/font-family: [\w]*;/i","", $body);
+					$body = preg_replace("/font-family: [\w]*;/i","", (string) $body);
 					$body = preg_replace('/class="[\w]*" /i',"", $body);
 					$body = str_replace("<br>","<br />",$body);
 					return $body;
@@ -88,13 +88,13 @@ class livejournal_import extends rss_import
 					return $body;
 				}		
 			break;
-			
+
 			default:
 				return $source[$type][0];
 			break;
 		}		
-		
-		
+
+
 	}
 
 	//TODO Comment Import: 	

--- a/e107_plugins/import/providers/rss_import_class.php
+++ b/e107_plugins/import/providers/rss_import_class.php
@@ -140,7 +140,7 @@ class rss_import extends base_import_class
 	function copyNewsData(&$target, &$source)
 	{
 		$this->foundImages = array();
-		
+
 		if(!$content = $this->process('content_encoded',$source))
 		{
 			$body = $this->process('description',$source);	
@@ -149,14 +149,14 @@ class rss_import extends base_import_class
 		{
 			$body = $content;
 		}
-				
+
 		$body 			= $this->saveImages($body,'news');
 		$keywords 		= $this->process('category',$source);
 		$sef            = $this->process('sef',$source);
-							
+
 		if(!vartrue($source['title'][0]))
 		{
-			list($title,$newbody) = explode("<br />",$body,2);
+			list($title,$newbody) = explode("<br />",(string) $body,2);
 			$title = strip_tags($title);
 			if(trim($newbody)!='')
 			{
@@ -167,14 +167,14 @@ class rss_import extends base_import_class
 		{
 			$title = $source['title'][0];
 		}
-		
+
 		$target['news_title']					= $title;
 		$target['news_sef']					    = $sef;
 		$target['news_body']					= "[html]".$body."[/html]";
 		//	$target['news_extended']			= '';
 		$target['news_meta_keywords']			= implode(",",$keywords);
 		//	$target['news_meta_description']	= '';
-			$target['news_datestamp']			= strtotime($source['pubDate'][0]);
+			$target['news_datestamp']			= strtotime((string) $source['pubDate'][0]);
 		//	$target['news_author']				= $source['post_author'];
 		//	$target['news_category']			= '';
 		//	$target['news_allow_comments']		= ($source['comment_status']=='open') ? 1 : 0;
@@ -187,12 +187,12 @@ class rss_import extends base_import_class
 			$target['news_thumbnail']			= !empty($this->foundImages[0]) ? $this->foundImages[0] : '';
 		//	$target['news_sticky']				= '';
 
-		
-		
+
+
 		return $target;  // comment out to debug 
-		
+
 	//	$this->renderDebug($source,$target);
-		
+
 		// DEBUG INFO BELOW. 		
 		
 	}
@@ -252,7 +252,7 @@ class rss_import extends base_import_class
 		$target['page_text']			= "[html]".$body."[/html]";
 	//	$target['page_metakeys']		= '';
 	//	$target['page_metadscr']		= '';
-		$target['page_datestamp']		= strtotime($source['pubDate'][0]);
+		$target['page_datestamp']		= strtotime((string) $source['pubDate'][0]);
 	//	$target['page_author']			= $source['post_author'];
 	//	$target['page_category']		= '',
 	//	$target['page_comment_flag']	= ($source['comment_status']=='open') ? 1 : 0;
@@ -310,25 +310,25 @@ class rss_import extends base_import_class
 
 
 		$result = $tp->getTags($body, 'img');
-			
+
 		if($result)
 		{
-			$relPath = 'images/'. substr(md5($this->feedUrl),0,10);
-		
+			$relPath = 'images/'. substr(md5((string) $this->feedUrl),0,10);
+
 			if(!is_dir(e_MEDIA.$relPath))
 			{
 				mkdir(e_MEDIA.$relPath,'0755');	
 			}
-		
+
 			foreach($result['img'] as $att)
 			{
-				$filename = basename($att['src']);
+				$filename = basename((string) $att['src']);
 
 				if(file_exists(e_MEDIA.$relPath."/".$filename))
 				{
 					continue;
 				}
-					
+
 				$fl->getRemoteFile($att['src'], $relPath."/".$filename, 'media');
 
 				if(filesize(e_MEDIA.$relPath."/".$filename) > 0)
@@ -339,59 +339,59 @@ class rss_import extends base_import_class
 					$replace[] = $src;
 				}
 			}	
-		
+
 		}
 		else
 		{
 			$mes->addDebug("No Images Found: ".print_a($result,true));
 		}
-		
+
 		if(count($search))
 		{
 			$mes->addDebug("Found: ".print_a($search,true));
 			$mes->addDebug("Replaced: ".print_a($replace,true));
 			$med->import($cat,e_MEDIA.$relPath);	
 		}
-		
+
 		return str_replace($search,$replace,$body);
-		
-		
+
+
 		/*
-		
+
 	//	echo htmlentities($body);
 		preg_match_all("/(((http:\/\/www)|(http:\/\/)|(www))[-a-zA-Z0-9@:%_\+.~#?&\/\/=]+)\.(jpg|jpeg|gif|png|svg)/im",$body,$matches);
 		$fl = e107::getFile();
-			
+
 		if(is_array($matches[0]))
 		{
 			$relPath = 'images/'. substr(md5($this->feedUrl),0,10);
-			
+
 			if(!is_dir(e_MEDIA.$relPath))
 			{
 				mkdir(e_MEDIA.$relPath,'0755');	
 			}
-			
+
 			foreach($matches[0] as $link)
 			{
 				$filename = basename($link);
-				
+
 				if(file_exists($relPath."/".$filename))
 				{
 					continue;
 				}
-				
+
 				$fl->getRemoteFile($link,$relPath."/".$filename, 'media');
-				
+
 				$search[] = $link;
 				$replace[] = $tp->createConstants(e_MEDIA.$relPath."/".$filename,1);
 			}	
 		}
-		
+
 		if(count($search))
 		{
 			$med->import($cat,e_MEDIA.$relPath);	
 		}
-		
+
 		return str_replace($search,$replace,$body);*/
 		
 	}

--- a/e107_plugins/import/providers/smf_import_class.php
+++ b/e107_plugins/import/providers/smf_import_class.php
@@ -13,17 +13,17 @@ require_once(__DIR__.'/../import_classes.php');
 
 class smf_import extends base_import_class
 {
-	
+
 	public $title			= 'SMF v2.x (Simple Machines Forum)';
 	public $description		= 'Currently does not import membergroups or more than 1 post attachment ';
 	public $supported		= array('users','forum','forumthread','forumpost');
 	public $mprefix			= 'smf_';
 	public $sourceType 		= 'db';		
-	
+
 	function init()
 	{
 
-		
+
 	}
 
 	function config()
@@ -40,7 +40,7 @@ class smf_import extends base_import_class
 		return $var;
 	}
 
-	
+
   // Set up a query for the specified task.
   // Returns TRUE on success. FALSE on error
 	function setupQuery($task, $blank_user=FALSE)
@@ -50,17 +50,17 @@ class smf_import extends base_import_class
 			e107::getMessage()->addDebug("Unable to connext");
 		    return FALSE;
 		}
-		
+
 	    switch ($task)
 		{
 			case 'users' :
-				
+
 				// Set up Userclasses. 
 				if($this->ourDB && $this->ourDB->gen("SELECT * FROM {$this->DBPrefix}membergroups WHERE group_name = 'Jr. Member' "))
 				{
 					e107::getMessage()->addDebug("Userclasses Found");	
 				}	
-				
+
 		    	$result = $this->ourDB->gen("SELECT * FROM {$this->DBPrefix}members WHERE `is_activated`=1");
 				if ($result === false)
 				{
@@ -69,8 +69,8 @@ class smf_import extends base_import_class
 					return false;
 				}
 			break;
-				
-				
+
+
  			case 'forum' :
  			    $qry = "SELECT f.*, m.id_member, m.poster_name, m.poster_time FROM {$this->DBPrefix}boards AS f LEFT JOIN {$this->DBPrefix}messages AS m ON f.id_last_msg = m.id_msg GROUP BY f.id_board ";
 
@@ -82,7 +82,7 @@ class smf_import extends base_import_class
 	  		        return false;
 				}
 			break;
-				
+
 			case 'forumthread' :
 
 				$qry = "SELECT t.*, m.poster_name, m.subject, m.poster_time, m.id_member, l.poster_name as lastpost_name, l.poster_time as lastpost_time, l.id_member as lastpost_user FROM {$this->DBPrefix}topics AS t
@@ -94,7 +94,7 @@ class smf_import extends base_import_class
 				if ($result === false) return false;
 
 			break;
-				
+
 			case 'forumpost' :
 
 				$qry = "SELECT m.*, a.filename, a.fileext, a.size FROM {$this->DBPrefix}messages AS m LEFT JOIN {$this->DBPrefix}attachments AS a ON m.id_msg = a.id_msg GROUP BY m.id_msg ORDER BY m.id_msg ASC ";
@@ -107,18 +107,18 @@ class smf_import extends base_import_class
 				//$result = $this->ourDB->gen("SELECT * FROM `{$this->DBPrefix}forums_track`");
 				//if ($result === FALSE) return FALSE;	  
 			break;
-				
+
 			default :
 		    return FALSE;
 		}
-		
+
 		$this->copyUserInfo = false;
 		$this->currentTask = $task;
 		return TRUE;
 	}
 
-	
-	
+
+
 	function convertUserclass($data)
 	{
 		if(empty($data))
@@ -153,21 +153,21 @@ class smf_import extends base_import_class
 		8	Hero Member			500	0	5#star.gif	0	0	-2	
 		*/
 	}	
-	
+
 	function convertAdmin($data)
 	{
-		
+
 		if($data == 1)
 		{
 			return 1;	
 		}	
-		
+
 	}
 
   //------------------------------------
   //	Internal functions below here
   //------------------------------------
-  
+
   // Copy data read from the DB into the record to be returned.
 	function copyUserData(&$target, &$source)
 	{
@@ -175,7 +175,7 @@ class smf_import extends base_import_class
 		{
 			 $target['user_id'] = 0; // $source['id_member'];
 		}
-		
+
 		$target['user_name'] 		= $source['real_name'];
 		$target['user_login'] 		= $source['member_name'];
 		$target['user_loginname'] 	= $source['memberName'];
@@ -201,10 +201,10 @@ class smf_import extends base_import_class
 		$target['user_birthday']	= $source['birthdate'];
 		$target['user_admin']		= $this->convertAdmin($source['id_group']);
 		$target['user_class']		= $this->convertUserclass($source['id_group']);
-		
+
 		$target['user_plugin_forum_viewed'] = 0;
 		$target['user_plugin_forum_posts']	= $source['posts'];
-		
+
 	//    $target['user_language'] = $source['lngfile'];			// Guess to verify
 		return $target;
 		}
@@ -217,7 +217,7 @@ class smf_import extends base_import_class
 	 */
 	function copyForumData(&$target, &$source)
 	{
-		
+
 		$target['forum_id'] 				= $source['id_board'];
 		$target['forum_name'] 				= $source['name'];
 		$target['forum_description'] 		= $source['description'];
@@ -225,7 +225,7 @@ class smf_import extends base_import_class
 		$target['forum_sub']				= ($source['child_level'] > 1) ? $source['id_parent'] : 0;
 		$target['forum_datestamp']			= time();
 		$target['forum_moderators']			= "";
-	
+
 		$target['forum_threads'] 			= $source['num_topics'];
 		$target['forum_replies']			= $source['num_posts'];
 		$target['forum_lastpost_user']		= $source['id_member'];
@@ -237,20 +237,20 @@ class smf_import extends base_import_class
 		$target['forum_threadclass']	    = e_UC_MEMBER;
 		$target['forum_options']	        = e_UC_MEMBER;
 		$target['forum_sef']                = eHelper::title2sef($source['name'],'dashl');
-		
+
 		return $target;
 
-		
+
 	}
 
-	
+
 	/**
 	 * $target - e107 forum_threads
 	 * $source - smf topics. 
 	 */
 	function copyForumThreadData(&$target, &$source)
 	{
-		
+
 		$target['thread_id'] 				= (int) $source['id_topic'];
 		$target['thread_name'] 				= $source['subject'];
 		$target['thread_forum_id'] 			= (int) $source['id_board'];
@@ -265,12 +265,12 @@ class smf_import extends base_import_class
 		$target['thread_lastuser_anon'] 	= empty($source['lastpost_user']) ? $source['lastpost_name'] : null;
 		$target['thread_total_replies'] 	= (int) $source['num_replies'];
 		$target['thread_options'] 			= null;
-	
+
 		return $target;
-		
+
 	}
 
- 	
+
 	/**
 	 * $target - e107_forum_post table
 	 * $source -smf
@@ -293,7 +293,7 @@ class smf_import extends base_import_class
 
 
 		return $target;
-		
+
 
 	}
 
@@ -370,7 +370,7 @@ CREATE TABLE {$db_prefix}polls (
  * 
  * 
  * 
- 
+
 
  * 
  * INSERT INTO {$db_prefix}membergroups

--- a/e107_plugins/import/providers/template_import_class.php
+++ b/e107_plugins/import/providers/template_import_class.php
@@ -177,7 +177,7 @@ class template_import extends base_import_class
 		$target['user_lastpost'] 	    = $source[''];
 		$target['user_chats'] 		    = $source[''];
 		$target['user_comments'] 	    = $source[''];
-	
+
 		$target['user_ip'] 			    = $source[''];
 		$target['user_prefs'] 		    = $source[''];
 		$target['user_visits'] 		    = $source[''];
@@ -196,7 +196,7 @@ class template_import extends base_import_class
 		$target['user_timezone'] 	    = $source[''];
 
 		$this->debug($source,$target);
-		
+
 		//return $target;
 	}
 
@@ -447,7 +447,7 @@ class template_import extends base_import_class
 		//$text = e107::getParser()->toDb($text);
 		return $text;
 					
-		$text 		= html_entity_decode($text,ENT_QUOTES,'UTF-8');
+		$text 		= html_entity_decode((string) $text,ENT_QUOTES,'UTF-8');
 
 		$detected 	= mb_detect_encoding($text); // 'ISO-8859-1'
 		$text 		= iconv($detected,'UTF-8',$text);

--- a/e107_plugins/import/providers/wordpress_import_class.php
+++ b/e107_plugins/import/providers/wordpress_import_class.php
@@ -37,10 +37,10 @@ class wordpress_import extends base_import_class
 	
 	function init()
 	{
-		
-		
+
+
 		$this->newsAuthor	= intval($_POST['news_author']);
-		
+
 	//	if($data = e107::getDb('phpbb')->retrieve('userclass_classes','userclass_id',"userclass_name='FORUM_MODERATOR' "))
 	//	{
 	//		$this->forum_moderator_class = $data;
@@ -169,13 +169,13 @@ class wordpress_import extends base_import_class
 		{
 			 $target['user_id'] = $source['ID'];
 		}
-		
+
 		$target['user_name'] 		= $source['user_nicename'];
 		$target['user_loginname'] 	= $source['user_login'];
 		$target['user_password'] 	= $source['user_pass'];   // needs to be salted!!!!
 		$target['user_email'] 		= $source['user_email'];
 		$target['user_hideemail'] 	= $source['user_hideemail'];
-		$target['user_join'] 		= strtotime($source['user_registered']);
+		$target['user_join'] 		= strtotime((string) $source['user_registered']);
 		$target['user_admin'] 		= ($user_meta['administrator'] == 1) ? 1 : 0;
 		$target['user_lastvisit'] 	= $source['user_lastvisit'];
 		$target['user_login'] 		= $source['firstname']." ".$source['lastname'];
@@ -188,7 +188,7 @@ class wordpress_import extends base_import_class
 		$target['user_lastpost'] 	= $source['user_lastpost'];
 		$target['user_chats'] 		= $source['user_chats'];
 		$target['user_comments'] 	= $source['user_comments'];
-	
+
 		$target['user_ip'] 			= $source['user_ip'];
 		$target['user_prefs'] 		= $source['user_prefs'];
 		$target['user_visits'] 		= $source['user_visits'];
@@ -207,7 +207,7 @@ class wordpress_import extends base_import_class
 		$target['user_timezone'] 	= $source['user_timezone'];
 
 		$this->renderDebug($source,$target);
-		
+
 	//return $target;
 	}
 
@@ -251,7 +251,7 @@ class wordpress_import extends base_import_class
 		//	$target['news_extended']			= '';
 		//	$target['news_meta_keywords']		= '';
 		//	$target['news_meta_description']	= '';
-			$target['news_datestamp']			= strtotime($source['post_date']);
+			$target['news_datestamp']			= strtotime((string) $source['post_date']);
 			$target['news_author']				= ($this->newsAuthor !=0) ? $this->newsAuthor : $source['post_author'];
 		//	$target['news_category']			= '';
 			$target['news_allow_comments']		= ($source['comment_status']=='open') ? 1 : 0;
@@ -310,7 +310,7 @@ class wordpress_import extends base_import_class
 		$target['page_text']			= (vartrue($source['post_content'])) ? "[html]".$this->convertText($source['post_content'])."[/html]" : ""; 
 		$target['page_metakeys']		= '';
 		$target['page_metadscr']		= '';
-		$target['page_datestamp']		= strtotime($source['post_date']);
+		$target['page_datestamp']		= strtotime((string) $source['post_date']);
 		$target['page_author']			= $source['post_author'];
 	//	$target['page_category']		= '',
 		$target['page_comment_flag']	= ($source['comment_status']=='open') ? 1 : 0;
@@ -394,7 +394,7 @@ class wordpress_import extends base_import_class
 		//$text = e107::getParser()->toDb($text);
 		return $text;
 					
-		$text 		= html_entity_decode($text,ENT_QUOTES,'UTF-8');
+		$text 		= html_entity_decode((string) $text,ENT_QUOTES,'UTF-8');
 
 		$detected 	= mb_detect_encoding($text); // 'ISO-8859-1'
 		$text 		= iconv($detected,'UTF-8',$text);

--- a/e107_plugins/import/providers/xoops_import_class.php
+++ b/e107_plugins/import/providers/xoops_import_class.php
@@ -451,7 +451,7 @@ class xoops_import extends base_import_class
 		//$text = e107::getParser()->toDb($text);
 		return $text;
 					
-		$text 		= html_entity_decode($text,ENT_QUOTES,'UTF-8');
+		$text 		= html_entity_decode((string) $text,ENT_QUOTES,'UTF-8');
 
 		$detected 	= mb_detect_encoding($text); // 'ISO-8859-1'
 		$text 		= iconv($detected,'UTF-8',$text);

--- a/e107_plugins/linkwords/e_parse.php
+++ b/e107_plugins/linkwords/e_parse.php
@@ -97,7 +97,7 @@ class linkwords_parse
 
 	private function loadRow($lw, $row)
 	{
-		$lw = trim($lw);
+		$lw = trim((string) $lw);
 
 		if(empty($lw))
 		{
@@ -143,7 +143,7 @@ class linkwords_parse
 		$cflag = false; // commented code prsent.
 
 		// Shouldn't need utf-8 on next line - just looking for HTML tags
-		$content = preg_split('#(<.*?>)#mis', $text, -1, PREG_SPLIT_NO_EMPTY | PREG_SPLIT_DELIM_CAPTURE );
+		$content = preg_split('#(<.*?>)#mis', (string) $text, -1, PREG_SPLIT_NO_EMPTY | PREG_SPLIT_DELIM_CAPTURE );
 
 		$range = range(1,5);
 
@@ -289,12 +289,12 @@ class linkwords_parse
 		}
 
 		// This splits the text into blocks, some of which will precisely contain a linkword
-		$split_line = preg_split('#\b('.$lw.')(\s|\b)#i'.$this->utfMode, $text, -1, PREG_SPLIT_NO_EMPTY | PREG_SPLIT_DELIM_CAPTURE );		// *utf (selected)
+		$split_line = preg_split('#\b('.$lw.')(\s|\b)#i'.$this->utfMode, (string) $text, -1, PREG_SPLIT_NO_EMPTY | PREG_SPLIT_DELIM_CAPTURE );		// *utf (selected)
 		//	$class = "".implode(' ',$lwClass)."' ";
 
 		$class = implode(' ',$lwClass);
 
-		$hash = md5($lw);
+		$hash = md5((string) $lw);
 		$this->hash = $hash;
 
 		if(!isset($this->wordCount[$hash]))
@@ -373,7 +373,7 @@ class linkwords_parse
 
 		// Now see if disabled on specific pages
 		$check_url = e_SELF . (defined('e_QUERY') ? "?" . e_QUERY : '');
-		$this->block_list = explode("|", substr(varset($pref['lw_page_visibility']), 2));    // Knock off the 'show/hide' flag
+		$this->block_list = explode("|", substr((string) varset($pref['lw_page_visibility']), 2));    // Knock off the 'show/hide' flag
 
 		foreach($this->block_list as $p)
 		{

--- a/e107_plugins/list_new/list_admin_class.php
+++ b/e107_plugins/list_new/list_admin_class.php
@@ -51,13 +51,13 @@ class list_admin
 	//	{
 	//		if($value != LIST_ADMIN_2){ $temp[$tp->toDB($key)] = $tp->toDB($value); }
 	//	}
-		
+
 		e107::getPlugConfig('list_new')->reset()->setPref($_POST)->save(true);
 
 	//	retrieve with e107::pref('list_new');
-		
+
 		return;
-		
+
 		/*
 		if ($this->e107->admin_log->logArrayDiffs($temp, $list_pref, 'LISTNEW_01'))
 		{
@@ -562,7 +562,7 @@ class list_admin
 	{
 
 		$frm = e107::getForm();
-		
+
 		$this->row['TOPIC'] = LIST_ADMIN_11;
 		$this->row['FIELD'] = $frm->admin_button('update_menu',LIST_ADMIN_2,'update');
 

--- a/e107_plugins/list_new/list_class.php
+++ b/e107_plugins/list_new/list_class.php
@@ -104,7 +104,7 @@ class listclass
 	function getListPrefs()
 	{
 		$listPrefs = e107::pref('list_new'); //TODO Convert from old format to new.   
-		
+
 		//insert default preferences
 		if (empty(	$listPrefs))
 		{
@@ -149,9 +149,9 @@ class listclass
 		//get all sections to use
 		foreach($this->list_pref as $key=>$value)
 		{
-			if(substr($key,-$len) == "_{$mode}_display" && $value == "1")
+			if(substr((string) $key,-$len) == "_{$mode}_display" && $value == "1")
 			{
-				$sections[] = substr($key,0,-$len);
+				$sections[] = substr((string) $key,0,-$len);
 			}
 		}
 		return $sections;

--- a/e107_plugins/list_new/section/list_news.php
+++ b/e107_plugins/list_new/section/list_news.php
@@ -136,6 +136,6 @@ class list_news
 		$replace[4] = '\\2';
 		$search[5] = "/\<a href=&#039;(.*?)&#039;>(.*?)<\/a>/si";
 		$replace[5] = '\\2';
-		return preg_replace($search, $replace, $title);
+		return preg_replace($search, $replace, (string) $title);
 	}
 }

--- a/e107_plugins/login_menu/login_menu.php
+++ b/e107_plugins/login_menu/login_menu.php
@@ -52,7 +52,7 @@ if (defined('CORRUPT_COOKIE') && CORRUPT_COOKIE == TRUE)
 	{$bullet} <a href='".SITEURL."index.php?logout'>".LAN_LOGOUT."</a></div>";
 	$ns->tablerender(LAN_LOGINMENU_9, $text, 'login_error');
 }
-    
+
 //Image code
 $use_imagecode = ($pref['logcode'] && extension_loaded('gd'));
 
@@ -64,7 +64,7 @@ if ($use_imagecode)
 }
 
 $text = '';
-    
+
 // START LOGGED CODE
 if (USER == TRUE || ADMIN == TRUE)
 {
@@ -127,16 +127,16 @@ if (USER == TRUE || ADMIN == TRUE)
 			$menu_data['new_users'] = $sql->count('user', '(user_join)', 'WHERE user_join > '.$time);
 			$new_total += $menu_data['new_users'];
 		}
-		
+
 		// ------------ Enable stats / other ---------------
-		
+
 		$menu_data['enable_stats'] = $menu_data || vartrue($loginPrefs['external_stats']) ? true : false;
 		$menu_data['new_total'] = $new_total + $loginClass->get_stats_total();
 		$menu_data['link_bullet'] = $bullet;
 		$menu_data['link_bullet_src'] = $bullet_src;
-		
+
 		// ------------ List New Link ---------------
-		
+
 		$menu_data['listnew_link'] = '';
 		if ($menu_data['new_total'] && array_key_exists('list_new', $pref['plug_installed'])) 
         {
@@ -146,14 +146,14 @@ if (USER == TRUE || ADMIN == TRUE)
 		// ------------ Pass the data & parse ------------
 		e107::setRegistry('login_menu_data', $menu_data);
 		$text = $tp->parseTemplate($LOGIN_MENU_LOGGED, true, $login_menu_shortcodes);
-    
+
     //menu caption
 	if (file_exists(THEME.'images/login_menu.png')) {
 		$caption = '<img src="'.THEME_ABS.'images/login_menu.png" alt="" />'.LAN_LOGINMENU_5.' '.USERNAME;
 	} else {
 		$caption = LAN_LOGINMENU_5.' '.USERNAME;
 	}
-	
+
 
 	$ns->tablerender($caption, $text, 'login');
 

--- a/e107_plugins/login_menu/login_menu_class.php
+++ b/e107_plugins/login_menu/login_menu_class.php
@@ -86,7 +86,7 @@ class login_menu_class
 		{
             foreach ($list_arr as $item) 
 			{
-				$path = explode('/', trim($item['path'], '/.'));
+				$path = explode('/', trim((string) $item['path'], '/.'));
                 $tmp = end($path);
                 
                 if(e107::isInstalled($tmp)) 
@@ -98,7 +98,7 @@ class login_menu_class
 
         if($sort && $this->loginPrefs['external_links']) 
 		{
-            $tmp = array_flip(explode(',', $this->loginPrefs['external_links']));
+            $tmp = array_flip(explode(',', (string) $this->loginPrefs['external_links']));
             
             $cnt = count($tmp);
             foreach ($list as $value) {
@@ -123,8 +123,8 @@ class login_menu_class
         //$lbox_admin = varsettrue($eplug_admin, false);
         $coreplugs = $this->get_coreplugs(); 
         
-        $lprefs = vartrue($this->loginPrefs['external_links']) ? explode(',', $this->loginPrefs['external_links']) : array();
-        $sprefs = vartrue($this->loginPrefs['external_stats']) ? explode(',', $this->loginPrefs['external_stats']) : array();
+        $lprefs = vartrue($this->loginPrefs['external_links']) ? explode(',', (string) $this->loginPrefs['external_links']) : array();
+        $sprefs = vartrue($this->loginPrefs['external_stats']) ? explode(',', (string) $this->loginPrefs['external_stats']) : array();
         
         if($active) 
 		{
@@ -232,7 +232,7 @@ class login_menu_class
         $lbox_infos = $this->parse_external_list(false);
         if(!vartrue($lbox_infos['links'])) return '';
         
-        $enabled = vartrue($this->loginPrefs['external_links']) ? explode(',', $this->loginPrefs['external_links']) : array();
+        $enabled = vartrue($this->loginPrefs['external_links']) ? explode(',', (string) $this->loginPrefs['external_links']) : array();
         
         $num = 1;
         foreach ($lbox_infos['links'] as $id => $stack) {
@@ -284,7 +284,7 @@ class login_menu_class
 
         if(!$lbox_infos) return '';
 
-        $enabled = vartrue($this->loginPrefs['external_stats']) ? explode(',', $this->loginPrefs['external_stats']) : array();
+        $enabled = vartrue($this->loginPrefs['external_stats']) ? explode(',', (string) $this->loginPrefs['external_stats']) : array();
         
         $num = 1;
         foreach ($lbox_infos as $id => $stack) 
@@ -324,7 +324,7 @@ class login_menu_class
 		}
             
         $ret = 0;
-        $lbox_active_sorted = $this->loginPrefs['external_stats'] ? explode(',', $this->loginPrefs['external_stats']) : array();
+        $lbox_active_sorted = $this->loginPrefs['external_stats'] ? explode(',', (string) $this->loginPrefs['external_stats']) : array();
         
         foreach ($lbox_active_sorted as $stackid) 
 		{ 

--- a/e107_plugins/login_menu/login_menu_shortcodes.php
+++ b/e107_plugins/login_menu/login_menu_shortcodes.php
@@ -340,7 +340,7 @@ e107::getLanguage()->bcDefs($bcDefs);
 				}
 
 				$lbox_infos = $lmc->parse_external_list(true, false);
-				$lbox_active = $menu_pref['login_menu']['external_links'] ? explode(',', $menu_pref['login_menu']['external_links']) : array();
+				$lbox_active = $menu_pref['login_menu']['external_links'] ? explode(',', (string) $menu_pref['login_menu']['external_links']) : array();
 
 				if(!vartrue($lbox_infos['links']))
 				{
@@ -467,7 +467,7 @@ e107::getLanguage()->bcDefs($bcDefs);
 
 				if(!vartrue($lbox_infos['stats'])) return '';
 
-				$lbox_active_sorted = $menu_pref['login_menu']['external_stats'] ? explode(',', $menu_pref['login_menu']['external_stats']) : array();
+				$lbox_active_sorted = $menu_pref['login_menu']['external_stats'] ? explode(',', (string) $menu_pref['login_menu']['external_stats']) : array();
 
 				$ret = array();
 

--- a/e107_plugins/news/e_gsitemap.php
+++ b/e107_plugins/news/e_gsitemap.php
@@ -119,7 +119,7 @@ class news_gsitemap
 				'lastmod'   => !empty($row['news_modified']) ? $row['news_modified'] : (int) $row['news_datestamp'],
 				'freq'      => 'hourly',
 				'priority'  => 0.5,
-				'image'     => (strpos($imgUrl, 'http') === 0) ? $imgUrl : SITEURLBASE.$sc->sc_news_image(['item'=>1, 'type'=>'src']),
+				'image'     => (strpos((string) $imgUrl, 'http') === 0) ? $imgUrl : SITEURLBASE.$sc->sc_news_image(['item'=>1, 'type'=>'src']),
 			];
 		}
 

--- a/e107_plugins/news/e_related.php
+++ b/e107_plugins/news/e_related.php
@@ -23,9 +23,9 @@ class news_related // include plugin-folder in the name.
 	{
 		$sql = e107::getDb();
 		$items = array();
-			
+
 		$tag_regexp = "'(^|,)(".str_replace(",", "|", $tags).")(,|$)'";
-		
+
 	//	$query = "SELECT * FROM #news WHERE news_id != ".$parm['current']." AND news_class REGEXP '".e_CLASS_REGEXP."'  AND news_meta_keywords REGEXP ".$tag_regexp."  ORDER BY news_datestamp DESC LIMIT ".$parm['limit'];
 
 		$query = "SELECT n.*, nc.category_id, nc.category_name, nc.category_sef 
@@ -38,7 +38,7 @@ class news_related // include plugin-folder in the name.
 		{		
 			while($row = $sql->fetch())
 			{
-				$thumbs = !empty($row['news_thumbnail']) ?  explode(",",$row['news_thumbnail']) : array();
+				$thumbs = !empty($row['news_thumbnail']) ?  explode(",",(string) $row['news_thumbnail']) : array();
 
 				$items[] = array(
 					'title'			=> varset($row['news_title']),
@@ -48,7 +48,7 @@ class news_related // include plugin-folder in the name.
 					'date'			=> e107::getParser()->toDate(varset($row['news_datestamp']), 'short'),
 				);
 			}
-			
+
 			return $items;
 	    }
 		//elseif(ADMIN)

--- a/e107_plugins/news/e_rss.php
+++ b/e107_plugins/news/e_rss.php
@@ -142,7 +142,7 @@ class news_rss // plugin-folder + '_rss'
 
 		if($this->showImages == true && !empty($row['news_thumbnail']))
 		{
-			$tmp = explode(",", $row['news_thumbnail']);
+			$tmp = explode(",", (string) $row['news_thumbnail']);
 
 			foreach($tmp as $img)
 			{
@@ -166,7 +166,7 @@ class news_rss // plugin-folder + '_rss'
 			return '';
 		}
 
-		$tmp = explode(",", $row['news_thumbnail']);
+		$tmp = explode(",", (string) $row['news_thumbnail']);
 
 		$ret = array();
 

--- a/e107_plugins/news/e_search.php
+++ b/e107_plugins/news/e_search.php
@@ -8,7 +8,7 @@
  * 
  * Chatbox e_search addon 
  */
- 
+
 
 if (!defined('e107_INIT')) { exit; }
 
@@ -17,15 +17,15 @@ if (!defined('e107_INIT')) { exit; }
 
 class news_search extends e_search // include plugin-folder in the name.
 {
-		
+
 	function config()
 	{
 		$sql = e107::getDb();
-		
+
 		$catList = array();
-		
+
 		$catList[] = array('id' => 'all', 'title' => LAN_SEARCH_51);
-		
+
 		if ($sql ->select("news_category", "category_id, category_name")) 
 		{
 			while($row = $sql->fetch()) 
@@ -34,14 +34,14 @@ class news_search extends e_search // include plugin-folder in the name.
 			//	$advanced_caption['title'][$row['category_id']] = 'News -> '.$row['category_name'];
 			}
 		}
-		
-		
+
+
 		$matchList = array(
 					array('id' => 0, 'title' => LAN_SEARCH_53),
 					array('id' => 1, 'title' => LAN_SEARCH_54)
 		);
 
-			
+
 		$search = array(
 			'name'			=> LAN_SEARCH_98,
 			'table'			=> 'news AS n LEFT JOIN #news_category AS c ON n.news_category = c.category_id',
@@ -51,10 +51,10 @@ class news_search extends e_search // include plugin-folder in the name.
 								'date'=> array('type'	=> 'date',			'text' => LAN_DATE_POSTED),
 								'match'=> array('type'	=> 'dropdown',		'text' =>  LAN_SEARCH_52, 'list'=>$matchList)
 							),
-							
+
 			'return_fields'	=> array('n.news_id', 'n.news_title', 'n.news_sef', 'n.news_body', 'n.news_extended', 'n.news_allow_comments', 'n.news_datestamp', 'n.news_category', 'c.category_name'), 
 			'search_fields'	=> array('n.news_title' => '1.2', 'n.news_body' => '0.6', 'n.news_extended' => '0.6', 'n.news_summary' => '1.2', 'n.news_meta_keywords'=>'1.1', 'n.news_meta_description'=>'1.1'), // fields and their weights.
-	
+
 			'order'			=> array('news_datestamp' => 'DESC'),
 			'refpage'		=> 'news.php'
 		);
@@ -69,18 +69,18 @@ class news_search extends e_search // include plugin-folder in the name.
 	function compile($row)
 	{
 		$tp = e107::getParser();
-		
+
 		$res = array();
-				
+
 		$res['link'] 		= e107::getUrl()->create('news/view/item', $row);//$row['news_allow_comments'] ? "news.php?item.".$row['news_id'] : "comment.php?comment.news.".$row['news_id'];
 		$res['pre_title'] 	= $tp->toHTML($row['category_name'],false,'TITLE')." | ";
 		$res['title'] 		= $row['news_title'];
 		$res['summary'] 	= $row['news_body'].' '.$row['news_extended'];
 		$res['detail'] 		= LAN_SEARCH_3.$tp->toDate($row['news_datestamp'], "long");
 		$res['image']		= $row['news_thumbnail'];
-		
+
 		return $res;
-		
+
 	}
 
 
@@ -92,22 +92,22 @@ class news_search extends e_search // include plugin-folder in the name.
 	function where($parm=null)
 	{
 		$tp = e107::getParser();
-	
+
 		$time = time();
-		
+
 		$qry = "(news_start < ".$time.") AND (news_end=0 OR news_end > ".$time.") AND news_class IN (".USERCLASS_LIST.") AND";
-		
+
 		if (isset($parm['cat']) && $parm['cat'] != 'all') {
 			$qry .= " c.category_id='".intval($parm['cat'])."' AND";
 		}
-		
+
 		if (isset($parm['time']) && is_numeric($parm['time'])) {
 			$qry .= " n.news_datestamp ".($parm['on'] == 'new' ? '>=' : '<=')." '".(time() - $parm['time'])."' AND";
 		}
-				
+
 		return $qry;
 	}
-	
+
 
 }
 

--- a/e107_plugins/news/news.php
+++ b/e107_plugins/news/news.php
@@ -211,7 +211,7 @@ class news_front
 
 	private function getRenderId()
 	{
-		$tmp = explode('/',$this->route);
+		$tmp = explode('/',(string) $this->route);
 
 		if(!empty($this->templateKey))
 		{
@@ -385,13 +385,13 @@ class news_front
 
 		$tp = e107::getParser();
 
-		if(vartrue($_GET['tag']) || substr($this->action,0,4) == 'tag=')
+		if(vartrue($_GET['tag']) || substr((string) $this->action,0,4) == 'tag=')
 		{
 
 			$this->route = 'news/list/tag';
 			if(!vartrue($_GET['tag']))
 			{
-				list($this->action,$word) = explode("=",$this->action,2);
+				list($this->action,$word) = explode("=",(string) $this->action,2);
 				$_GET['tag'] = $word;
 				unset($word,$tmp);
 			}
@@ -400,13 +400,13 @@ class news_front
 			$this->from = intval(varset($_GET['page'],0));
 		}
 
-		if(!empty($_GET['author']) || substr($this->action,0,4) == 'author=')
+		if(!empty($_GET['author']) || substr((string) $this->action,0,4) == 'author=')
 		{
 
 			$this->route = 'news/list/author';
 			if(!vartrue($_GET['author']))
 			{
-				list($action,$author) = explode("=",$this->action,2);
+				list($action,$author) = explode("=",(string) $this->action,2);
 				$_GET['author'] = $author;
 				unset($author,$tmp);
 			}
@@ -631,7 +631,7 @@ class news_front
 
 
 
-				$title = strip_tags($title);
+				$title = strip_tags((string) $title);
 
 				$this->dayMonth = $title;
 
@@ -725,8 +725,8 @@ class news_front
 			// include news-thumbnail/image in meta. - always put this one first.
 			if(!empty($news['news_thumbnail']))
 			{
-				$iurl = (substr($news['news_thumbnail'],0,3)=="{e_") ? $news['news_thumbnail'] : SITEURL.e_IMAGE."newspost_images/".$news['news_thumbnail'];
-				$tmp = explode(",", $iurl);
+				$iurl = (substr((string) $news['news_thumbnail'],0,3)=="{e_") ? $news['news_thumbnail'] : SITEURL.e_IMAGE."newspost_images/".$news['news_thumbnail'];
+				$tmp = explode(",", (string) $iurl);
 
 				if(!empty($tmp[0]) && substr($tmp[0],-8) !== '.youtube')
 				{
@@ -756,7 +756,7 @@ class news_front
 			foreach($youtube as $yt)
 			{
 				if($c == 3){ break; }
-				list($img,$tmp) = explode("?",$yt);
+				list($img,$tmp) = explode("?",(string) $yt);
 				e107::meta('og:image',"https://img.youtube.com/vi/".$img."/0.jpg");
 				$c++;
 			}
@@ -773,7 +773,7 @@ class news_front
 			if($news['news_meta_keywords'] && !defined('META_KEYWORDS'))
 			{
 				e107::meta('keywords',$news['news_meta_keywords']);
-				$tmp = explode(",",$news['news_meta_keywords']);
+				$tmp = explode(",",(string) $news['news_meta_keywords']);
 				foreach($tmp as $t)
 				{
 					e107::meta('article:tag', trim($t));
@@ -1060,8 +1060,8 @@ class news_front
 			{
 				if(!empty($row['news_thumbnail']))
 				{
-					$iurl = (substr($row['news_thumbnail'],0,3)=="{e_") ? $row['news_thumbnail'] : SITEURL.e_IMAGE."newspost_images/".$row['news_thumbnail'];
-					$tmp = explode(",", $iurl);
+					$iurl = (substr((string) $row['news_thumbnail'],0,3)=="{e_") ? $row['news_thumbnail'] : SITEURL.e_IMAGE."newspost_images/".$row['news_thumbnail'];
+					$tmp = explode(",", (string) $iurl);
 
 					if($tp->isImage($tmp[0]))
 					{
@@ -1179,7 +1179,7 @@ class news_front
 		{
 			e107::setRegistry('core/news/pagination', $parms);
 			$text .= $tp->parseTemplate($template['end']);
-			if(strpos($template['end'], '{NEWS_PAGINATION') !== false)
+			if(strpos((string) $template['end'], '{NEWS_PAGINATION') !== false)
 			{
 				$paginationSC = true;
 				$this->addDebug("Pagination Shortcode", 'true');
@@ -1979,7 +1979,7 @@ class news_front
 				e107::setRegistry('core/news/pagination', $parms);
 				$nsc = e107::getScBatch('news')->setScVar('news_item', $newsAr[1])->setScVar('param', $param);
 				echo $tp->parseTemplate($tmpl['end'], true, $nsc);
-				if(strpos($tmpl['end'], '{NEWS_PAGINATION') !== false) // BC fix.
+				if(strpos((string) $tmpl['end'], '{NEWS_PAGINATION') !== false) // BC fix.
 				{
 					$paginationSC = true;
 					$this->addDebug("Pagination Shortcode", 'true');

--- a/e107_plugins/news/news_archive_menu.php
+++ b/e107_plugins/news/news_archive_menu.php
@@ -36,7 +36,7 @@ if(ADMIN && empty($template))
 {
 	$text = "Missing Template. Check that your theme's news_menu_template.php file contains an 'archive' template. ";
 }
-  
+
 foreach($arr as $year=>$val)
 {
 	if($year == date('Y'))
@@ -51,17 +51,17 @@ foreach($arr as $year=>$val)
 	}
 
 	$id = "news-archive-".$year;
- 
+
 
   $var = array('EXPANDOPEN' => $expandOpen,
                'YEAR_ID' => $id,
                'YEAR_NAME' => $year,
                'YEAR_DISPLAY' => $displayYear
- 
+
    );
- 
+
   $text .=  $tp->simpleParse($template['year_start'], $var);
- 
+
 		foreach($val as $month=>$items)
 		{
 			//$displayMonth = ($mCount === 1) ? 'display:block': 'display:none';
@@ -72,16 +72,16 @@ foreach($arr as $year=>$val)
                    'MONTH_NAME' => $monthLabels[$month],
                    'MONTH_COUNT'=> count($items),
       );
-         
+
 			$text .=  $tp->simpleParse($template['month_start'], $var);
- 
+
       /*
 			if(!empty($parm['badges'])) // param only (no menu-manager config. To be replaced by template.
 			{
 				$num = count($items);
 				$text .= "<span class='badge'>".$num."</span>";
 			} */
- 
+
 
 			foreach($items as $row)
 			{
@@ -93,7 +93,7 @@ foreach($arr as $year=>$val)
 			}
 			$text .= $template['month_end'];
 		}
- 
+
 	$text .= $template['year_end'];
 
 }

--- a/e107_plugins/news/news_months_menu.php
+++ b/e107_plugins/news/news_months_menu.php
@@ -31,9 +31,9 @@ if(false === $cached)
 	{
 		function newsFormatDate($year, $month, $day = "") {
 			$date = $year;
-			$date .= (strlen($month) < 2)?"0".$month:
+			$date .= (strlen((string) $month) < 2)?"0".$month:
 			$month;
-			$date .= (strlen($day) < 2 && $day != "")?"0".$day:
+			$date .= (strlen((string) $day) < 2 && $day != "")?"0".$day:
 			$day;
 			return $date;
 		}

--- a/e107_plugins/newsfeed/admin_config.php
+++ b/e107_plugins/newsfeed/admin_config.php
@@ -225,7 +225,7 @@ class newsfeed_form_ui extends e_admin_form_ui
 
 			case 'write': // Edit Page
 
-				$tmp = explode('::',$curVal);
+				$tmp = explode('::',(string) $curVal);
 
 				return $frm->text('newsfeed_image',$tmp[0], 255, 'size=large');
 			break;
@@ -275,7 +275,7 @@ class newsfeed_form_ui extends e_admin_form_ui
 		{
 			case 'read': // List Page
 				$data = $this->getController()->getListModel()->get('newsfeed_image');
-				list($image,$menu,$main) = explode('::',$data);
+				list($image,$menu,$main) = explode('::',(string) $data);
 
 				return intval($main);
 			break;
@@ -283,7 +283,7 @@ class newsfeed_form_ui extends e_admin_form_ui
 			case 'write': // Edit Page
 
 				$data = $this->getController()->getModel()->get('newsfeed_image');
-				list($image,$menu,$main) = explode('::',$data);
+				list($image,$menu,$main) = explode('::',(string) $data);
 
 				if(empty($main))
 				{
@@ -310,14 +310,14 @@ class newsfeed_form_ui extends e_admin_form_ui
 		{
 			case 'read': // List Page
 				$data = $this->getController()->getListModel()->get('newsfeed_image');
-				list($image,$menu,$main) = explode('::',$data);
+				list($image,$menu,$main) = explode('::',(string) $data);
 
 				return intval($menu);
 			break;
 
 			case 'write': // Edit Page
 				$data = $this->getController()->getModel()->get('newsfeed_image');
-				list($image,$menu,$main) = explode('::',$data);
+				list($image,$menu,$main) = explode('::',(string) $data);
 
 				if(empty($menu))
 				{

--- a/e107_plugins/newsfeed/newsfeed_functions.php
+++ b/e107_plugins/newsfeed/newsfeed_functions.php
@@ -96,17 +96,17 @@ class newsfeedClass
 			while ($row = $sql->fetch())
 			{
 				$nfID = $row['newsfeed_id'];
-				
+
 				if (!empty($row['newsfeed_data']))
 				{
 					$this->newsList[$nfID]['newsfeed_data'] = $row['newsfeed_data'];		// Pull out the actual news - might as well since we're here
 
-					
+
 					unset($row['newsfeed_data']);			// Don't keep this in memory twice!
 				}
 
 				$this->newsList[$nfID]['newsfeed_timestamp'] = $row['newsfeed_timestamp'];
-				
+
 				$this->feedList[$nfID] = $row;						// Put the rest into the feed data
 			}
 			$this->validFeedList = TRUE;
@@ -142,7 +142,7 @@ class newsfeedClass
 
 		$cachedData  = e107::getCache()->retrieve(NEWSFEED_NEWS_CACHE_TAG.$feedID,$maxAge, true);
 
-		if(empty($this->newsList[$feedID]['newsfeed_timestamp']) || empty($cachedData) || (!empty($this->newsList[$feedID]['newsfeed_data']) && strpos($this->newsList[$feedID]['newsfeed_data'],'MagpieRSS'))) //BC Fix to update newsfeed_data from v1 to v2 spec.
+		if(empty($this->newsList[$feedID]['newsfeed_timestamp']) || empty($cachedData) || (!empty($this->newsList[$feedID]['newsfeed_data']) && strpos((string) $this->newsList[$feedID]['newsfeed_data'],'MagpieRSS'))) //BC Fix to update newsfeed_data from v1 to v2 spec.
 		{
 			$force = true;
 			// e107::getDebug()->log("NewsFeed Force");
@@ -172,7 +172,7 @@ class newsfeedClass
 				if($rawData = $xml->getRemoteFile($this->feedList[$feedID]['newsfeed_url'])) // Need to update feed
 				{	
 					$rss = new MagpieRSS( $rawData );
-					list($newsfeed_image, $newsfeed_showmenu, $newsfeed_showmain) = explode("::", $this->feedList[$feedID]['newsfeed_image']);
+					list($newsfeed_image, $newsfeed_showmenu, $newsfeed_showmain) = explode("::", (string) $this->feedList[$feedID]['newsfeed_image']);
 					
 					$temp['channel'] = $rss->channel;
 					
@@ -314,8 +314,8 @@ class newsfeedClass
 			{
 				if (($rss = $this->getFeed($nfID)))	// Call ensures that feed is updated if necessary
 				{
-					list($newsfeed_image, $newsfeed_showmenu, $newsfeed_showmain) = explode("::", $feed['newsfeed_image']);
-					
+					list($newsfeed_image, $newsfeed_showmenu, $newsfeed_showmain) = explode("::", (string) $feed['newsfeed_image']);
+
 					$numtoshow = intval($where == 'main' ? $newsfeed_showmain : $newsfeed_showmenu);
 					$numtoshow = ($numtoshow > 0 ? $numtoshow : 999);
 
@@ -326,7 +326,7 @@ class newsfeedClass
 					$vars['FEEDDESCRIPTION'] = $feed['newsfeed_description'];
 					$vars['FEEDIMAGE'] = $rss['newsfeed_image_link'];
 					$vars['FEEDLANGUAGE'] = $rss['channel']['language'];
-					
+
 					if($rss['channel']['lastbuilddate'])
 					{
 						$pubbed = $rss['channel']['lastbuilddate'];
@@ -359,9 +359,9 @@ class newsfeedClass
 					{
 						$vars['LINKTOMAIN'] = "";
 					}
-	
+
 					$data = "";
-	
+
 					$numtoshow = min($numtoshow, count($rss['items']));
 					$i = 0;
 					while($i < $numtoshow)
@@ -369,12 +369,12 @@ class newsfeedClass
 						$item = $rss['items'][$i];
 
 
-						
+
 						$vars['FEEDITEMLINK']       = "<a href='".$item['link']."' rel='external'>".$tp -> toHTML($item['title'], FALSE)."</a>\n";
 						$vars['FEEDITEMLINK']       = str_replace('&', '&amp;', $vars['FEEDITEMLINK']);
-						$feeditemtext               = preg_replace("#\[[a-z0-9=]+\]|\[\/[a-z]+\]|\{[A-Z_]+\}#si", "", strip_tags($item['description']));
+						$feeditemtext               = preg_replace("#\[[a-z0-9=]+\]|\[\/[a-z]+\]|\{[A-Z_]+\}#si", "", strip_tags((string) $item['description']));
 						$vars['FEEDITEMCREATOR']    = $tp -> toHTML(vartrue($item['author']), FALSE);
-						
+
 						if ($where == 'main')
 						{
 							if(!empty($NEWSFEED_COLLAPSE))
@@ -391,7 +391,7 @@ class newsfeedClass
 							{
 								$vars['FEEDITEMLINK']   = "<a href='".$item['link']."' rel='external'>".$tp -> toHTML($item['title'], FALSE)."</a>\n";
 								$vars['FEEDITEMLINK']   = str_replace('&', '&amp;', $vars['FEEDITEMLINK']);
-								$feeditemtext           = preg_replace("#\[[a-z0-9=]+\]|\[\/[a-z]+\]|\{[A-Z_]+\}#si", "", $item['description']);
+								$feeditemtext           = preg_replace("#\[[a-z0-9=]+\]|\[\/[a-z]+\]|\{[A-Z_]+\}#si", "", (string) $item['description']);
 								$vars['FEEDITEMTEXT']   = $tp -> toHTML($feeditemtext, FALSE)."\n";
 							}
 							$data .= $tp->simpleParse( $NEWSFEED_MAIN, $vars);

--- a/e107_plugins/newsletter/admin_config.php
+++ b/e107_plugins/newsletter/admin_config.php
@@ -86,7 +86,7 @@ class newsletter
 		foreach($_POST as $key => $value)
 		{
 			$key = $tp->toDB($key);
-			if(strpos($key, 'nlmailnow') === 0)
+			if(strpos((string) $key, 'nlmailnow') === 0)
 			{
 				$this->releaseIssue($key);
 				break;
@@ -154,7 +154,7 @@ class newsletter
 				<tr>
 					<td>".$data['newsletter_id']."</td>
 					<td>".$data['newsletter_title']."</td>
-					<td>".((substr_count($data['newsletter_subscribers'], chr(1))!= 0)?"<a href='".e_SELF."?vs.".$data['newsletter_id']."'>".substr_count($data['newsletter_subscribers'], chr(1))."</a>":substr_count($data['newsletter_subscribers'], chr(1)))."</td>
+					<td>".((substr_count((string) $data['newsletter_subscribers'], chr(1))!= 0)?"<a href='".e_SELF."?vs.".$data['newsletter_id']."'>".substr_count((string) $data['newsletter_subscribers'], chr(1))."</a>":substr_count((string) $data['newsletter_subscribers'], chr(1)))."</td>
 					<td>
 						<a class='btn btn-default btn-secondary btn-large' href='".e_SELF."?edit.".$data['newsletter_id']."'>".ADMIN_EDIT_ICON."</a>
 						<input class='btn btn-default btn-secondary btn-large' type='image' title='".LAN_DELETE."' name='delete[newsletter_".$data['newsletter_id']."]' src='".ADMIN_DELETE_ICON_PATH."' onclick=\"return jsconfirm(".$tp->toAttribute($tp->toJSON(LAN_CONFIRMDEL." [ID: ".$data['newsletter_id']." ]")).") \"/>
@@ -440,7 +440,7 @@ class newsletter
 			return FALSE;
 		}
 		$newsletterParentInfo = $sql->fetch();
-		$memberArray = explode(chr(1), $newsletterParentInfo['newsletter_subscribers']);
+		$memberArray = explode(chr(1), (string) $newsletterParentInfo['newsletter_subscribers']);
 
 		require(e_HANDLER.'mail_manager_class.php');
 		$mailer = new e107MailManager;
@@ -559,7 +559,7 @@ class newsletter
 		$mes = e107::getMessage();
 
 		$tmp = key($_POST['delete']);
-		if(strpos($tmp['key'], 'newsletter') === 0)
+		if(strpos((string) $tmp['key'], 'newsletter') === 0)
 		{
 			$id = intval(str_replace('newsletter_', '', $tmp['key']));
 			$sql->delete('newsletter', "newsletter_id='{$id}'");
@@ -643,7 +643,7 @@ class newsletter
 
 			if($nl_row = $nl_sql->fetch())
 			{
-				$subscribers_list = explode(chr(1), trim($nl_row['newsletter_subscribers']));
+				$subscribers_list = explode(chr(1), trim((string) $nl_row['newsletter_subscribers']));
 				sort($subscribers_list);
 				$subscribers_total_count = count($subscribers_list) - 1;	// Get a null entry as well
 			}
@@ -716,7 +716,7 @@ class newsletter
 		$sql ->select('newsletter', '*', 'newsletter_id='.intval($p_id));
 		if($nl_row = $sql->fetch())
 		{
-			$subscribers_list = array_flip(explode(chr(1), $nl_row['newsletter_subscribers']));
+			$subscribers_list = array_flip(explode(chr(1), (string) $nl_row['newsletter_subscribers']));
 			unset($subscribers_list[$p_key]);
 			$new_subscriber_list = implode(chr(1), array_keys($subscribers_list));
 			$sql->update('newsletter', "newsletter_subscribers='{$new_subscriber_list}' WHERE newsletter_id='".$p_id."'");

--- a/e107_plugins/newsletter/e_mailout.php
+++ b/e107_plugins/newsletter/e_mailout.php
@@ -135,12 +135,12 @@ class newsletter_mailout
 					$this->selectorActive = FALSE;
 					return FALSE;		// Run out of DB records
 				}
-				$this->targets = explode(chr(1), $row['newsletter_subscribers']);
+				$this->targets = explode(chr(1), (string) $row['newsletter_subscribers']);
 				unset($row);
 			}
 			foreach ($this->targets as $k => $v)
 			{
-				if ($uid = intval(trim($v)))
+				if ($uid = intval(trim((string) $v)))
 				{	// Got a user ID here - look them up and add their data
 					if ($this->ourDB->select('user', 'user_name,user_email,user_lastvisit', '`user_id`='.$uid))
 					{

--- a/e107_plugins/newsletter/newsletter_legacy_menu.php
+++ b/e107_plugins/newsletter/newsletter_legacy_menu.php
@@ -28,14 +28,14 @@ $requery = false;
 
 foreach($_POST as $key => $value)
 {
-	if(strpos($key, 'nlUnsubscribe_') === 0)
+	if(strpos((string) $key, 'nlUnsubscribe_') === 0)
 	{
 		$subid = str_replace('nlUnsubscribe_', '', $key);
 		$newsletterArray[$subid]['newsletter_subscribers'] = str_replace(chr(1).USERID, "", $newsletterArray[$subid]['newsletter_subscribers']);
 		$sql->update('newsletter', "newsletter_subscribers='".$newsletterArray[$subid]['newsletter_subscribers']."' WHERE newsletter_id='".intval($subid)."' ");
 		$requery = true;
 	}
-	elseif(strpos($key, 'nlSubscribe_') === 0)
+	elseif(strpos((string) $key, 'nlSubscribe_') === 0)
 	{
 		$subid = str_replace("nlSubscribe_", "", $key);
 		$nl_subscriber_array = $newsletterArray[$subid]['newsletter_subscribers'];
@@ -81,7 +81,7 @@ foreach($newsletterArray as $nl)
 	$tp->toHTML($nl['newsletter_text'], TRUE)."</span><br /><br />
 	";
 
-	if(preg_match("#".chr(1).USERID."(".chr(1)."|$)#si", $nl['newsletter_subscribers']))
+	if(preg_match("#".chr(1).USERID."(".chr(1)."|$)#si", (string) $nl['newsletter_subscribers']))
 	{
 		$text .= NLLAN_48."<br /><br />
 		<input class='btn btn-sm btn-primary button' type='submit' name='nlUnsubscribe_".$nl['newsletter_id']."' value='".NLLAN_51."' onclick=\"return jsconfirm(".$tp->toAttribute($tp->toJSON(NLLAN_49)).") \" />

--- a/e107_plugins/online/online_shortcodes.php
+++ b/e107_plugins/online/online_shortcodes.php
@@ -233,7 +233,7 @@ class online_shortcodes extends e_shortcode
 
 					$pinfo = $row['user_location'];
 
-					$online_location_page = str_replace('.php', '', substr(strrchr($pinfo, '/'), 1));
+					$online_location_page = str_replace('.php', '', substr(strrchr((string) $pinfo, '/'), 1));
 					if ($pinfo == 'log.php' || $pinfo == 'error.php')
 					{
 						$pinfo = 'news.php';

--- a/e107_plugins/page/e_search.php
+++ b/e107_plugins/page/e_search.php
@@ -130,24 +130,24 @@ class page_search extends e_search // include plugin-folder in the name.
 	function where($parm=array())
 	{
 		$tp = e107::getParser();
-	
+
 		$time = time();
 
 		$qry = " (c.chapter_visibility IN (".USERCLASS_LIST.") OR p.page_chapter = 0) AND p.page_class IN (".USERCLASS_LIST.") AND p.page_text != '' AND ";
-		
+
 		if(!empty($parm['cat']) && $parm['cat'] != 'all')
 		{
 			$qry .= " p.page_chapter='".intval($parm['cat'])."' AND";	
 		}
-		
+
 		return $qry;
-		
+
 		/*
-		
+
 		if (isset($parm['time']) && is_numeric($parm['time'])) {
 			$qry .= " n.news_datestamp ".($parm['on'] == 'new' ? '>=' : '<=')." '".(time() - $parm['time'])."' AND";
 		}
-				
+
 		return $qry;
 		*/
 	

--- a/e107_plugins/page/page_menu.php
+++ b/e107_plugins/page/page_menu.php
@@ -24,8 +24,8 @@ foreach($data as $row)
 {
 	$title = $tp->toHTML($row['page_title'],false,'TITLE');
 	$body = $tp->toHTML($row['page_text'],true,'BODY');
-	
-	
+
+
 	$ns->tablerender($title, $body,'page-menu'); // check for $mode == 'page-menu' in tablestyle() if you need a simple 'echo' without rendering styles. 
 }
 

--- a/e107_plugins/pm/admin_config.php
+++ b/e107_plugins/pm/admin_config.php
@@ -92,7 +92,7 @@ class pm_admin extends e_admin_dispatcher
 				
 class private_msg_ui extends e_admin_ui
 {
-			
+
 		protected $pluginTitle		= LAN_PLUGIN_PM_NAME;
 		protected $pluginName		= 'pm';
 		protected $table			= 'private_msg';
@@ -100,7 +100,7 @@ class private_msg_ui extends e_admin_ui
 		protected $perPage 			= 7;
         protected $listQry          = '';
         protected $listOrder        = "p.pm_id DESC";
-			
+
 		protected $fields 		= array (  'checkboxes' =>   array ( 'title' => '', 'type' => null, 'data' => null, 'width' => '5%', 'thclass' => 'center', 'forced' => '1', 'class' => 'center', 'toggle' => 'e-multiselect',  ),
 		  'pm_id'             => array ( 'title' => LAN_ID,       'data' => 'int', 'width' => '5%', 'help' => '', 'readParms' => array(), 'writeParms' => array(), 'class' => 'left', 'thclass' => 'left',  ),
 		  'pm_from'           => array ( 'title' => LAN_PLUGIN_PM_FROM,       'type' => 'method', 'noedit'=>true, 'data' => 'int', 'filter'=>true, 'width' => '5%%', 'help' => '', 'readParms' => array(), 'writeParms' => array(), 'class' => 'left', 'thclass' => 'left',  ),
@@ -109,7 +109,7 @@ class private_msg_ui extends e_admin_ui
 		  'pm_subject'        => array ( 'title' => LAN_PLUGIN_PM_SUB,    'type' => 'text', 'data' => 'str', 'width' => '15%', 'help' => '', 'readParms' => array(), 'writeParms' => array('size'=>'xlarge'), 'class' => 'left', 'thclass' => 'left',  ),
 		  'pm_text'           => array ( 'title' => LAN_PLUGIN_PM_MESS,    'type' => 'bbarea', 'data' => 'str', 'width' => '40%', 'help' => '', 'readParms' => 'expand=1&truncate=50', 'writeParms' => 'rows=5&size=block&cols=80', 'class' => 'left', 'thclass' => 'left',  ),
 		  'pm_read'           => array ( 'title' => LAN_PLUGIN_PM_READ,       'type' => 'boolean', 'noedit'=>1, 'data' => 'int', 'batch'=>true, 'filter'=>true, 'width' => '5%', 'help' => '', 'readParms' => array(), 'writeParms' => array(), 'class' => 'center', 'thclass' => 'center',  ),
-        
+
           'pm_sent_del'       => array ( 'title' => LAN_PLUGIN_PM_DEL,        'type' => 'boolean', 'noedit'=>true, 'data' => 'int', 'width' => 'auto', 'help' => '', 'readParms' => array(), 'writeParms' => array(), 'class' => 'center', 'thclass' => 'center',  ),
 		  'pm_read_del'       => array ( 'title' => LAN_PLUGIN_PM_DEL,        'type' => 'boolean', 'noedit'=>true, 'data' => 'int', 'width' => 'auto', 'help' => '', 'readParms' => array(), 'writeParms' => array(), 'class' => 'center', 'thclass' => 'center',  ),
 		  'pm_attachments'    => array ( 'title' => LAN_PLUGIN_PM_ATTACHMENT, 'type' => 'text', 'noedit'=>true, 'data' => 'str', 'width' => 'auto', 'help' => '', 'readParms' => array(), 'writeParms' => array(), 'class' => 'center', 'thclass' => 'center',  ),
@@ -117,7 +117,7 @@ class private_msg_ui extends e_admin_ui
 		  'pm_size'           => array ( 'title' => LAN_PLUGIN_PM_SIZE,       'type' => 'boolean', 'noedit'=>true, 'data' => 'int', 'width' => 'auto', 'help' => '', 'readParms' => array(), 'writeParms' => array(), 'class' => 'center', 'thclass' => 'center',  ),
 		  'options'           => array ( 'title' => LAN_OPTIONS,    'type' => 'method', 'data' => null, 'width' => '10%', 'thclass' => 'center last', 'class' => 'center last', 'forced' => '1',  ),
 		);		
-		
+
 		protected $fieldpref = array('pm_id', 'pm_from', 'pm_to', 'pm_sent', 'pm_read', 'pm_subject', 'pm_text');
 
 		protected $preftabs = array(LAN_BASIC, LAN_ADVANCED);
@@ -695,7 +695,7 @@ class private_msg_ui extends e_admin_ui
 				{
 					while ($row = $db2->fetch())
 					{
-						$attachList = explode(chr(0), $row['pm_attachments']);
+						$attachList = explode(chr(0), (string) $row['pm_attachments']);
 						foreach ($attachList as $a)
 						{
 							$found = FALSE;
@@ -870,7 +870,7 @@ class private_msg_ui extends e_admin_ui
 
 				if(!empty($_GET['subject']))
 				{
-					$this->fields['pm_subject']['writeParms']['default'] = "Re: ". base64_decode($_GET['subject']);
+					$this->fields['pm_subject']['writeParms']['default'] = "Re: ". base64_decode((string) $_GET['subject']);
 				}
 
 
@@ -878,7 +878,7 @@ class private_msg_ui extends e_admin_ui
 
 
 
-        
+
         }
 
 		public function beforeCreate($new_data, $old_data)
@@ -890,7 +890,7 @@ class private_msg_ui extends e_admin_ui
 				return false;
 			}
 
-			$new_data['pm_size'] = strlen($new_data['pm_text']);
+			$new_data['pm_size'] = strlen((string) $new_data['pm_text']);
 			$new_data['pm_from'] = USERID;
 			return $new_data;
 		}
@@ -903,16 +903,16 @@ class private_msg_ui extends e_admin_ui
 			'pref_name' 				=> array('title'=> 'name', 'type' => 'text', 'data' => 'string', 'validate' => 'regex', 'rule' => '#^[\w]+$#i', 'help' => 'allowed characters are a-zA-Z and underscore')
 		);
 
-		
 
-	
-		
+
+
+
 		public function customPage()
 		{
 			$ns = e107::getRender();
 			$text = 'Hello World!';
 			$ns->tablerender('Hello',$text);	
-			
+
 		}
 		*/
 			
@@ -953,7 +953,7 @@ class private_msg_form_ui extends e_admin_form_ui
 				$link .= (!empty($_GET['iframe'])) ? 'mode=inbox&iframe=1' : 'mode=outbox';
 
 
-				$link .= "&action=create&to=".intval($pmData['pm_from'])."&subject=".base64_encode($pmData['pm_subject']);
+				$link .= "&action=create&to=".intval($pmData['pm_from'])."&subject=".base64_encode((string) $pmData['pm_subject']);
 
 
 

--- a/e107_plugins/pm/pm.php
+++ b/e107_plugins/pm/pm.php
@@ -266,7 +266,7 @@
 			{
 				foreach($pmlist['messages'] as $rec)
 				{
-					if(trim($rec['pm_subject']) == '')
+					if(trim((string) $rec['pm_subject']) == '')
 					{
 						$rec['pm_subject'] = '[' . LAN_PM_61 . ']';
 					}
@@ -338,7 +338,7 @@
 			{
 				foreach($pmlist['messages'] as $rec)
 				{
-					if(trim($rec['pm_subject']) == '')
+					if(trim((string) $rec['pm_subject']) == '')
 					{
 						$rec['pm_subject'] = '[' . LAN_PM_61 . ']';
 					}
@@ -611,7 +611,7 @@
 					}
 				}
 
-				$totalsize = strlen($_POST['pm_message']);
+				$totalsize = strlen((string) $_POST['pm_message']);
 
 				$maxsize = intval($this->pmPrefs['attach_size']) * 1024;
 
@@ -809,11 +809,11 @@
 		}
 		else
 		{
-			if(substr($_SERVER['HTTP_REFERER'], -5) == 'inbox')
+			if(substr((string) $_SERVER['HTTP_REFERER'], -5) == 'inbox')
 			{
 				$action = 'inbox';
 			}
-			elseif(substr($_SERVER['HTTP_REFERER'], -6) == 'outbox')
+			elseif(substr((string) $_SERVER['HTTP_REFERER'], -6) == 'outbox')
 			{
 				$action = 'outbox';
 			}

--- a/e107_plugins/pm/pm_class.php
+++ b/e107_plugins/pm/pm_class.php
@@ -60,7 +60,7 @@ class private_message
 		else
 		{
 			e107::getDb()->gen("UPDATE `#private_msg` SET `pm_read` = {$now} WHERE `pm_id`=".intval($pm_id)); // TODO does this work properly?
-			if(strpos($pm_info['pm_option'], '+rr') !== FALSE)
+			if(strpos((string) $pm_info['pm_option'], '+rr') !== FALSE)
 			{
 				$this->pm_send_receipt($pm_info);
 			}
@@ -128,7 +128,7 @@ class private_message
 			$info = array();
 			foreach ($vars as $k => $v)
 			{
-				if (strpos($k, 'pm_') === 0)
+				if (strpos((string) $k, 'pm_') === 0)
 				{
 					$info[$k] = $v;
 					unset($vars[$k]);
@@ -153,16 +153,16 @@ class private_message
 				}
 				$attachlist = implode(chr(0), $a_list);
 			}
-			$pmsize += strlen($vars['pm_message']);
+			$pmsize += strlen((string) $vars['pm_message']);
 
-			$pm_subject = trim($tp->toDB($vars['pm_subject']));
-			$pm_message = trim($tp->toDB($vars['pm_message']));
-			
+			$pm_subject = trim((string) $tp->toDB($vars['pm_subject']));
+			$pm_message = trim((string) $tp->toDB($vars['pm_message']));
+
 			if (!$pm_subject && !$pm_message && !$attachlist)
 			{  // Error - no subject, no message body and no uploaded files
 				return LAN_PM_65;
 			}
-			
+
 			// Most of the pm info is fixed - just need to set the 'to' user on each send
 			$info = array(
 				'pm_from' => $vars['from_id'],
@@ -329,7 +329,7 @@ class private_message
 			if($force == TRUE)
 			{
 				// Delete any attachments and remove PM from db
-				$attachments = explode(chr(0), $row['pm_attachments']);
+				$attachments = explode(chr(0), (string) $row['pm_attachments']);
 				$aCount = array(0,0);
 				foreach($attachments as $a)
 				{
@@ -626,7 +626,7 @@ class private_message
 		else
 		{
 		//	$var = strip_if_magic($var);
-			$var = str_replace("'", '&#039;', trim($var));		// Display name uses entities for apostrophe
+			$var = str_replace("'", '&#039;', trim((string) $var));		// Display name uses entities for apostrophe
 			$where = "user_name LIKE '".$sql->escape($var, FALSE)."'";
 		}
 
@@ -703,7 +703,7 @@ class private_message
 
 		$user = e107::user($uid);
 
-		$uclass = explode(",", $user['user_class']);
+		$uclass = explode(",", (string) $user['user_class']);
 
 		if($this->pmPrefs['send_to_class'] == 'matchclass')
 		{
@@ -806,7 +806,7 @@ class private_message
 	{
 		$pm_info = $this->pm_get($pmid);
 
-		$attachments = explode(chr(0), $pm_info['pm_attachments']);
+		$attachments = explode(chr(0), (string) $pm_info['pm_attachments']);
 
 		if(!isset($attachments[$filenum]))
 		{
@@ -860,12 +860,12 @@ class private_message
 
 		if (connection_status() == 0)
 		{
-			if (strpos($_SERVER['HTTP_USER_AGENT'], "MSIE") !== false) {
+			if (strpos((string) $_SERVER['HTTP_USER_AGENT'], "MSIE") !== false) {
 				$file = preg_replace('/\./', '%2e', $file, substr_count($file, '.') - 1);
 			}
 			if (isset($_SERVER['HTTP_RANGE']))
 			{
-				$seek = intval(substr($_SERVER['HTTP_RANGE'] , strlen('bytes=')));
+				$seek = intval(substr((string) $_SERVER['HTTP_RANGE'] , strlen('bytes=')));
 			}
 			$bufsize = 2048;
 			ignore_user_abort(true);

--- a/e107_plugins/pm/pm_conf.php
+++ b/e107_plugins/pm/pm_conf.php
@@ -115,7 +115,7 @@ if (isset($_POST['update_prefs']))
 	$temp = array();
 	foreach($_POST as $k => $v)
 	{
-		if (strpos($k, 'pm_option-') === 0)
+		if (strpos((string) $k, 'pm_option-') === 0)
 		{
 			$k = str_replace('pm_option-','',$k);
 			$temp[$k] = $v;
@@ -751,7 +751,7 @@ function doMaint($opts, $pmPrefs)
 		{
 			while ($row = $db2->fetch())
 			{
-				$attachList = explode(chr(0), $row['pm_attachments']);
+				$attachList = explode(chr(0), (string) $row['pm_attachments']);
 				foreach ($attachList as $a)
 				{
 					$found = FALSE;

--- a/e107_plugins/pm/pm_shortcodes.php
+++ b/e107_plugins/pm/pm_shortcodes.php
@@ -232,7 +232,7 @@ if(!class_exists('plugin_pm_pm_shortcodes'))
 			if(vartrue($this->var['pm_subject']))
 			{
 				$value = $this->var['pm_subject'];
-				if(substr($value, 0, strlen(LAN_PM_58)) != LAN_PM_58)
+				if(substr((string) $value, 0, strlen(LAN_PM_58)) != LAN_PM_58)
 				{
 					$value = LAN_PM_58.$value;
 				}
@@ -255,7 +255,7 @@ if(!class_exists('plugin_pm_pm_shortcodes'))
 				if(isset($_POST['quote']))
 				{
 					$t = time();
-					$value = "\n\n\n\n\n\n\n[quote{$t}={$this->var['from_name']}]\n".trim($this->var['pm_text'])."[/quote{$t}]";
+					$value = "\n\n\n\n\n\n\n[quote{$t}={$this->var['from_name']}]\n".trim((string) $this->var['pm_text'])."[/quote{$t}]";
 				}
 			}
 
@@ -335,7 +335,7 @@ if(!class_exists('plugin_pm_pm_shortcodes'))
 
 			if(!empty($this->var['pm_attachments']))
 			{
-				$attachments = explode(chr(0), $this->var['pm_attachments']);
+				$attachments = explode(chr(0), (string) $this->var['pm_attachments']);
 				$i = 0;
 				$ret = '';
 				foreach($attachments as $a)

--- a/e107_plugins/poll/poll_class.php
+++ b/e107_plugins/poll/poll_class.php
@@ -47,10 +47,10 @@ class poll
 			foreach($_COOKIE as $cookie_name => $cookie_val)
 			{	// Collect poll cookies
 
-				if(strpos($cookie_name,'poll_') === 0)
+				if(strpos((string) $cookie_name,'poll_') === 0)
 				{
 					// e107::getDebug()->log("Poll: ".$cookie_name);
-					list($str, $int) = explode('_', $cookie_name, 2);
+					list($str, $int) = explode('_', (string) $cookie_name, 2);
 					if (($str == 'poll') && is_numeric($int))
 					{	// Yes, its poll's cookie
 						$arr_polls_cookies[] = $int;
@@ -68,7 +68,7 @@ class poll
 			}
 		}
 	}	
-	
+
 	/*
 	function delete_poll
 	parameter in: $existing - existing poll id to be deleted
@@ -78,7 +78,7 @@ class poll
 	{
 		global $admin_log;
 		$sql = e107::getDb();
-		
+
 		if ($sql->delete("polls", " poll_id='".intval($existing)."' "))
 		{
 			if (function_exists("admin_purge_related"))
@@ -103,9 +103,9 @@ class poll
 
 	function clean_poll_array($val) 
 	{
- 		$val = trim($val); // trims the array to remove poll answers which are (seemingly) empty but which may contain spaces
+ 		$val = trim((string) $val); // trims the array to remove poll answers which are (seemingly) empty but which may contain spaces
   		$allowed_vals = array("0"); // Allows for '0' to be a poll answer option. Possible to add more allowed values. 
- 		
+
  		return in_array($val, $allowed_vals, true) ? true : ( $val ? true : false );
 	}
 
@@ -155,7 +155,7 @@ class poll
 			/* update poll results - bugtracker #1124 .... */
 			$sql->select("polls", "poll_votes", "poll_id='".$pollID."' ");
 			$foo = $sql->fetch();
-			$voteA = explode(chr(1), $foo['poll_votes']);
+			$voteA = explode(chr(1), (string) $foo['poll_votes']);
 
 		//	$poll_option = varset($poll_options, 0);
 			$opt = count($pollOption) - count($voteA);
@@ -206,7 +206,7 @@ class poll
 	{
 		global $e107;		
 		$sql = e107::getDb();
-		
+
 		if ($sql->gen($query))
 		{
 			$pollArray = $sql->fetch();
@@ -233,7 +233,7 @@ class poll
 
 					case POLL_MODE_IP:
 						$userid = e107::getIPHandler()->getIP(FALSE);
-						$voted_ids = explode('^', substr($pollArray['poll_ip'], 0, -1));
+						$voted_ids = explode('^', substr((string) $pollArray['poll_ip'], 0, -1));
 						if (in_array($userid, $voted_ids))
 						{
 							$POLLMODE = 'voted';
@@ -252,7 +252,7 @@ class poll
 						else
 						{
 							$userid = USERID;
-							$voted_ids = explode('^', substr($pollArray['poll_ip'], 0, -1));
+							$voted_ids = explode('^', substr((string) $pollArray['poll_ip'], 0, -1));
 							if (in_array($userid, $voted_ids))
 							{
 								$POLLMODE = 'voted';
@@ -291,7 +291,7 @@ class poll
 				{
 					$votes[($_POST['votea']-1)] ++;
 				}
-				$optionArray = explode(chr(1), $pollArray['poll_options']);
+				$optionArray = explode(chr(1), (string) $pollArray['poll_options']);
 				$optionArray = array_slice($optionArray, 0, -1);
 				foreach ($optionArray as $k=>$v)
 				{
@@ -347,7 +347,7 @@ class poll
 		{
 			$sc->pollPreview = true;
 		}
-		
+
 		switch ($POLLMODE)
 		{
 			case 'query' :	// Show poll, register any vote
@@ -382,7 +382,7 @@ class poll
 
 		}
 
-		
+
 
 		if ($type == 'preview')
 		{
@@ -400,17 +400,17 @@ class poll
 			}
 			else
 			{
-				$optionArray = explode(chr(1), $pollArray['poll_options']);
+				$optionArray = explode(chr(1), (string) $pollArray['poll_options']);
 				$optionArray = array_slice($optionArray, 0, -1);
 			}
-			$voteArray = explode(chr(1), $pollArray['poll_votes']);
+			$voteArray = explode(chr(1), (string) $pollArray['poll_votes']);
 //			$voteArray = array_slice($voteArray, 0, -1);
 		}
 		else
 		{  // Get existing results
-			$optionArray = explode(chr(1), $pollArray['poll_options']);
+			$optionArray = explode(chr(1), (string) $pollArray['poll_options']);
 			$optionArray = array_slice($optionArray, 0, -1);
-			$voteArray = explode(chr(1), $pollArray['poll_votes']);
+			$voteArray = explode(chr(1), (string) $pollArray['poll_votes']);
 //			$voteArray = array_slice($voteArray, 0, -1);
 		}
 
@@ -499,11 +499,11 @@ class poll
 				{
 					$sc->answerOption = $option; 
 					$text .= $tp->parseTemplate($template['form']['item'], true, $sc);
-						
+
 					$count ++;
 					$sc->answerCount++;
 				}
-				
+
 				$text .= $tp->parseTemplate($template['form']['end'], true, $sc);
 
 				$text .= "</form>";
@@ -538,10 +538,10 @@ class poll
 						$count ++;
 						$sc->answerCount++;
 					}
-						
+
 					$text .= $tp->parseTemplate($template['results']['end'], true, $sc);
 				}
-			
+
 				break;
 
 
@@ -570,9 +570,9 @@ class poll
 
 
 		if (!defined("POLLRENDERED")) define("POLLRENDERED", TRUE);
-		
+
 		$caption = (file_exists(THEME."images/poll_menu.png") ? "<img src='".THEME_ABS."images/poll_menu.png' alt='' /> ".LAN_PLUGIN_POLL_NAME : LAN_PLUGIN_POLL_NAME);
-		
+
 		if ($type == 'preview')
 		{
 			$caption = LAN_CREATE.SEP.LAN_PREVIEW; // "Preview"; // TODO not sure this is used. 
@@ -594,7 +594,7 @@ class poll
 	}
 
 
-	
+
 	function generateBar($perc)
 	{
 		if(deftrue('BOOTSTRAP',false))
@@ -606,7 +606,7 @@ class poll
 			   <span class="sr-only visually-hidden">'.$val.'%</span>
 			 </div>
 			 </div>';	
-			
+
 		}
 		else
 		{
@@ -635,16 +635,16 @@ class poll
 		$tp = e107::getParser();
 		$frm = e107::getForm();
 	//	echo "MODE=".$mode;
-		
+
 		//XXX New v2.x default for front-end. Currently used by forum-post in bootstrap mode. 
 		// TODO LAN - Needs a more generic LAN rewrite when used on another area than forum
 
 
 		if ($mode == 'front')
 		{				
-			
+
 			$text = "
-			
+
 			<div class='alert alert-info'>
 				<small >".LAN_FORUM_3029."</small>
 			</div>";
@@ -664,14 +664,14 @@ class poll
 			$text .= "		
 				<div id='pollsection'>
 					<label for='pollopt'>".POLLAN_4."</label>";
-				
+
 				for($count = 1; $count <= $option_count; $count++)
 				{
 					// if ($count != 1 && $_POST['poll_option'][($count-1)] =="")
 					// {
 					// //	break;
 					// }
-					
+
 					$opt = ($count==1) ? "poll_answer" : "";
 
 					$text .= "<div class='form-group' id='".$opt."'>
@@ -686,11 +686,11 @@ class poll
 						</div>
 
 				";
-			
+
 			//FIXME - get this looking good with Bootstrap CSS only. 
-			
+
 			$opts = array(1 => LAN_YES, 0=> LAN_NO);
-				
+
 			// Set to IP address.. Can add a pref to Poll admin for 'default front-end storage method' if demand is there for it. 
 
 		$text .= "<br />
@@ -703,38 +703,38 @@ class poll
 		";
 
 	//	$text .= "</form>";
-		
+
 		return $text;
-		
-			
+
+
 	/*
 			$text .= "
 				<div class='controls controls-row'>".POLL_506."
-				
+
 				<input type='radio' name='multi/pleChoice' value='1'".(vartrue($_POST['multipleChoice']) ? " checked='checked'" : "")." /> ".POLL_507."&nbsp;&nbsp;
 				<input type='radio' name='multi/pleChoice' value='0'".(!$_POST['multipleChoice'] ? " checked='checked'" : "")." /> ".POLL_508."
-				
+
 				</div>";
 			*/
-		
+
 			//XXX Should NOT be decided by USER 
 			/*
 			$text .= "
 
 			<div>
 			".POLLAN_16."
-			
+
 			<input type='radio' name='storageMethod' value='0'".(!vartrue($_POST['storageMethod']) ? " checked='checked'" : "")." /> ".POLLAN_17."<br />
 			<input type='radio' name='storageMethod' value='1'".($_POST['storageMethod'] == 1 ? " checked='checked'" : "")." /> ".LAN_IP_ADDRESS."<br />
 			<input type='radio' name='storageMethod' value='2'".($_POST['storageMethod'] ==2 ? " checked='checked'" : "")." /> ".POLLAN_19."
 			</div>
 			";
 			*/
-		
-			
+
+
 		}
-		
-		
+
+
 		//TODO Hardcoded FORUM code needs to be moved somewhere. 
 		if ($mode == 'forum') // legacy code.
 		{
@@ -841,10 +841,10 @@ class poll
 
 		<tr>
 		<td style='width:30%'>".POLLAN_15."</td>";
-		
+
 		$uclass = (ADMIN) ? "" : "public,member,admin,classes,matchclass";
-		
-		
+
+
 		$text .= "
 		<td>".r_userclass("pollUserclass", vartrue($_POST['pollUserclass']), 'off', $uclass)."</td>
 		</tr>
@@ -870,11 +870,11 @@ class poll
 		{
 			// $text .= "<input  type='submit' name='preview' value='".LAN_PREVIEW."' /> ";
 			$text .= $frm->admin_button('preview',LAN_PREVIEW,'other');
-			
+
 			if (defset('POLLACTION') === 'edit')
 			{
 				$text .= $frm->admin_button('submit', LAN_UPDATE, 'update')."
-				
+
 				<input type='hidden' name='poll_id' value='".intval($_POST['poll_id'])."' /> ";
 			}
 			else
@@ -888,7 +888,7 @@ class poll
 			$text .= $frm->admin_button('preview','no-value','other',LAN_PREVIEW);
 		//	$text .= "<input  type='submit' name='preview' value='".LAN_PREVIEW."' /> ";
 		}
-		
+
 		if (defset('POLLID')) 
 		{
 			$text .= $frm->admin_button('reset','no-value','reset',LAN_CLEAR);

--- a/e107_plugins/poll/search/search_comments.php
+++ b/e107_plugins/poll/search/search_comments.php
@@ -17,7 +17,7 @@ $comments_table['poll'] = "LEFT JOIN #polls AS po ON c.comment_type=4 AND po.pol
 
 function com_search_4($row) {
 	global $con;
-	$nick = preg_replace("/[0-9]+\./", "", $row['comment_author']);
+	$nick = preg_replace("/[0-9]+\./", "", (string) $row['comment_author']);
 	$datestamp = $con -> convert_date($row['comment_datestamp'], "long");
 	$res['link'] = e_PLUGIN."poll/oldpolls.php?".$row['poll_id'];
 	$res['pre_title'] = 'Posted in reply to poll: ';

--- a/e107_plugins/rss_menu/e_meta.php
+++ b/e107_plugins/rss_menu/e_meta.php
@@ -23,7 +23,7 @@ if(USER_AREA && e107::getDb()->select("rss", "*", "rss_class='0' AND rss_limit>0
 
 	while($row = $sql->fetch())
 	{
-		if(strpos($row['rss_url'], "*") === false) // Wildcard topic_id's should not be listed
+		if(strpos((string) $row['rss_url'], "*") === false) // Wildcard topic_id's should not be listed
 		{
 			$name = $tp->toHTML($row['rss_name'], TRUE, 'no_hook, emotes_off');
 			$title = htmlspecialchars(SITENAME, ENT_QUOTES, 'utf-8')." ".htmlspecialchars($name, ENT_QUOTES, 'utf-8');

--- a/e107_plugins/rss_menu/rss.php
+++ b/e107_plugins/rss_menu/rss.php
@@ -154,11 +154,11 @@ if(!$sql->select('rss', '*', "rss_class != 2 AND rss_url='".$content_type."' ".$
 	if(!$sql->select('rss', '*', "rss_class != 2 AND rss_url='".$content_type."' ".$check_topic." AND rss_limit > 0 "))
 	{
 		require_once(HEADERF);
-		
+
 		$repl  		= array("<br /><br /><a href='".e_REQUEST_SELF."'>", "</a>");
 		$message 	= str_replace(array("[","]"), $repl, RSS_LAN_ERROR_1);
 		e107::getRender()->tablerender('', $message);
-		
+
 		require_once(FOOTERF);
 		exit;
 	}
@@ -177,7 +177,7 @@ else
 
 if($rss = new rssCreate($content_type, $rss_type, $topic_id, $row))
 {
-	$rss_title = ($rss->contentType ? $rss->contentType : ucfirst($content_type));
+	$rss_title = ($rss->contentType ? $rss->contentType : ucfirst((string) $content_type));
 
 	if(defset('E107_DEBUG_LEVEL') > 0)
 	{
@@ -236,9 +236,9 @@ class rssCreate
 		{
 			$path = e_PLUGIN.$row['rss_path'].'/e_rss.php';
 		}
-		if(strpos($row['rss_path'],'|')!==FALSE) //FIXME remove this check completely. 
+		if(strpos((string) $row['rss_path'],'|')!==FALSE) //FIXME remove this check completely. 
 		{
-			$tmp = explode("|", $row['rss_path']);
+			$tmp = explode("|", (string) $row['rss_path']);
 			$path = e_PLUGIN.$tmp[0]."/e_rss.php";
 			$this->parm = $tmp[1];	// FIXME @Deprecated - use $parm['url'] instead in data() method within e_rss.php.  Parm is used in e_rss.php to define which feed you need to prepare
 		}
@@ -295,7 +295,7 @@ class rssCreate
 					}
 
 					$this -> rssItems[$loop]['description'] = $value['comment_comment'];
-					$this -> rssItems[$loop]['author'] = substr($value['comment_author'], (strpos($value['comment_author'], ".")+1));
+					$this -> rssItems[$loop]['author'] = substr((string) $value['comment_author'], (strpos((string) $value['comment_author'], ".")+1));
 					$loop++;
 				}
 				break;
@@ -328,16 +328,16 @@ class rssCreate
 			if (is_readable($path))
 			{
 				require_once($path);
-				
+
 				$className = basename(dirname($path)).'_rss';
-				
+
 				// v2.x standard 
 				if($data = e107::callMethod($className,'data', array('url' => $content_type, 'id' => $this->topicid, 'limit' => $this->limit)))
 				{			
 					$eplug_rss_data = array(0 => $data);
 					unset($data);			
 				}
-								
+
 				foreach($eplug_rss_data as $key=>$rs)
 				{
 					foreach($rs as $k=>$row)
@@ -348,7 +348,7 @@ class rssCreate
 
 						if($row['link'])
 						{
-							if(stripos($row['link'], 'http') !== FALSE)
+							if(stripos((string) $row['link'], 'http') !== FALSE)
 							{
 								$this -> rssItems[$k]['link'] = $row['link'];
 							}
@@ -359,12 +359,12 @@ class rssCreate
 						}
 
 						$this -> rssItems[$k]['description'] = $row['description'];
-						
+
 						if($row['enc_url'])
 						{
 							$this -> rssItems[$k]['enc_url'] = SITEURLBASE.e_PLUGIN_ABS.$row['enc_url'].$row['item_id'];
 						}
-						
+
 						if($row['enc_leng'])
 						{
 							$this -> rssItems[$k]['enc_leng'] = $row['enc_leng'];
@@ -380,10 +380,10 @@ class rssCreate
 						}
 
 						$this -> rssItems[$k]['category_name'] = $row['category_name'];
-						
+
 						if($row['category_link'])
 						{
-							if(stripos($row['category_link'], 'http') !== FALSE)
+							if(stripos((string) $row['category_link'], 'http') !== FALSE)
 							{
 								$this -> rssItems[$k]['category_link'] = $row['category_link'];
 							}
@@ -392,7 +392,7 @@ class rssCreate
 								$this -> rssItems[$k]['category_link'] = SITEURLBASE.e_PLUGIN_ABS.$row['category_link'];
 							}
 						}
-						
+
 						if(!empty($row['datestamp']))
 						{
 							$this -> rssItems[$k]['pubdate'] = $row['datestamp'];
@@ -458,7 +458,7 @@ class rssCreate
 							<item>
 							<title>".$tp->toRss($value['title'])."</title>
 							<description>".substr($tp->toRss($value['description']),0,150);
-						if($pref['rss_shownewsimage'] == 1 && strlen(trim($value['news_thumbnail'])) > 0)
+						if($pref['rss_shownewsimage'] == 1 && strlen(trim((string) $value['news_thumbnail'])) > 0)
 						{
 							$news_thumbnail = SITEURLBASE.e_IMAGE_ABS."newspost_images/".$tp->toRss($value['news_thumbnail']);
 							echo "&lt;a href=&quot;".$link."&quot;&gt;&lt;img src=&quot;".$news_thumbnail."&quot; height=&quot;50&quot; border=&quot;0&quot; hspace=&quot;10&quot; vspace=&quot;10&quot; align=&quot;right&quot;&gt;&lt;/a&gt;";
@@ -475,7 +475,7 @@ class rssCreate
 			break;
 
 			case 2:	// RSS 2.0
-				$sitebutton = (strpos(SITEBUTTON, "http:") !== false ? SITEBUTTON : SITEURL.str_replace("../", "", SITEBUTTON));
+				$sitebutton = (strpos((string) SITEBUTTON, "http:") !== false ? SITEBUTTON : SITEURL.str_replace("../", "", SITEBUTTON));
 				echo "<?xml version=\"1.0\" encoding=\"utf-8\"?".">
 				<!-- generator=\"e107\" -->
 				<!-- content type=\"".$this->contentType."\" -->
@@ -509,7 +509,7 @@ class rssCreate
 				echo "
 				<atom:link href=\"".$tp->toRss(e107::url('rss_menu','atom', array('rss_url'=>$this->contentType, 'rss_topicid'=>$this->topicid),'full'))."\" rel=\"self\" type=\"application/rss+xml\" />\n";
 
-				if (trim(SITEBUTTON))
+				if (trim((string) SITEBUTTON))
 				{
 					$path = e107::getConfig()->get('sitebutton');
 					$imgPath = e107::getParser()->thumbUrl($path, array(), false, true);					
@@ -702,7 +702,7 @@ class rssCreate
 					<generator uri='https://e107.org/' version='".defset('e_VERSION')."'>e107</generator>\n";
 					//<icon>/icon.jpg</icon>\n
 					echo "
-					<logo>".(strpos(SITEBUTTON, "http:") !== false ? SITEBUTTON : SITEURL.str_replace("../", "", SITEBUTTON))."</logo>\n
+					<logo>".(strpos((string) SITEBUTTON, "http:") !== false ? SITEBUTTON : SITEURL.str_replace("../", "", SITEBUTTON))."</logo>\n
 					<rights type='html'>".$pref['siteadmin']." - ".$this->nospam($pref['siteadminemail'])."</rights>\n";
 					if($pref['sitedescription']){
 					echo "
@@ -817,7 +817,7 @@ class rssCreate
 
 	function getmime($file)
 	{
-		$ext = strtolower(str_replace(".","",strrchr(basename($file), ".")));
+		$ext = strtolower(str_replace(".","",strrchr(basename((string) $file), ".")));
 		$mime["mp3"] = "audio/mpeg";
 		return $mime[$ext];
 	}
@@ -833,7 +833,7 @@ class rssCreate
 
 	function nospam($text)
 	{
-		$tmp = explode("@",$text);
+		$tmp = explode("@",(string) $text);
 		return ($tmp[0] != "") ? $tmp[0].RSS_LAN_2 : RSS_LAN_3;
 	}
 } // End class rssCreate

--- a/e107_plugins/rss_menu/rss_setup.php
+++ b/e107_plugins/rss_menu/rss_setup.php
@@ -48,7 +48,7 @@ class rss_menu_setup
 /*	
 	function uninstall_options()
 	{
-	
+
 	}
 
 

--- a/e107_plugins/siteinfo/e_shortcode.php
+++ b/e107_plugins/siteinfo/e_shortcode.php
@@ -36,7 +36,7 @@ class siteinfo_shortcodes // must match the folder name of the plugin.
 		}
 		else
 		{
-			$path = (strpos(SITEBUTTON, 'http:') !== false || strpos(SITEBUTTON, e_IMAGE_ABS) !== false ? SITEBUTTON : e_IMAGE.SITEBUTTON);
+			$path = (strpos((string) SITEBUTTON, 'http:') !== false || strpos((string) SITEBUTTON, e_IMAGE_ABS) !== false ? SITEBUTTON : e_IMAGE.SITEBUTTON);
 		}
 
 		if(varset($parm['type']) == 'url')
@@ -72,7 +72,7 @@ class siteinfo_shortcodes // must match the folder name of the plugin.
 	
 	function sc_siteurl($parm='')
 	{
-		if(strlen(deftrue('SITEURL')) < 3 ) //fixes CLI/cron
+		if(strlen((string) deftrue('SITEURL')) < 3 ) //fixes CLI/cron
 		{
 			return e107::getPref('siteurl');
 		}
@@ -106,7 +106,7 @@ class siteinfo_shortcodes // must match the folder name of the plugin.
 	{
 		if(is_string($parm))
 		{
-			parse_str(vartrue($parm),$parm);		// Optional {LOGO=file=file_name} or {LOGO=link=url} or {LOGO=file=file_name&link=url}
+			parse_str((string) vartrue($parm),$parm);		// Optional {LOGO=file=file_name} or {LOGO=link=url} or {LOGO=file=file_name&link=url}
 		}
 		// Paths to image file, link are relative to site base
 		$tp = e107::getParser();

--- a/e107_plugins/siteinfo/sitebutton_menu.php
+++ b/e107_plugins/siteinfo/sitebutton_menu.php
@@ -17,11 +17,11 @@
 if (!defined('e107_INIT')) { exit; }
 // echo "parm=".$parm; //FIXME - just for testing only.
 
-if(strpos(SITEBUTTON, "://") !== false) // external url.
+if(strpos((string) SITEBUTTON, "://") !== false) // external url.
 {
 	$path = SITEBUTTON;
 } 
-elseif(basename(SITEBUTTON) == SITEBUTTON) // v1.x BC Fix. - no path included. 
+elseif(basename((string) SITEBUTTON) == SITEBUTTON) // v1.x BC Fix. - no path included. 
 {
 	$path = e_IMAGE_ABS.SITEBUTTON;
 }

--- a/e107_plugins/social/admin_config.php
+++ b/e107_plugins/social/admin_config.php
@@ -404,7 +404,7 @@ class social_ui extends e_admin_ui
 			{
 				$keypref = "xurl[".$k."]";
 				$text_label = "xurl-".$k."";
-				$def = "XURL_". strtoupper($k);
+				$def = "XURL_". strtoupper((string) $k);
 				$help = LAN_SOCIAL_ADMIN_13." ".$var['label']." ".LAN_SOCIAL_ADMIN_12." (".$def.")";
 				$opts = array('size'=>'xxlarge','placeholder'=> $var['placeholder']);
 
@@ -628,7 +628,7 @@ class social_ui extends e_admin_ui
 
 		);
 
-		return varset($labels[$fieldSlash], ucfirst($fieldSlash));
+		return varset($labels[$fieldSlash], ucfirst((string) $fieldSlash));
 	}
 
 		/**
@@ -648,7 +648,7 @@ class social_ui extends e_admin_ui
 		$textKeys = '';
 		$textScope = '';
 		$label = !empty(self::getApiDocumentationUrlFor($provider_name)) ? "<a class='e-tip' rel='external' title=' " . LAN_SOCIAL_ADMIN_10 . "' href='" . self::getApiDocumentationUrlFor($provider_name) . "'>" . $pretty_provider_name . "</a>" : $pretty_provider_name;
-		$radio_label = strtolower($provider_name);
+		$radio_label = strtolower((string) $provider_name);
 
 		$text = "<table class='table adminform'>
 				<colgroup>
@@ -708,7 +708,7 @@ class social_ui extends e_admin_ui
 		$textKeys = '';
 		$textScope = '';
 		$label = !empty(self::getApiDocumentationUrlFor($provider_name)) ? "<a class='e-tip' rel='external' title=' " . LAN_SOCIAL_ADMIN_10 . "' href='" . self::getApiDocumentationUrlFor($provider_name) . "'>" . $pretty_provider_name . "</a>" : $pretty_provider_name;
-		$radio_label = strtolower($provider_name);
+		$radio_label = strtolower((string) $provider_name);
 		$text = "
 					<tr id='social-login-row-" . $radio_label."'>
 						<td><label for='social-login-" . $radio_label . "-enabled'>" . $label . "</label></td>
@@ -878,7 +878,7 @@ class social_admin_tree_model extends e_tree_model
 		foreach($themeList as $k=>$v)
 		{
 
-			if(!empty($parms['searchqry']) && stripos($v['description'],$parms['searchqry']) === false && stripos($v['folder'],$parms['searchqry']) === false && stripos($v['name'],$parms['searchqry']) === false)
+			if(!empty($parms['searchqry']) && stripos((string) $v['description'],(string) $parms['searchqry']) === false && stripos((string) $v['folder'],(string) $parms['searchqry']) === false && stripos((string) $v['name'],(string) $parms['searchqry']) === false)
 			{
 				continue;
 			}

--- a/e107_plugins/social/e_event.php
+++ b/e107_plugins/social/e_event.php
@@ -19,22 +19,22 @@ class social_event
 	*/
 	function __construct()
 	{
-		
-		
+
+
 	}
 
 
 	function config()
 	{
 		$event = array();
-		
+
 		$event[] = array(
 			'name'     => "system_meta_pre",
 			'function' => "addFallbackMeta",
 		);
 
 		return $event;
-		
+
 	}
 
 
@@ -113,13 +113,13 @@ class social_event
 		}
 		elseif(!empty($pref['sitebutton']))
 		{
-			$siteButton = (strpos($pref['sitebutton'],'{e_MEDIA') !== false) ? e107::getParser()->thumbUrl($pref['sitebutton'],'w=800',false, true) : e107::getParser()->replaceConstants($pref['sitebutton'],'full');
+			$siteButton = (strpos((string) $pref['sitebutton'],'{e_MEDIA') !== false) ? e107::getParser()->thumbUrl($pref['sitebutton'],'w=800',false, true) : e107::getParser()->replaceConstants($pref['sitebutton'],'full');
 			e107::meta('og:image',$siteButton);
 			e107::meta('twitter:image', $siteButton);
 		}
 		elseif(!empty($pref['sitelogo'])) // fallback to sitelogo
 		{
-			$siteLogo = (strpos($pref['sitelogo'],'{e_MEDIA') !== false) ? e107::getParser()->thumbUrl($pref['sitelogo'],'w=800',false, true) : e107::getParser()->replaceConstants($pref['sitelogo'],'full');
+			$siteLogo = (strpos((string) $pref['sitelogo'],'{e_MEDIA') !== false) ? e107::getParser()->thumbUrl($pref['sitelogo'],'w=800',false, true) : e107::getParser()->replaceConstants($pref['sitelogo'],'full');
 			e107::meta('og:image',$siteLogo);
 			e107::meta('twitter:image', $siteLogo);
 		}

--- a/e107_plugins/social/e_shortcode.php
+++ b/e107_plugins/social/e_shortcode.php
@@ -105,7 +105,7 @@ class social_shortcodes extends e_shortcode
 		if(!empty($parm['type']))
 		{
 			$newList = array();
-			$tmp = explode(",",$parm['type']);
+			$tmp = explode(",",(string) $parm['type']);
 			foreach($tmp as $v)
 			{
 				if(isset($social[$v]))
@@ -255,7 +255,7 @@ class social_shortcodes extends e_shortcode
 	 */
 	public function getShareUrl($type, $urlScheme, $data=array(), $options=array())
 	{
-		$data = array('u'=> rawurlencode($data['url']), 't'=> rawurlencode($data['title']), 'd'	=> rawurlencode($data['description']), 'm' => rawurlencode($data['media']));
+		$data = array('u'=> rawurlencode((string) $data['url']), 't'=> rawurlencode((string) $data['title']), 'd'	=> rawurlencode((string) $data['description']), 'm' => rawurlencode((string) $data['media']));
 
 		return $this->parseShareUrlScheme($type, $urlScheme, $data, $options);
 	}
@@ -278,7 +278,7 @@ class social_shortcodes extends e_shortcode
 		{
 			if(!empty($options['hashtags']))
 			{
-				$shareUrl .= "&amp;hashtags=".rawurlencode($options['hashtags']);
+				$shareUrl .= "&amp;hashtags=".rawurlencode((string) $options['hashtags']);
 			}
 
 			if(!empty($options['twitterAccount']))
@@ -329,7 +329,7 @@ class social_shortcodes extends e_shortcode
 		}
 		else
 		{
-			$parm['providers']  = explode(",",$parm['providers']);
+			$parm['providers']  = explode(",",(string) $parm['providers']);
 		}
 
 		if(empty($parm['dropdown']))
@@ -348,7 +348,7 @@ class social_shortcodes extends e_shortcode
 		$size			= varset($parm['size'],		'md');
 
 
-		$data = array('u'=> rawurlencode($url), 't'=> rawurlencode($title), 'd'	=> rawurlencode($description), 'm' => rawurlencode($media));
+		$data = array('u'=> rawurlencode((string) $url), 't'=> rawurlencode((string) $title), 'd'	=> rawurlencode((string) $description), 'm' => rawurlencode($media));
 		
 		if(!vartrue($parm['dropdown']))
 		{
@@ -414,7 +414,7 @@ class social_shortcodes extends e_shortcode
 		elseif(!empty($parm['type']))
 		{
 			$newlist = array();
-			$tmp = explode(",",$parm['type']);
+			$tmp = explode(",",(string) $parm['type']);
 			foreach($tmp as $v)
 			{
 				if(isset($opt[$v]))

--- a/e107_plugins/social/includes/social_login_config.php
+++ b/e107_plugins/social/includes/social_login_config.php
@@ -151,7 +151,7 @@ class social_login_config
 	public function getProviderConfig($providerName, $path = "")
 	{
 		if (empty($path)) $path = "";
-		elseif (substr($path, 0, 1) !== "/") $path = "/$path";
+		elseif (substr((string) $path, 0, 1) !== "/") $path = "/$path";
 
 		$pref = $this->config->getPref(
 			self::SOCIAL_LOGIN_PREF . '/' . $this->normalizeProviderName($providerName) . $path
@@ -257,14 +257,14 @@ class social_login_config
 		$normalizedProviderName = $providerName;
 		foreach ($this->getSupportedProviders() as $providerProperCaps)
 		{
-			if (mb_strtolower($providerName) == mb_strtolower($providerProperCaps))
+			if (mb_strtolower((string) $providerName) == mb_strtolower($providerProperCaps))
 			{
 				$normalizedProviderName = $providerProperCaps;
 				break;
 			}
 		}
 		$providerType = $this->getTypeOfProvider($normalizedProviderName);
-		$normalizedProviderName = preg_replace('/(OpenID|OAuth1|OAuth2)$/i', '', $normalizedProviderName);
+		$normalizedProviderName = preg_replace('/(OpenID|OAuth1|OAuth2)$/i', '', (string) $normalizedProviderName);
 		if (empty($normalizedProviderName) && !empty($providerType) || $providerName == $providerType)
 			return $providerType;
 		elseif ($providerType)
@@ -279,7 +279,7 @@ class social_login_config
 	 */
 	public function denormalizeProviderName($normalizedProviderName)
 	{
-		list($provider_name, $provider_type) = array_pad(explode("-", $normalizedProviderName), 2, "");
+		list($provider_name, $provider_type) = array_pad(explode("-", (string) $normalizedProviderName), 2, "");
 		if ($provider_type != $this->getTypeOfProvider($provider_name)) $provider_name .= $provider_type;
 		return $provider_name;
 	}

--- a/e107_plugins/social/social_setup.php
+++ b/e107_plugins/social/social_setup.php
@@ -138,7 +138,7 @@ class social_setup
 				$new_user_xup = preg_replace(
 					'/^' . preg_quote($oldProviderName) . '_/',
 					$newProviderName . '_',
-					$old_user_xup
+					(string) $old_user_xup
 				);
 				$this->fixUserXup($db, $row['user_id'], $old_user_xup, $new_user_xup);
 			}

--- a/e107_plugins/tagcloud/tagcloud_class.php
+++ b/e107_plugins/tagcloud/tagcloud_class.php
@@ -194,16 +194,16 @@ class TagCloud
     if ($this->options['transformation']) {
       switch ($this->options['transformation']) {
         case 'upper':
-          $string = $this->options['transliterate'] ? strtoupper($string) : mb_convert_case($string, MB_CASE_UPPER, "UTF-8");
+          $string = $this->options['transliterate'] ? strtoupper((string) $string) : mb_convert_case((string) $string, MB_CASE_UPPER, "UTF-8");
           break;
         default:
-          $string = $this->options['transliterate'] ? strtolower($string) : mb_convert_case($string, MB_CASE_LOWER, "UTF-8");
+          $string = $this->options['transliterate'] ? strtolower((string) $string) : mb_convert_case((string) $string, MB_CASE_LOWER, "UTF-8");
       }
     }
     if ($this->options['trim']) {
-      $string = trim($string);
+      $string = trim((string) $string);
     }
-    return preg_replace('/[^\w ]/u', '', strip_tags($string));
+    return preg_replace('/[^\w ]/u', '', strip_tags((string) $string));
   }
 
   /**
@@ -416,7 +416,7 @@ class TagCloud
     if (empty($this->orderBy)) {
       $this->shuffle();
     } else {
-      $orderDirection = strtolower($this->orderBy['direction']) == 'desc' ? 'SORT_DESC' : 'SORT_ASC';
+      $orderDirection = strtolower((string) $this->orderBy['direction']) == 'desc' ? 'SORT_DESC' : 'SORT_ASC';
       $this->tagsArray = $this->order(
         $this->tagsArray,
         $this->orderBy['field'],
@@ -552,7 +552,7 @@ class TagCloud
       $i = 0;
       $_tagsArray = array();
       foreach ($this->tagsArray as $key => $value) {
-        if (strlen($value['tag']) >= $limit) {
+        if (strlen((string) $value['tag']) >= $limit) {
           $_tagsArray[$value['tag']] = $value;
         }
         $i++;

--- a/e107_plugins/tagcloud/tagcloud_menu.php
+++ b/e107_plugins/tagcloud/tagcloud_menu.php
@@ -73,7 +73,7 @@ if(!class_exists('tagcloud_menu'))
 				foreach ($result as $row)
 				{
 
-					$tmp = explode(",", $row['news_meta_keywords']);
+					$tmp = explode(",", (string) $row['news_meta_keywords']);
 
 					$c = 0;
 					foreach ($tmp as $word)
@@ -126,7 +126,7 @@ if(!class_exists('tagcloud_menu'))
 
 			if(!empty($parm['order']))
 			{
-				list($o1,$o2) = explode(',', $parm['order']);
+				list($o1,$o2) = explode(',', (string) $parm['order']);
 				$cloud->setOrder($o1, strtoupper($o2));
 			}
 			else

--- a/e107_plugins/tagcloud/templates/tagcloud_menu_template.php
+++ b/e107_plugins/tagcloud/templates/tagcloud_menu_template.php
@@ -1,11 +1,11 @@
 <?php
 $TAGCLOUD_MENU_TEMPLATE = array();
-          
+
 $TAGCLOUD_MENU_TEMPLATE['default']['caption']       = '{TAGCLOUD_MENU_CAPTION}';
 $TAGCLOUD_MENU_TEMPLATE['default']['start']       = '<div class="tagcloud-menu">';
 $TAGCLOUD_MENU_TEMPLATE['default']['item']       = "<a class='tag' href='{TAG_URL}'><span class='size{TAG_SIZE}'>{TAG_NAME}</span></a>";
 $TAGCLOUD_MENU_TEMPLATE['default']['end']       = '<div style="clear:both"></div></div>';
-      
+
   /* example  for the same size tag
 $TAGCLOUD_MENU_TEMPLATE['default']['caption']   = '{TAGCLOUD_MENU_CAPTION}';
 $TAGCLOUD_MENU_TEMPLATE['default']['start']     = '<div class="tag-cloud">';

--- a/e107_plugins/tinymce4/plugins/e107/dialog.php
+++ b/e107_plugins/tinymce4/plugins/e107/dialog.php
@@ -33,49 +33,49 @@ e107::js('inline',"
 $(document).ready(function()
 {
 		$('#insertButton').click(function () {
-						
+
 			var buttonType = $('input:radio[name=buttonType]:checked').val();
 			var buttonSize = $('input:radio[name=buttonSize]:checked').val();
-					
+
 			var buttonText = $('#buttonText').val();
 			var buttonUrl = $('#buttonUrl').val();
-			
+
 			var buttonClass = (buttonType != '') ? 'btn-'+buttonType : '';
-					
+
 
 			var html = '<a class=\"btn ' + buttonClass + ' ' + buttonSize + '\" href=\"' + buttonUrl + '\" >' + buttonText + '</a>  ';
 		//	alert(html);		
 			tinyMCEPopup.editor.execCommand('mceInsertContent', false, html);
 			tinyMCEPopup.close();
 		});
-		
-		
+
+
 		$('span.label, span.badge').click(function () {
                 var cls = $(this).attr('class');
                 var html = '<span class=\"' + cls + '\">' + $(this).text() + '</span>&nbsp;';
 				tinyMCEPopup.editor.execCommand('mceInsertContent', false, html);
 				tinyMCEPopup.close();
 		});
-		
-	
+
+
 		$('ul.glyphicons li, #glyph-save').click(function () {
-		
+
 				var color = $('#glyph-color').val();	
 				var custom = $('#glyph-custom').val();			
                 var cls = (custom != '') ? custom : $(this).find('i').attr('class');	
-	
+
                 var html = '<i class=\"' + cls + '\"></i>&nbsp;';
-				
+
 			//	alert(html);
 				tinyMCEPopup.editor.execCommand('mceInsertContent', false, html);
 				tinyMCEPopup.close();
 		});
-	
+
 		$('#bbcodeInsert').click(function () 
 		{
 				s = $('#bbcodeValue').val();
 				s = s.trim(s);
-	
+
 				var html = $.ajax({
 					type: 'POST',
 					url: './parser.php',
@@ -93,17 +93,17 @@ alert(html);
 				tinyMCEPopup.editor.execCommand('mceInsertContent', false, html);
 				tinyMCEPopup.close();
 		});
-	
+
 		$('a.bbcodeSelect').click(function () {
 			var html = $(this).html();	
 			$('#bbcodeValue').val(html);
 		});
-		
+
 		$('#e-cancel').click(function () {
-					
+
 			tinyMCEPopup.close();
 		});
-		
+
 });
 
 
@@ -112,89 +112,89 @@ alert(html);
 
 class e_bootstrap
 {
-				
+
 	private $styleClasses = array(''=>'Default', 'primary'=>"Primary", 'success'=>"Success", 'info'=>"Info", 'warning'=>"Warning",'danger'=>"Danger",'inverse'=>"Inverse");
-			
-		
-	
+
+
+
 	function init()
 	{
 		$ns = e107::getRender();
-		
-		
+
+
 		if(e_QUERY == 'bbcode')
 		{
 			echo $this->bbcodeForm();		
 			return;
 		}
-					
-				
-			
-		
+
+
+
+
 		$text = "<div class='alert alert-warning'>Warning: These will only work if you have a bootstrap-based theme installed</div>";
-		
-		
+
+
 		$text .= '
 		<ul class="nav nav-tabs">';
-		
+
 		$text .= '<li class="active" ><a href="#mbuttons" data-toggle="tab" data-bs-toggle="tab">Buttons</a></li>';
-		
+
 		$text .= '<li><a href="#badges" data-toggle="tab" data-bs-toggle="tab">Labels &amp; Badges</a></li>';
-	
+
 		$text .= '<li><a href="#glyphs" data-toggle="tab" data-bs-toggle="tab">Glyphicons</a></li>';
-		
+
 		$text .= '</ul>';
-		 
+
 		$text .= '<div class="tab-content">';
-		
+
 		$text .= '<div class="tab-pane active left" id="mbuttons">'.$this->buttonForm().'</div>';
-		
+
 		$text .= '<div class="tab-pane left" id="badges">'.$this->badgeForm().'</div>';
-		
+
 		$text .= '<div class="tab-pane left" id="glyphs">'.$this->glyphicons().'</div>';
-		
-	
+
+
 		$text .= '</div>';
 
 		echo $text;
-			
+
 	}
-	
-	
-	
-	
-	
-	
+
+
+
+
+
+
 	function buttonForm()
 	{
 		$frm = e107::getForm();
-		
+
 		$buttonSizes = array(''=>'Default', 'btn-mini'=>"Mini", 'btn-small'=>"Small", 'btn-large' => "Large");
-		
+
 		$buttonTypes = $this->styleClasses;
-			
+
 		$butSelect = "";
 		$butSelect .= "<div class='form-inline' style='padding:5px'>";	
 		foreach($buttonTypes as $type=>$diz)
 		{
-			
+
 			$label = '<button class="btn btn-'.$type.'" >'.$diz.'</button>';
 			$butSelect .= $frm->radio('buttonType', $type, false, array('label'=>$label));
-			
+
 		}
 		$butSelect .= "</div>";		
-		
+
 		$butSize = "<div class='form-inline' style='padding:5px'>";	
-		
+
 		foreach($buttonSizes as $size=>$label)
 		{
 			$selected = ($size == '') ? true : false;
 			$butSize .= $frm->radio('buttonSize', $size, $selected, array('label'=>$label));	
 		}
 		$butSize .= "</div>";		
-		
-		
-		
+
+
+
 		$text = "
 		<table class='table area'>
 		<tr>
@@ -213,17 +213,17 @@ class e_bootstrap
 			<td>Button Url</td>
 			<td><p>".$frm->text('buttonUrl','',255,'size=xxlarge')."</p></td>
 		</tr>
-			
-				
+
+
 		</table>
 
 		<div class='center'>". $frm->admin_button('insertButton','save','other',"Insert") ."
 		<button class='btn btn-default btn-secondary ' id='e-cancel'>".LAN_CANCEL."</button>
 		</div>";
-		
-		
+
+
 		return $text;
-		
+
 	}
 
 
@@ -231,26 +231,26 @@ class e_bootstrap
 	function badgeForm()
 	{
 		unset($this->styleClasses['primary']);
-		
+
 		foreach($this->styleClasses as $key=>$type)
 		{
 			$classLabel = ($key != '') ? " label-".$key : "";
 			$classBadge = ($key != '') ? " badge-".$key : "";	
-			
+
 			$text .= '<div class="area"><span class="label'.$classLabel.'">'.$type.'</span>&nbsp;';
 			$text .= '<span class="badge'.$classBadge.'">'.$type.'</span>';
 			$text .= "</div>";
 		} 
-		
+
 		return $text;      
-	
+
 	}
-	
-	
+
+
 	function bbcodeForm()
 	{
 		$list = e107::getPref('bbcode_list');
-		
+
 		$text .= "
 		<h4>e107 Bbcodes</h4>
 		<div class='well'>
@@ -263,7 +263,7 @@ class e_bootstrap
 		{
 			$text .= "<tr><td>".$plugin."</td>
 			<td>";
-			
+
 			foreach($val as $bb=>$v)
 			{
 				$text .= "<a href='#' class='bbcodeSelect' style='cursor:pointer'>[".$bb."][/".$bb."]</a>";
@@ -271,22 +271,22 @@ class e_bootstrap
 			$text .= "</td>
 			</tr>";
 		}
-			
+
 		$text .= "</table>
 		</div>";
-			
+
 		$frm = e107::getForm();
 		$text .= $frm->text('bbcodeValue','',false,'size=xlarge');
 		$text .= $frm->button('bbcodeInsert','go','other','Insert');
-			
-		
+
+
 		return $text;
-				
-		
+
+
 	}
-				
-	
-			
+
+
+
 	function glyphicons()
 	{
 		$icons = array(
@@ -437,39 +437,39 @@ class e_bootstrap
 
 		$frm = e107::getForm();
 		$sel = array(''=>'Dark Gray','icon-white'=>'White');	
-			
+
 		$text .= "<div  class='area'>";
 		$text .= "<div class='inline-form'>Color: ".$frm->select('glyph-color',$sel)."     Custom: ".$frm->text('glyph-custom','').$frm->button('glyph-save','Go')."</div>";	
-					
+
 		$text .= "<ul class='glyphicons well clearfix'>";
-		
+
 	//	$inverse = (e107::getPref('admincss') == "admin_dark.css") ? " icon-white" : "";
-		
+
 		foreach($icons as $ic)
 		{
 			$text .= '<li><i class="'.$ic.'"></i> '.$ic.'</li>';
 			$text .= "\n";
 		}
-					
+
 		$text .= "</ul>";	
 		$text .= "</div>";
 
 		return $text;
 
 }
-					
-				
-			
-			
-		
-		
 
 
-	
-	
+
+
+
+
+
+
+
+
 }
 
-       
+
 require_once(e_ADMIN."auth.php");			
 //e107::lan('core','admin',TRUE);
 

--- a/e107_plugins/tinymce4/plugins/e107/parser.php
+++ b/e107_plugins/tinymce4/plugins/e107/parser.php
@@ -94,7 +94,7 @@ TEMPL;
 		if($this->gzipCompression == true)
 		{
 			header('Content-Encoding: gzip');
-			$gzipoutput = gzencode($html,6);
+			$gzipoutput = gzencode((string) $html,6);
 			header('Content-Length: '.strlen($gzipoutput));
 			echo $gzipoutput;
 		}
@@ -122,7 +122,7 @@ TEMPL;
 			define('BOOTSTRAP', (int) $bs);
 		}
 
-		$content = stripslashes($content);
+		$content = stripslashes((string) $content);
 
 		//	$content = e107::getBB()->htmltoBBcode($content);	//XXX This breaks inserted images from media-manager. :/
 		e107::getBB()->setClass($this->getMediaCategory());
@@ -176,7 +176,7 @@ TEMPL;
 	{
 		e107::getBB()->setClass($this->getMediaCategory());
 
-		$content = stripslashes($content);
+		$content = stripslashes((string) $content);
 
 		if(check_class($this->postHtmlClass)) // Plain HTML mode.
 		{

--- a/e107_plugins/tinymce4/tinymce4_setup.php
+++ b/e107_plugins/tinymce4/tinymce4_setup.php
@@ -18,24 +18,24 @@ class tinymce4_setup
 	function upgrade_required()
 	{
 		$list = e107::getConfig()->get('e_meta_list'); 
-			
+
 		if(!empty($list) && in_array('tinymce4',$list))
 		{
 			return true; 	
 		}	
-			
+
 		if(file_exists(e_PLUGIN."tinymce4/e_meta.php")) // Outdated file. 
 		{
 			e107::getMessage()->addInfo("Please delete the outdated file <b>".e_PLUGIN."tinymce4/e_meta.php</b> and then run the updating process."); 
 		//	print_a(debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS,8)); 
 			return true; 
 		}
-		
+
 		return false; 
 	}
-	
 
-	
+
+
 /*	
  	function install_pre($var)
 	{
@@ -44,12 +44,12 @@ class tinymce4_setup
 
 	function install_post($var)
 	{
-	
+
 	}
 
 	function uninstall_options()
 	{
-	
+
 	}
 
 	function uninstall_post($var)
@@ -59,13 +59,13 @@ class tinymce4_setup
 
 	function upgrade_pre($var)
 	{
-		
+
 	}
 
 	function upgrade_post($var)
 	{
 
 	}
- 
+
  */
 }

--- a/e107_plugins/tinymce4/wysiwyg.php
+++ b/e107_plugins/tinymce4/wysiwyg.php
@@ -122,7 +122,7 @@ define('USE_GZIP', true);
 $compression_browser_support = false;
 $compression_server_support = false;
 
-if(strpos(varset($_SERVER['HTTP_ACCEPT_ENCODING']), 'gzip') !== false)
+if(strpos((string) varset($_SERVER['HTTP_ACCEPT_ENCODING']), 'gzip') !== false)
 {
 	$compression_browser_support = true;
 }
@@ -161,7 +161,7 @@ elseif((USE_GZIP === true) && $compression_browser_support && $compression_serve
 	header('Content-Encoding: gzip');
 
 	$minified = e107::minify($gen);
-	$gzipoutput = gzencode($minified,6);
+	$gzipoutput = gzencode((string) $minified,6);
 
 	header('Content-Length: '.strlen($gzipoutput));
 	echo $gzipoutput;

--- a/e107_plugins/tinymce4/wysiwyg_class.php
+++ b/e107_plugins/tinymce4/wysiwyg_class.php
@@ -156,7 +156,7 @@ class wysiwyg
 			return null;
 		}
 
-		$tmp = explode(" ",$data);
+		$tmp = explode(" ",(string) $data);
 
 		if(e107::pref('core','smiley_activate',false))
 		{
@@ -181,7 +181,7 @@ class wysiwyg
 	function convertBoolean($string)
 	{
 
-		if(substr($string,0,1) == '{' || substr($string,0,1) == '[' || substr($string,0,9) == 'function(')
+		if(substr((string) $string,0,1) == '{' || substr((string) $string,0,1) == '[' || substr((string) $string,0,9) == 'function(')
 		{
 			return $string;
 		}
@@ -377,7 +377,7 @@ class wysiwyg
                     {title: 'Image Right', selector: 'img', classes: 'bbcode-img-right', icon: 'alignright'}
 
                 ]},
-                
+
                 {title: 'Glyphs', items: [
                     {title: 'Size 2x', selector: 'i', classes: 'fa-2x'},
                     {title: 'Size 3x', selector: 'i', classes: 'fa-3x'},
@@ -427,9 +427,9 @@ class wysiwyg
 				 {title: 'Hover', selector: 'table', classes: 'table-hover'},
                  {title: 'Striped', selector: 'table', classes: 'table-striped'},
                 ]},
-                
 
-                
+
+
                 {title: 'Animate.css Style', items: [
 					{title: 'bounce',  selector: 'p,h1,h2,h3,h4,h5,h6,td,th,div,ul,ol,li,table,img', classes: 'animated bounce'},
 					{title: 'flash',  selector: 'p,h1,h2,h3,h4,h5,h6,td,th,div,ul,ol,li,table,img', classes: 'animated flash'},
@@ -508,7 +508,7 @@ class wysiwyg
 					{title: 'slideOutLeft',  selector: 'p,h1,h2,h3,h4,h5,h6,td,th,div,ul,ol,li,table,img', classes: 'animated slideOutLeft'},
 					{title: 'slideOutRight',  selector: 'p,h1,h2,h3,h4,h5,h6,td,th,div,ul,ol,li,table,img', classes: 'animated slideOutRight'},
 					{title: 'slideOutUp',  selector: 'p,h1,h2,h3,h4,h5,h6,td,th,div,ul,ol,li,table,img', classes: 'animated slideOutUp'}, */
-		
+
                 ]},
 
 
@@ -633,9 +633,9 @@ class wysiwyg
 			$c = 0;
 			foreach($emo as $path=>$co)
 			{
-				$codes = explode(" ",$co);
+				$codes = explode(" ",(string) $co);
 				$url = e_IMAGE_ABS."emotes/" . $pack . "/" . str_replace("!",".",$path);
-				$emotes[$i][] = array('shortcut'=>$codes, 'url'=>$url, 'title'=>ucfirst($path));
+				$emotes[$i][] = array('shortcut'=>$codes, 'url'=>$url, 'title'=>ucfirst((string) $path));
 
 				if($c == 6)
 				{
@@ -714,7 +714,7 @@ class wysiwyg
 
 		$this->config = implode(",\n",$text);
 
-		
+
 
 		// -------------------------------------------------------------------------------------
 

--- a/e107_plugins/user/e_dashboard.php
+++ b/e107_plugins/user/e_dashboard.php
@@ -116,7 +116,7 @@ class user_dashboard // plugin-folder + '_url'
 				$log_data = $value['log_data'];
 			//	extract($value);
 
-				$log_id = substr($log_id, 0, 4).'-'.substr($log_id, 5, 2).'-'.str_pad(substr($log_id, 8), 2, '0', STR_PAD_LEFT);
+				$log_id = substr((string) $log_id, 0, 4).'-'.substr((string) $log_id, 5, 2).'-'.str_pad(substr((string) $log_id, 8), 2, '0', STR_PAD_LEFT);
 				if(is_array($log_data)) {
 					$entries[0] = $log_data['host'];
 					$entries[1] = $log_data['date'];
@@ -127,7 +127,7 @@ class user_dashboard // plugin-folder + '_url'
 				}
 				else
 				{
-					$entries = explode(chr(1), $log_data);
+					$entries = explode(chr(1), (string) $log_data);
 				}
 
 				$dayarray[$log_id]['daytotal'] = $entries[0];
@@ -140,7 +140,7 @@ class user_dashboard // plugin-folder + '_url'
 				{
 					if($entry)
 					{
-						list($url, $total, $unique) = explode("|", $entry);
+						list($url, $total, $unique) = explode("|", (string) $entry);
 						if(strpos($url, "/") !== false)
 						{
 							$urlname = preg_replace("/\.php|\?.*/", "", substr($url, (strrpos($url, "/")+1)));
@@ -289,25 +289,25 @@ class user_dashboard // plugin-folder + '_url'
 
 
 		$cht->setProvider('google');
-		
+
 		$width='100%'; $height = 380; 
-	
+
 		$data[] = array('Day', "Registered" );
-		
+
 		$amt = array();
-		
+
 	//	if($when == 'this')
 		{
 			$month_start = strtotime('first day of this month', mktime(0,0,0));		
 			$month_end = strtotime('last day of this month', mktime(23,59,59));
 		}
-		
+
 	/*	if($when == 'last')
 		{
 			$month_start = strtotime('first day of last month', mktime(0,0,0));		
 			$month_end = strtotime('last day of last month', mktime(23,59,59));	
 		}*/
-		
+
 		if(!$sql->gen("SELECT user_id,user_ban,user_join FROM `#user` WHERE user_join BETWEEN ".$month_start." AND ".$month_end." AND user_ban = 0"))
 		{
 			return false;
@@ -332,13 +332,13 @@ class user_dashboard // plugin-folder + '_url'
 	//	print_a($monthNumber);
 
 		$sum = array_sum($amt);
-		
+
 	//	$this->title = 'Registered '.date('M Y',$month_start).' ('.$sum.')';
 
 		$this->title = UC_LAN_9.' ('.$sum.')';
-	
+
 		$totalDays = date('t', $month_start);
-	
+
 		for ($i=1; $i < ($totalDays +1); $i++) 
 		{
 			$diz = date('D jS', mktime(1,1,1,$monthNumber,$i, $yearNumber));
@@ -346,9 +346,9 @@ class user_dashboard // plugin-folder + '_url'
 			$data[] = array($diz, $val); //	$dateName[$i]
 			$ticks[] = $i;
 		}
-		
+
 	//	print_a($data);
-			
+
 		$options = array(
 			'chartArea'	=>array('left'=>'60', 'width'=>'100%', 'top'=>'25'),
 			'legend'	=> array('position'=> 'none', 'alignment'=>'center', 'textStyle' => array('fontSize' => 14, 'color' => '#ccc')),
@@ -357,29 +357,29 @@ class user_dashboard // plugin-folder + '_url'
 			'colors'	=> array('#77acd9','#EDA0B6', '#EE8D21', '#5CB85C'),
 			'animation'	=> array('duration'=>1000, 'easing' => 'out'), 
 			'areaOpacity'	=> 0.8,
-	
+
 			'backgroundColor' => array('fill' => 'transparent' )
 		);
 		//
 		$cht->setType('column');
 		$cht->setOptions($options);
 		$cht->setData($data);
-		
+
 		// redraw to fix sizing issue.
 	/*	e107::js('footer-inline', "
-		
-			
+
+
 			$('a[data-toggle=\"tab\"]').on('shown.bs.tab', function (e) {
 			  	//	drawLast();
 			  		drawThismonth();
 			})
-						
-			
+
+
 		");*/
-		
-		
+
+
 		return "<div class='height:50%'>".$cht->render($id, $width, $height)."</div>";
-		
+
 		// return "<div class='height:50%'>".$cht->render('projection', 320, 380)."</div>";
 		
 	}
@@ -446,7 +446,7 @@ class user_dashboard // plugin-folder + '_url'
 				<td class='nowrap'>".e107::getDateConvert()->convert_date($val['user_currentvisit'],'%H:%M:%S')."</td>
 				<td>".$this->renderOnlineName($val['online_user_id'])."</td>
 				<td>".e107::getIPHandler()->ipDecode($val['user_ip'])."</td>
-				<td><a class='e-tip' href='".$val['user_location']."' title='".$val['user_location']."'>".$tp->html_truncate(basename($val['user_location']),50,"...")."</a></td>
+				<td><a class='e-tip' href='".$val['user_location']."' title='".$val['user_location']."'>".$tp->html_truncate(basename((string) $val['user_location']),50,"...")."</a></td>
 				<td class='center'><a class='e-tip' href='#' title='".$val['user_agent']."'>".$this->browserIcon($val)."</a></td>";
 
 			$panelOnline .= (!empty($multilan)) ? "<td class='center'><a class='e-tip' href='#' title=\"".$lng->convert($val['user_language'])."\">".$val['user_language']."</a></td>" : "";
@@ -485,7 +485,7 @@ class user_dashboard // plugin-folder + '_url'
 
 		foreach($types as $icon=>$b)
 		{
-			if(strpos($row['user_agent'], $b)!==false)
+			if(strpos((string) $row['user_agent'], $b)!==false)
 			{
 				return "<i class='browsers e-".$icon."-16' ></i>";
 			}

--- a/e107_plugins/user/usertheme_menu.php
+++ b/e107_plugins/user/usertheme_menu.php
@@ -43,7 +43,7 @@ if ((USER == TRUE) && check_class(varset($pref['allow_theme_select'],FALSE)))
  
 		while ($row = $sql->fetch()) 
 		{
-            $up = (substr($row['user_prefs'],0,5) == "array") ? e107::unserialize($row['user_prefs']) : unserialize($row['user_prefs']);
+            $up = (substr((string) $row['user_prefs'],0,5) == "array") ? e107::unserialize($row['user_prefs']) : unserialize($row['user_prefs']);
 
 			if (isset($themecount[$up['sitetheme']])) { $themecount[$up['sitetheme']]++; }
 		}

--- a/e107_plugins/user/usertheme_menu_config.php
+++ b/e107_plugins/user/usertheme_menu_config.php
@@ -25,7 +25,7 @@ if (!getperms("2")) 		// Same permissions as menu configuration
 require_once(e_ADMIN."auth.php");
 
 $frm = e107::getForm();
-	
+
 // Get the list of available themes
 $handle = opendir(e_THEME);
 while ($file = readdir($handle)) 
@@ -47,7 +47,7 @@ if (isset($_POST['update_theme']))
 	$tmp = array();
 	foreach($_POST as $key => $value) 
 	{
-		if (substr($key,0,6) == 'theme_')
+		if (substr((string) $key,0,6) == 'theme_')
 		{
 			$tmp[] = $value;
 		}
@@ -117,9 +117,9 @@ $text = "
 	</form>
 	";
 	$mes = e107::getMessage();
-	
+
 $ns->tablerender(defset('LAN_UMENU_THEME_6'),$mes->render().$text);
-	
+
 require_once(e_ADMIN."footer.php");
 
 /*

--- a/e107_tests/lib/deployers/SFTPDeployer.php
+++ b/e107_tests/lib/deployers/SFTPDeployer.php
@@ -22,7 +22,7 @@ class SFTPDeployer extends Deployer
 		if (empty($this->getFsParam('privkey_path')) &&
 			!empty($this->getFsParam('password')))
 		{
-			return 'sshpass -p '.escapeshellarg($this->getFsParam('password')).' ';
+			return 'sshpass -p '.escapeshellarg((string) $this->getFsParam('password')).' ';
 		}
 		return '';
 	}
@@ -35,9 +35,9 @@ class SFTPDeployer extends Deployer
 	private function generateRsyncRemoteShell()
 	{
 		$prefix = 'ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -p '.
-			escapeshellarg($this->getFsParam('port'));
+			escapeshellarg((string) $this->getFsParam('port'));
 		if (!empty($this->getFsParam('privkey_path')))
-			return $prefix.' -i ' . escapeshellarg($this->getFsParam('privkey_path'));
+			return $prefix.' -i ' . escapeshellarg((string) $this->getFsParam('privkey_path'));
 		else
 			return $prefix;
 	}
@@ -78,7 +78,7 @@ class SFTPDeployer extends Deployer
 		$command = $this->generateSshpassPrefix().
 			$this->generateRsyncRemoteShell().
 			" ".escapeshellarg("{$fs_params['user']}@{$fs_params['host']}").
-			" ".escapeshellarg("rm -v " . escapeshellarg(rtrim($fs_params['path'], '/')."/$relative_path"));
+			" ".escapeshellarg("rm -v " . escapeshellarg(rtrim((string) $fs_params['path'], '/')."/$relative_path"));
 		$retcode = self::runCommand($command);
 		if ($retcode === 0)
 		{
@@ -93,10 +93,10 @@ class SFTPDeployer extends Deployer
 	private function start_fs()
 	{
 		$fs_params = $this->getFsParams();
-		$fs_params['path'] = rtrim($fs_params['path'], '/') . '/';
+		$fs_params['path'] = rtrim((string) $fs_params['path'], '/') . '/';
 		$command = $this->generateSshpassPrefix() .
 			'rsync -e ' .
-			escapeshellarg($this->generateRsyncRemoteShell()) .
+			escapeshellarg((string) $this->generateRsyncRemoteShell()) .
 			' --delete -avzHXShs ' .
 			escapeshellarg(rtrim(APP_PATH, '/') . '/') . ' ' .
 			escapeshellarg("{$fs_params['user']}@{$fs_params['host']}:{$fs_params['path']}");

--- a/e107_tests/lib/deployers/cPanelDeployer.php
+++ b/e107_tests/lib/deployers/cPanelDeployer.php
@@ -105,7 +105,7 @@ class cPanelDeployer extends Deployer
 		if (!is_null($acceptance_tests_apiresponse->{'data'}))
 		{
 			$acceptance_tests_raw = $acceptance_tests_apiresponse->{'data'}->{'content'};
-			$acceptance_tests = (array) json_decode($acceptance_tests_raw, true);
+			$acceptance_tests = (array) json_decode((string) $acceptance_tests_raw, true);
 			self::prune_acceptance_tests($acceptance_tests);
 		}
 		return $acceptance_tests;
@@ -157,7 +157,7 @@ class cPanelDeployer extends Deployer
 		foreach ($target_files as $target_file)
 		{
 			$questionable_filename = $target_file->{'file'};
-			if (substr($questionable_filename, 0, strlen(self::TEST_PREFIX)) === self::TEST_PREFIX &&
+			if (substr((string) $questionable_filename, 0, strlen(self::TEST_PREFIX)) === self::TEST_PREFIX &&
 				!in_array($questionable_filename, $valid_acceptance_test_ids))
 			{
 				self::println("Deleting expired test folder \"".self::TARGET_RELPATH.$questionable_filename."\"…");
@@ -172,9 +172,9 @@ class cPanelDeployer extends Deployer
 		foreach ($dbs as $db)
 		{
 			$db = (array) $db;
-			if (substr($db['db'], 0, strlen($prefix)) !== $prefix)
+			if (substr((string) $db['db'], 0, strlen($prefix)) !== $prefix)
 				continue;
-			$questionable_db = substr($db['db'], strlen($prefix));
+			$questionable_db = substr((string) $db['db'], strlen($prefix));
 			if (!in_array($questionable_db, $ids))
 			{
 				self::println("Deleting expired MySQL database \"".$db['db']."\"…");
@@ -189,9 +189,9 @@ class cPanelDeployer extends Deployer
 		foreach ($users as $user)
 		{
 			$user = (array) $user;
-			if (substr($user['user'], 0, strlen($prefix)) !== $prefix)
+			if (substr((string) $user['user'], 0, strlen($prefix)) !== $prefix)
 				continue;
-			$questionable_user = substr($user['user'], strlen($prefix));
+			$questionable_user = substr((string) $user['user'], strlen($prefix));
 			if (!in_array($questionable_user, $ids))
 			{
 				self::println("Deleting expired MySQL user \"".$user['user']."\"…");
@@ -356,8 +356,8 @@ class cPanelDeployer extends Deployer
 		foreach ($i as $file_info)
 		{
 			$realpath = $file_info->getRealPath();
-			if (substr($realpath, 0, strlen($path)) === $path)
-				$relpath = substr($realpath, strlen($path));
+			if (substr((string) $realpath, 0, strlen($path)) === $path)
+				$relpath = substr((string) $realpath, strlen($path));
 			if (substr($relpath, -3) === "/.." ||
 				substr($relpath, -2) === "/." ||
 				!file_exists($realpath) ||

--- a/e107_tests/lib/preparers/E107Preparer.php
+++ b/e107_tests/lib/preparers/E107Preparer.php
@@ -31,7 +31,7 @@ class E107Preparer implements Preparer
 
 	private function deleteDir($dirPath)
 	{
-		codecept_debug(__CLASS__ . ' is deleting '.escapeshellarg($dirPath).'…');
+		codecept_debug(__CLASS__ . ' is deleting '.escapeshellarg((string) $dirPath).'…');
 
 		if(!is_dir($dirPath))
 		{

--- a/e107_tests/tests/_bootstrap.php
+++ b/e107_tests/tests/_bootstrap.php
@@ -45,7 +45,7 @@ class E107TestSuiteBootstrap
         $params = include(PARAMS_GENERATOR);
 
         $app_path = $params['app_path'] ?: codecept_root_dir() . "/e107";
-        if (substr($app_path, 0, 1) !== '/')
+        if (substr((string) $app_path, 0, 1) !== '/')
         {
             $app_path = codecept_root_dir() . "/$app_path";
         }

--- a/e107_tests/tests/_data/basic-light/templates/news/news_menu_template.php
+++ b/e107_tests/tests/_data/basic-light/templates/news/news_menu_template.php
@@ -83,7 +83,7 @@ $NEWS_MENU_TEMPLATE['other2']['item'] 	= "<li class='media'>
 										<div class='media-body'><h5>{NEWSTITLELINK}</h5>
 										</div>
 										</li>\n";
-										
+
 $NEWS_MENU_TEMPLATE['other2']['end'] 	= "</ul>";
 
 

--- a/e107_tests/tests/_data/testcore/fs_functions.php
+++ b/e107_tests/tests/_data/testcore/fs_functions.php
@@ -6,7 +6,7 @@ function hilite($link,$enabled=''){
     if(!$enabled){ return FALSE; }
 
     $link = $tp->replaceConstants($link,TRUE);
-  	$tmp = explode("?",$link);
+  	$tmp = explode("?",(string) $link);
     $link_qry = (isset($tmp[1])) ? $tmp[1] : "";
     $link_slf = (isset($tmp[0])) ? $tmp[0] : "";
 	$link_pge = basename($link_slf);
@@ -22,7 +22,7 @@ function hilite($link,$enabled=''){
 // ----------- highlight overriding - set the link matching in the page itself.
 
 	if(defined("HILITE")) {
-		if(strpos($link,HILITE)) {
+		if(strpos((string) $link,(string) HILITE)) {
         	return TRUE;
 		}
 	}
@@ -37,11 +37,11 @@ function hilite($link,$enabled=''){
 	}
 
 // --------------- highlighting for plugins. ----------------
-		if(stristr($link, $PLUGINS_DIRECTORY) !== FALSE && stristr($link, "custompages") === FALSE){
+		if(stristr((string) $link, (string) $PLUGINS_DIRECTORY) !== FALSE && stristr((string) $link, "custompages") === FALSE){
 
 			if($link_qry)
 			{  // plugin links with queries
-                $subq = explode("?",$link);
+                $subq = explode("?",(string) $link);
 				if(strpos(e_SELF,$subq[0]) && e_QUERY == $subq[1]){
 			   		return TRUE;
 				}else{
@@ -60,10 +60,10 @@ function hilite($link,$enabled=''){
 
 // --------------- highlight for news items.----------------
 // eg. news.php, news.php?list.1 or news.php?cat.2 etc
-	if(substr(basename($link),0,8) == "news.php")
+	if(substr(basename((string) $link),0,8) == "news.php")
 	{
 
-		if (strpos($link, "news.php?") !== FALSE && strpos(e_SELF,"/news.php")!==FALSE) {
+		if (strpos((string) $link, "news.php?") !== FALSE && strpos(e_SELF,"/news.php")!==FALSE) {
 
 			$lnk = explode(".",$link_qry); // link queries.
 			$qry = explode(".",e_QUERY); // current page queries.
@@ -100,7 +100,7 @@ function hilite($link,$enabled=''){
 // --------------- highlight for Custom Pages.----------------
 // eg. page.php?1
 
-		if (strpos($link, "page.php?") !== FALSE && strpos(e_SELF,"/page.php")) {
+		if (strpos((string) $link, "page.php?") !== FALSE && strpos(e_SELF,"/page.php")) {
             list($custom,$page) = explode(".",$link_qry);
 			list($q_custom,$q_page) = explode(".",e_QUERY);
 			if($custom == $q_custom){
@@ -111,7 +111,7 @@ function hilite($link,$enabled=''){
 		}
 
 // --------------- highlight default ----------------
-		if(strpos($link, "?") !== FALSE){
+		if(strpos((string) $link, "?") !== FALSE){
 
 			$thelink = str_replace("../", "", $link);
 			if((strpos(e_SELF,$thelink) !== false) && (strpos(e_QUERY,$link_qry) !== false)){
@@ -122,11 +122,11 @@ function hilite($link,$enabled=''){
 		  	return true;
 		}
 
-   		if((!$link_qry && !e_QUERY) && (strpos(e_SELF,$link) !== FALSE)){
+   		if((!$link_qry && !e_QUERY) && (strpos(e_SELF,(string) $link) !== FALSE)){
 			return TRUE;
 		}
 
-		if(($link_slf == e_SELF && !link_qry) || (e_QUERY && strpos(e_SELF."?".e_QUERY,$link)!== FALSE) ){
+		if(($link_slf == e_SELF && !link_qry) || (e_QUERY && strpos(e_SELF."?".e_QUERY,(string) $link)!== FALSE) ){
           	return TRUE;
 		}
 
@@ -137,7 +137,7 @@ function hilite($link,$enabled=''){
 function adnav_cat($cat_title, $cat_link, $cat_id=FALSE, $cat_open=FALSE) {
 	global $tp;
 
-	$cat_link = (strpos($cat_link, '://') === FALSE && strpos($cat_link, 'mailto:') !== 0 ? e_HTTP.$cat_link : $cat_link);
+	$cat_link = (strpos((string) $cat_link, '://') === FALSE && strpos((string) $cat_link, 'mailto:') !== 0 ? e_HTTP.$cat_link : $cat_link);
 	
 	if ($cat_open == 4 || $cat_open == 5){
 		$dimen = ($cat_open == 4) ? "600,400" : "800,600";
@@ -166,8 +166,8 @@ function render_sub($linklist, $id) {
 	foreach ($linklist['sub_'.$id] as $sub) {
 	
 		// Filter title for backwards compatibility ---->
-		if(substr($sub['link_name'],0,8) == "submenu.") {
-			$tmp = explode(".",$sub['link_name']);
+		if(substr((string) $sub['link_name'],0,8) == "submenu.") {
+			$tmp = explode(".",(string) $sub['link_name']);
 			$subname = $tmp[2];
 		} else {
 			$subname = $sub['link_name'];
@@ -214,7 +214,7 @@ function render_sub($linklist, $id) {
 function adnav_main($cat_title, $cat_link, $cat_id=FALSE, $cat_open=FALSE) {
 	global $tp;
 	
-	$cat_link = (strpos($cat_link, '://') === FALSE) ? e_HTTP.$cat_link : $cat_link;
+	$cat_link = (strpos((string) $cat_link, '://') === FALSE) ? e_HTTP.$cat_link : $cat_link;
 	$cat_link = $tp->replaceConstants($cat_link,TRUE);
 
 	if ($cat_open == 4 || $cat_open == 5){

--- a/e107_tests/tests/_support/Helper/DelayedDb.php
+++ b/e107_tests/tests/_support/Helper/DelayedDb.php
@@ -21,14 +21,14 @@ class DelayedDb extends \Codeception\Module\Db
     public function _getDbHostname()
     {
         $matches = [];
-        $matched = preg_match('~host=([^;]+)~s', $this->config['dsn'], $matches);
+        $matched = preg_match('~host=([^;]+)~s', (string) $this->config['dsn'], $matches);
         return $matched ? $matches[1] : false;
     }
 
     public function _getDbName()
     {
         $matches = [];
-        $matched = preg_match('~dbname=([^;]+)~s', $this->config['dsn'], $matches);
+        $matched = preg_match('~dbname=([^;]+)~s', (string) $this->config['dsn'], $matches);
         return $matched ? $matches[1] : false;
     }
 

--- a/e107_tests/tests/unit/CronParserTest.php
+++ b/e107_tests/tests/unit/CronParserTest.php
@@ -77,13 +77,13 @@ class CronParserTest extends \Codeception\Test\Unit
 	{
 		$lastTimeZone = date_default_timezone_get();
 		date_default_timezone_set('America/Chihuahua');
-	
+
 		$this->cp->calcLastRan('* * * * *');
-		
+
 		$due = $this->cp->getLastDue();
 		$now = $this->cp->getNow();
 
-		list($date, $time) = explode('T', $due);
+		list($date, $time) = explode('T', (string) $due);
 		list($year,$month,$day) = explode('-', $date);
 		list($hour,$minute) = explode(':', $time);
 

--- a/e107_tests/tests/unit/TreeModelTest.php
+++ b/e107_tests/tests/unit/TreeModelTest.php
@@ -94,7 +94,7 @@ class TreeModelTest extends \Codeception\Test\Unit
         $method->setAccessible(true);
         $method->invoke($tree_model);
 
-        $this->assertEquals('ORDER BY n.news_sticky DESC, n.news_datestamp DESC', trim($tree_model->getParam('db_query')));
+        $this->assertEquals('ORDER BY n.news_sticky DESC, n.news_datestamp DESC', trim((string) $tree_model->getParam('db_query')));
         $this->assertEquals('4', $tree_model->getParam('db_limit_count'));
         $this->assertEmpty($tree_model->getParam('db_limit_offset'));
     }
@@ -109,7 +109,7 @@ class TreeModelTest extends \Codeception\Test\Unit
         $method->setAccessible(true);
         $method->invoke($tree_model);
 
-        $this->assertEquals('ORDER BY n.news_sticky DESC, n.news_datestamp DESC', trim($tree_model->getParam('db_query')));
+        $this->assertEquals('ORDER BY n.news_sticky DESC, n.news_datestamp DESC', trim((string) $tree_model->getParam('db_query')));
         $this->assertEquals('163', $tree_model->getParam('db_limit_count'));
         $this->assertEquals('79', $tree_model->getParam('db_limit_offset'));
     }

--- a/e107_tests/tests/unit/e107EmailTest.php
+++ b/e107_tests/tests/unit/e107EmailTest.php
@@ -343,7 +343,7 @@ Admin<br />
 			if (!file_exists($filePath)) return false;
 			$handle = fopen($filePath, 'r');
 			while (($buffer = fgets($handle)) !== false) {
-				if (strpos($buffer, $string) !== false) {
+				if (strpos($buffer, (string) $string) !== false) {
 					return true;
 				}
 			}

--- a/e107_tests/tests/unit/e107Test.php
+++ b/e107_tests/tests/unit/e107Test.php
@@ -99,20 +99,20 @@ class e107Test extends \Codeception\Test\Unit
 			        </div><!--/.navbar-collapse -->
 			      </div>
 			    </div>
-			
+
 			<!--- Optional custom header template controlled by theme_shortcodes -->
 			{---HEADER---}
-			
+
 			<!-- Page Content -->
 			{---LAYOUT---}
-			
+
 			<!-- Footer --> 
-			
+
 			{SETSTYLE=default}
 			<footer>
 				<div class="container">
 					<div class="row">
-			
+
 						<div>
 							<div class="col-lg-6">
 								{MENU=100}
@@ -121,23 +121,23 @@ class e107Test extends \Codeception\Test\Unit
 								{MENU=101}
 							</div>
 						</div>
-			
+
 						<div>
 							<div class="col-sm-12 col-lg-4">
 								{MENU=102}
 							</div>
-			
+
 							<div class="col-sm-12 col-lg-8">
 								{MENU=103}
 							</div>
 						</div>
-			
+
 						<div >
 							<div class="col-lg-12">
 								{MENU=104}
 							</div>
 						</div>
-			
+
 						<div>
 							<div class="col-lg-6">
 								{MENU=105}
@@ -148,28 +148,28 @@ class e107Test extends \Codeception\Test\Unit
 								{BOOTSTRAP_USERNAV: placement=bottom&dir=up}
 							</div>
 						</div>
-			
+
 						<div>
 							<div class="col-lg-12">
-					
+
 							</div>
 						</div>
-			
+
 						<div>
 							<div id="sitedisclaimer" class="col-lg-12 text-center">
 								<small >{SITEDISCLAIMER}</small>
 							</div>
 						</div>
-			
+
 					</div>	 <!-- /row -->
 				</div> <!-- /container -->
 			</footer>
-			
+
 			{---MODAL---}
 			<!--- Optional custom footer template controlled by theme_shortcodes -->
 			{---FOOTER---}
-			
-			
+
+
 			<!-- Javascripts and other information are automatically added below here -->
 			</body> <!-- This tag is not necessary and is ignored and replaced. Left here only as a reference -->';
 
@@ -1644,7 +1644,7 @@ class e107Test extends \Codeception\Test\Unit
 	private function generateRows($var, $plugin)
 	{
 
-		preg_match_all('#\{([a-z_]*)\}#', $var['sef'], $matches);
+		preg_match_all('#\{([a-z_]*)\}#', (string) $var['sef'], $matches);
 
 
 		$variables = array('-one-', '-two-', '-three-');

--- a/e107_tests/tests/unit/e107pluginTest.php
+++ b/e107_tests/tests/unit/e107pluginTest.php
@@ -195,7 +195,7 @@
 			      ),
 		     )
 			);
-			
+
 			$expected = array ( 
 				0 => array (  
 					'name' => 'plugin_test_custom',  
@@ -213,8 +213,8 @@
 					'source' => 'plugin_test',
 				), 
 			); 
-			
-			
+
+
 
 			$result = $this->ep->XmlExtendedFields('test', $extendedVars);
 

--- a/e107_tests/tests/unit/e_admin_controller_uiTest.php
+++ b/e107_tests/tests/unit/e_admin_controller_uiTest.php
@@ -60,7 +60,7 @@
 					OR e.calls_from = REPLACE(m.mem_phone_other1 , '-', '') 
 					OR e.calls_from = REPLACE(m.mem_phone_other2 , '-', '')
 				)
-			
+
 			) 
 			LEFT JOIN `#member_calender` AS cl ON 
 			(
@@ -69,7 +69,7 @@
 					cl.cal_by_phone = REPLACE(m.mem_phone_day, '-', '') 
 					OR cl.cal_by_cell = REPLACE(m.mem_phone_cell , '-', '') 
 				)
-			
+
 			) ";
 
 			$this->ui->joinAlias($qry2);

--- a/e107_tests/tests/unit/e_bbcodeTest.php
+++ b/e107_tests/tests/unit/e_bbcodeTest.php
@@ -74,7 +74,7 @@
 
 			$result = $this->bb->htmltoBbcode($text);
 
-			$expected = strip_tags($result);
+			$expected = strip_tags((string) $result);
 
 			$this->assertSame($expected, $result);
 

--- a/e107_tests/tests/unit/e_customfieldsTest.php
+++ b/e107_tests/tests/unit/e_customfieldsTest.php
@@ -229,7 +229,7 @@
 			  19 => 'Userclass',
 			  20 => 'Progress Bar',
 			);
-			
+
 		$expectedValues = array (
 		  'image'       => '<img class="img-responsive img-fluid"',
 		  'video'       => '<div class="embed-responsive embed-responsive-16by9',

--- a/e107_tests/tests/unit/e_db_abstractTest.php
+++ b/e107_tests/tests/unit/e_db_abstractTest.php
@@ -609,7 +609,7 @@ abstract class e_db_abstractTest extends \Codeception\Test\Unit
 		$row = $this->db->db_Fetch('num');
 		$this->assertEquals('e107_user', $row[0]);
 
-		$check = (strpos($row[1], "CREATE TABLE `e107_user`") !== false);
+		$check = (strpos((string) $row[1], "CREATE TABLE `e107_user`") !== false);
 		$this->assertTrue($check);
 
 		$this->db->select('user', '*', 'user_id = 1');
@@ -971,7 +971,7 @@ abstract class e_db_abstractTest extends \Codeception\Test\Unit
 		$this->db->select('doesnt_exists');
 		$result = $this->db->getLastErrorText();
 
-		$actual = (strpos($result,"doesn't exist")!== false );
+		$actual = (strpos((string) $result,"doesn't exist")!== false );
 
 		$this->assertTrue($actual);
 	}

--- a/e107_tests/tests/unit/e_fileTest.php
+++ b/e107_tests/tests/unit/e_fileTest.php
@@ -476,7 +476,7 @@ class e_fileTest extends \Codeception\Test\Unit
 				foreach($test as $mime=>$ext)
 				{
 					$actual = $this->fl->getFileExtension($mime);
-		
+
 					self::assertSame($ext, $actual);
 				}	
 			}
@@ -630,7 +630,7 @@ class e_fileTest extends \Codeception\Test\Unit
 		{
 			foreach ($src_dest_map as $src => $dest)
 			{
-				$desired_filename = preg_replace("/^".preg_quote($src, '/')."/", $dest, $desired_filename);
+				$desired_filename = preg_replace("/^".preg_quote($src, '/')."/", $dest, (string) $desired_filename);
 			}
 			self::assertContains(realpath($destination.$desired_filename), $results['success'],
 				"Desired file $desired_filename did not appear in file system");

--- a/e107_tests/tests/unit/e_formTest.php
+++ b/e107_tests/tests/unit/e_formTest.php
@@ -1321,7 +1321,7 @@ class e_formTest extends \Codeception\Test\Unit
 			$result = str_replace(array("\n", "\r"), "", $result);
 
 			$expected = "<select name='dropdown_004[]' id='dropdown-004' class='tbox select form-control' multiple='multiple'><option value='noindex' data-title='Prevent search engines from indexing this item.'>NoIndex</option><option value='nofollow' data-title='Prevent search engines from following links in this item.'>NoFollow</option><option value='noarchive' data-title='Prevent cached copies of this item from appearing in search results.'>NoArchive</option><option value='noimageindex' data-title='Prevent search engines from indexing images of this item.'>NoImageIndex</option></select>";
-		
+
 			self::assertSame($expected, $result);
 	}
 

--- a/e107_tests/tests/unit/e_jsmanagerTest.php
+++ b/e107_tests/tests/unit/e_jsmanagerTest.php
@@ -377,7 +377,7 @@ class e_jsmanagerTest extends \Codeception\Test\Unit
 
 		foreach($tests as $var)
 		{
-			$result = (strpos($actual, $var['expected']) !== false);
+			$result = (strpos((string) $actual, $var['expected']) !== false);
 			$this->assertTrue($result, $var['expected'] . " was not found in the rendered links. Render links result:" . $actual . "\n\n");
 		}
 
@@ -431,7 +431,7 @@ class e_jsmanagerTest extends \Codeception\Test\Unit
 
 		foreach($staticTests as $var)
 		{
-			$result = (strpos($actual, $var['expected']) !== false);
+			$result = (strpos((string) $actual, $var['expected']) !== false);
 			self::assertTrue($result, $var['expected'] . " was not found in the rendered links. Render links result:" . $actual . "\n\n");
 		}
 

--- a/e107_tests/tests/unit/e_library_managerTest.php
+++ b/e107_tests/tests/unit/e_library_managerTest.php
@@ -155,7 +155,7 @@
 				return false;
 			}
 
-			if(!empty($headers[0]) && strpos($headers[0], 'OK') !== false)
+			if(!empty($headers[0]) && strpos((string) $headers[0], 'OK') !== false)
 			{
 				return true;
 			}

--- a/e107_tests/tests/unit/e_parseTest.php
+++ b/e107_tests/tests/unit/e_parseTest.php
@@ -1288,7 +1288,7 @@ EXPECTED;
 
 	private function isValidXML($xmlContent)
 	{
-		if (trim($xmlContent) == '')
+		if (trim((string) $xmlContent) == '')
 		{
 			return false;
 		}
@@ -2707,7 +2707,7 @@ EXPECTED;
 		foreach ($tests as $index => $var)
 		{
 			$result = $this->tp->toImage($var['src'], $var['parms']);
-			$result = preg_replace('/"([^"]*)thumb.php/', '"thumb.php', $result);
+			$result = preg_replace('/"([^"]*)thumb.php/', '"thumb.php', (string) $result);
 			self::assertSame($var['expected'], $result);
 
 		}

--- a/e107_tests/tests/unit/e_pluginTest.php
+++ b/e107_tests/tests/unit/e_pluginTest.php
@@ -321,7 +321,7 @@
 		public function testIsValidAddonMarkup()
         {
             $content = '<?php    
-            
+
             ';
             $result = $this->ep->isValidAddonMarkup($content);
             $this->assertTrue($result);

--- a/e107_tests/tests/unit/e_pluginbuilderTest.php
+++ b/e107_tests/tests/unit/e_pluginbuilderTest.php
@@ -6,7 +6,7 @@ class e_pluginbuilderTest extends \Codeception\Test\Unit
 
 	/** @var e_pluginbuilder */
 	protected $pb;
-	
+
 	protected $posted;
 
 	protected function _before()
@@ -21,7 +21,7 @@ class e_pluginbuilderTest extends \Codeception\Test\Unit
 		{
 			$this->fail($e->getMessage());
 		}
-		
+
 		$this->posted = array (
 		  'xml' => 
 		  array (

--- a/e107_tests/tests/unit/e_thumbnailTest.php
+++ b/e107_tests/tests/unit/e_thumbnailTest.php
@@ -378,10 +378,10 @@ class compareImages
     public function compareHash($imageHash)
     {
         $sString = $this->getHasString();
-        if (strlen($imageHash) == 64 && strlen($sString) == 64) {
+        if (strlen((string) $imageHash) == 64 && strlen((string) $sString) == 64) {
             $diff = 0;
-            $sString = str_split($sString);
-            $imageHash = str_split($imageHash);
+            $sString = str_split((string) $sString);
+            $imageHash = str_split((string) $imageHash);
             for($a = 0; $a < 64; $a++) {
                 if ($imageHash[$a] != $sString[$a]) {
                     $diff++;

--- a/e107_themes/bootstrap3/admin_theme.php
+++ b/e107_themes/bootstrap3/admin_theme.php
@@ -94,7 +94,7 @@ class bootstrap3_admintheme implements e_theme_render
 		// global $style;
 
 		$style = $data['setStyle'];
-		
+
 	//	echo "Style: ".$style;
 
 		echo "\n\n<!-- UniqueID: ".$data['uniqueId']." -->\n\n";
@@ -140,7 +140,7 @@ class bootstrap3_admintheme implements e_theme_render
 			return;
 		}
 
-		if(trim($caption) == '')
+		if(trim((string) $caption) == '')
 		{
 			$style = 'no_caption';
 		}
@@ -159,7 +159,7 @@ class bootstrap3_admintheme implements e_theme_render
 
 
 
-		
+
 		switch(varset($style, 'admin_content'))
 		{
 			case 'flexpanel':

--- a/e107_themes/bootstrap3/theme_shortcodes.php
+++ b/e107_themes/bootstrap3/theme_shortcodes.php
@@ -164,10 +164,10 @@ class theme_shortcodes extends e_shortcode
 				$text .= '
 				<li class="divider-vertical"></li>
 				<li class="dropdown">
-			
+
 				<a class="dropdown-toggle" href="#" data-toggle="dropdown">'.LAN_LOGINMENU_51.' <strong class="caret"></strong></a>
 				<div class="dropdown-menu col-sm-12" style="min-width:250px; padding: 15px; padding-bottom: 0px;">
-				
+
 				{SOCIAL_LOGIN: size=2x&label=1}
 				'; // Sign In
 			}

--- a/e107_themes/bootstrap5/theme_shortcodes.php
+++ b/e107_themes/bootstrap5/theme_shortcodes.php
@@ -140,7 +140,7 @@ class theme_shortcodes extends e_shortcode
 			default:
 			if(!empty($news['news_thumbnail']))
 			{
-				$tmp = explode(',', $news['news_thumbnail']);
+				$tmp = explode(',', (string) $news['news_thumbnail']);
 
 				$opts = array(
 					'w' => 1800,

--- a/e107_themes/voux/templates/news/news_menu_template.php
+++ b/e107_themes/voux/templates/news/news_menu_template.php
@@ -102,7 +102,7 @@ $NEWS_MENU_TEMPLATE['other2']['item'] 	= "<li class='media'>
 										<p class='text-right'><a class='btn btn-primary btn-othernews2' href='{NEWSURL}'>".LAN_READ_MORE." &raquo;</a></p>
 										</div>
 										</li>\n";
-										
+
 $NEWS_MENU_TEMPLATE['other2']['end'] 	= "</ul>";
 
 

--- a/e107_themes/voux/theme.php
+++ b/e107_themes/voux/theme.php
@@ -58,36 +58,36 @@ define('PRE_EXTENDEDSTRING', '<br />');
 function tablestyle($caption, $text, $id='', $info=array()) 
 {
 //	global $style; // no longer needed. 
-	
+
 	$style = $info['setStyle'];
-	
+
 	echo "<!-- tablestyle: style=".$style." id=".$id." -->\n\n";
-	
+
 	$type = $style;
 	if(empty($caption))
 	{
 		$type = 'box';
 	}
-	
+
 	if($style == 'navdoc' || $style == 'none')
 	{
 		echo $text;
 		return;
 	}
-	
+
 	/*
 	if($id == 'wm') // Example - If rendered from 'welcome message' 
 	{
-		
+
 	}
-	
+
 	if($id == 'featurebox') // Example - If rendered from 'featurebox' 
 	{
-		
+
 	}	
 	*/
-	
-	
+
+
 	if($style == 'jumbotron')
 	{
 		echo '<div class="jumbotron">
@@ -102,11 +102,11 @@ function tablestyle($caption, $text, $id='', $info=array())
     	</div>';	
 		return;
 	}
-	
+
 	if($style == 'col-md-3' || $style == 'col-md-4' || $style == 'col-md-6' || $style == 'col-md-8' || $style == 'col-md-9')
 	{
 		echo ' <div class="col-xs-12 '.$style.'">';
-		
+
 		if(!empty($caption))
 		{
             echo '<h2>'.$caption.'</h2>';
@@ -116,9 +116,9 @@ function tablestyle($caption, $text, $id='', $info=array())
           '.$text.'
         </div>';
 		return;	
-		
+
 	}
-		
+
 	if($style == 'menu')
 	{
 		echo '<div class="menu">
@@ -128,7 +128,7 @@ function tablestyle($caption, $text, $id='', $info=array())
 	  </div>
 	</div>';
 		return;
-		
+
 	}	
 
 	if($style == 'portfolio')
@@ -152,11 +152,11 @@ function tablestyle($caption, $text, $id='', $info=array())
 	echo $text;
 
 
-					
+
 	return;
-	
-	
-	
+
+
+
 }
 
 // applied before every layout.
@@ -190,8 +190,8 @@ $LAYOUT['_header_'] = '
 </h1>
 </div>
 </div>
-  
-	
+
+
 ';
 
 // applied after every layout. 
@@ -331,9 +331,9 @@ $LAYOUT['jumbotron_home'] =  <<<TMPL
 	<div class="container">	
 
 	{MENU=1}
-	
+
 	{---}
-	
+
 	</div>
     <div class="container">
       <!-- Example row of columns -->
@@ -397,14 +397,14 @@ $LAYOUT['modern_business_home'] =  <<<TMPL
     {SETSTYLE=none}
 
 	{FEATUREBOX}   
-	
+
 	<div class="container">	
 	{ALERTS}
 <!-- Start Menu 1 --> 
 	{MENU=1}
 <!-- End Menu 1 --> 
 	</div>
-	
+
 	<div class="section">
 	    <div class="container">
 	      <!-- Example row of columns -->
@@ -416,7 +416,7 @@ $LAYOUT['modern_business_home'] =  <<<TMPL
 	      </div>
 		</div>
 	</div>
-		
+
 {SETSTYLE=default}
 
 	<div class="section-colored text-center">
@@ -431,8 +431,8 @@ $LAYOUT['modern_business_home'] =  <<<TMPL
 
   	</div><!-- /.section-colored -->
 
-	
-	
+
+
 	<div class="section">
 
       <div class="container">
@@ -442,11 +442,11 @@ $LAYOUT['modern_business_home'] =  <<<TMPL
             <h2>Display Some Work on the Home Page Portfolio</h2>
             <hr>
           </div>
-          
+
 		  {SETSTYLE=portfolio}
 		  {SETIMAGE: w=700&h=500&crop=1}
 		  {GALLERY_PORTFOLIO: placeholder=1&limit=6}   
-		  
+
         </div><!-- /.row -->
 
       </div><!-- /.container -->
@@ -462,29 +462,29 @@ $LAYOUT['modern_business_home'] =  <<<TMPL
 		<div class="container">
 
 			<div class="row">
-			
+
         		{CMENU=feature-menu-1}
-				
+
 			</div>
-			
+
 		</div><!-- /.container -->
 
 	</div><!-- /.section-colored -->
 
 
-	
+
 	 <div class="section">
-	
+
 		<div class="container">
-		
+
 			<div class="row">
-			
+
 				{CMENU=feature-menu-2}
-				
+
 			</div>
-			
+
 		</div><!-- /.container -->
-	
+
 	</div><!-- /.section -->
 
 
@@ -492,9 +492,9 @@ $LAYOUT['modern_business_home'] =  <<<TMPL
 	<div class="container">
 
 		<div class="row well">
-      
+
         	{CMENU=feature-menu-3}
-		
+
 		</div><!-- /.row -->
 
 	</div><!-- /.container -->
@@ -517,32 +517,32 @@ TMPL;
 
 
 $LAYOUT['jumbotron_full'] = '
-   
+
 	{SETSTYLE=default}
 	<div class="container">	
 	{ALERTS}
    	 {MENU=1}
 	{---}
-	
+
 	</div>
     <div class="container">
-   
-     
+
+
 
 	';
 
 
 
 $LAYOUT['jumbotron_sidebar_right'] =  '
-   
+
 	{SETSTYLE=default}
 	<div class="container">	
 	{ALERTS}
 		<div class="row">
    			<div class="col-xs-12 col-md-8">
-   		
+
 				{---}
-	
+
  			</div>
         	<div id="sidebar" class="col-xs-12 col-md-4">
         	{SETSTYLE=menu}
@@ -550,7 +550,7 @@ $LAYOUT['jumbotron_sidebar_right'] =  '
         		{MENU=1}
         	</div>
       </div>
-	
+
 	</div>
     <div class="container">
            {SETSTYLE=default}
@@ -597,9 +597,9 @@ $LAYOUT['jumbotron_sidebar_right'] =  '
 
 
 /*
- 
- 
- 
+
+
+
 $NEWSCAT = "\n\n\n\n<!-- News Category -->\n\n\n\n
 	<div style='padding:2px;padding-bottom:12px'>
 	<div class='newscat_caption'>

--- a/e107_themes/voux/theme_shortcodes.php
+++ b/e107_themes/voux/theme_shortcodes.php
@@ -129,10 +129,10 @@ class theme_shortcodes extends e_shortcode
 				$text .= '
 				<li class="divider-vertical"></li>
 				<li class="dropdown">
-			
+
 				<a class="dropdown-toggle" href="#" data-toggle="dropdown">'.LAN_LOGINMENU_51.' <strong class="caret"></strong></a>
 				<div class="dropdown-menu col-sm-12" style="min-width:250px; padding: 15px; padding-bottom: 0px;">
-				
+
 				{SOCIAL_LOGIN: size=2x&label=1}
 				'; // Sign In
 			}

--- a/e107_web/js/e_ajax.php
+++ b/e107_web/js/e_ajax.php
@@ -39,7 +39,7 @@ ob_implicit_flush(0);
 			 // parse errror fix from the previous commit
 			 e107::getScParser()->loadThemeShortcodes();
 		}
-		list($fld,$parm) = explode("=", $_POST['ajax_sc'], 2);
+		list($fld,$parm) = explode("=", (string) $_POST['ajax_sc'], 2);
 		$prm = ($parm) ? "=".rawurldecode($parm) : ""; //var_dump($_GET);
 		echo e107::getParser()->parseTemplate("{".strtoupper($fld).$prm."}", true, $shortcodes);
 		exit;

--- a/e107_web/js/e_jslib.php
+++ b/e107_web/js/e_jslib.php
@@ -17,7 +17,7 @@
 error_reporting(0);
 
 //admin or front-end call
-if (strpos($_SERVER['QUERY_STRING'], '_admin') !== FALSE)
+if (strpos((string) $_SERVER['QUERY_STRING'], '_admin') !== FALSE)
 {
 	define('ADMIN_AREA', true); //force admin area
 }
@@ -26,7 +26,7 @@ else
 	define('USER_AREA', true); //force user area
 }
 // no-browser-cache check
-if (strpos($_SERVER['QUERY_STRING'], '_nobcache') !== FALSE)
+if (strpos((string) $_SERVER['QUERY_STRING'], '_nobcache') !== FALSE)
 {
 	define('e_NOCACHE', true); //force no browser cache
 }
@@ -36,7 +36,7 @@ else
 }
 
 // no-server-cache check
-if (strpos($_SERVER['QUERY_STRING'], '_nocache') !== FALSE)
+if (strpos((string) $_SERVER['QUERY_STRING'], '_nocache') !== FALSE)
 {
 	define('e_NOSCACHE', true); //force no system cache
 }
@@ -176,7 +176,7 @@ function e_jslib_is_cache($encoding)
 function e_jslib_browser_enc()
 {
 	//NEW - option to disable completely gzip compression
-	if(strpos($_SERVER['QUERY_STRING'], '_nogzip') !== false)
+	if(strpos((string) $_SERVER['QUERY_STRING'], '_nogzip') !== false)
 	{
 		return '';
 	}
@@ -185,11 +185,11 @@ function e_jslib_browser_enc()
 	{
 		$encoding = '';
 	}
-	elseif (strpos($_SERVER["HTTP_ACCEPT_ENCODING"], 'x-gzip') !== false)
+	elseif (strpos((string) $_SERVER["HTTP_ACCEPT_ENCODING"], 'x-gzip') !== false)
 	{
 		$encoding = 'x-gzip';
 	}
-	elseif (strpos($_SERVER["HTTP_ACCEPT_ENCODING"], 'gzip') !== false)
+	elseif (strpos((string) $_SERVER["HTTP_ACCEPT_ENCODING"], 'gzip') !== false)
 	{
 		$encoding = 'gzip';
 	}

--- a/email.php
+++ b/email.php
@@ -58,7 +58,7 @@ unset($qs);
 $error = '';
 $message = '';
 
-$referrer = strip_tags(urldecode(html_entity_decode(varset($_SERVER['HTTP_REFERER'],''), ENT_QUOTES)));
+$referrer = strip_tags(urldecode(html_entity_decode((string) varset($_SERVER['HTTP_REFERER'],''), ENT_QUOTES)));
 $emailurl = ($source == 'referer') ? $referrer : SITEURL;
 
 $comments = '';
@@ -122,9 +122,9 @@ if (isset($_POST['emailsubmit']))
 	$ip = e107::getIPHandler()->getIP(FALSE);
 	$message .= "\n\n".LAN_EMAIL_2." ".$ip."\n\n";
 
-	if (substr($source,0,7) == 'plugin:')
+	if (substr((string) $source,0,7) == 'plugin:')
 	{
-		$plugin = substr($source,7);
+		$plugin = substr((string) $source,7);
 		$text = '';
 		if(file_exists(e_PLUGIN.$plugin.'/e_emailprint.php'))
 		{
@@ -146,12 +146,12 @@ if (isset($_POST['emailsubmit']))
 			e107::redirect();
 			exit;
 		}
-		$message .= strip_tags($_POST['referer']);
-		$emailurl = strip_tags($_POST['referer']);
+		$message .= strip_tags((string) $_POST['referer']);
+		$emailurl = strip_tags((string) $_POST['referer']);
 	}
 	else
 	{
-		$emailurl = strip_tags($_POST['referer']);
+		$emailurl = strip_tags((string) $_POST['referer']);
 		$message = '';
 		if($sql->select('news', 'news_title, news_body, news_extended', 'news_id='.((int)$parms)))
 		{

--- a/fpw.php
+++ b/fpw.php
@@ -95,7 +95,7 @@ if(e_QUERY)
 	define('FPW_ACTIVE','TRUE');
 
 	// Verify the password reset code syntax
-	$tmpinfo = preg_replace("#[\W_]#", "", e107::getParser()->toDB(e_QUERY, true));			// query part is a 'random' number
+	$tmpinfo = preg_replace("#[\W_]#", "", (string) e107::getParser()->toDB(e_QUERY, true));			// query part is a 'random' number
 	if ($tmpinfo != e_QUERY)
 	{
 		// Shouldn't be any characters that toDB() changes
@@ -118,7 +118,7 @@ if(e_QUERY)
 
 		$sql->delete('tmp', "tmp_time < ".time()); // cleanup table.
 
-		list($uid, $loginName, $md5) = explode(FPW_SEPARATOR, $row['tmp_info']);
+		list($uid, $loginName, $md5) = explode(FPW_SEPARATOR, (string) $row['tmp_info']);
 		$loginName = $tp->toDB($loginName, true);
 
 		// This should never happen! 

--- a/gsitemap.php
+++ b/gsitemap.php
@@ -103,10 +103,10 @@ class gsitemap_xml
 
 			if($url[0] === '/')
 			{
-				 $url = ltrim($url, '/');
+				 $url = ltrim((string) $url, '/');
 			}
 
-			$loc = (strpos($url, 'http') === 0) ? $url : SITEURL.$tp->replaceConstants($url,true);
+			$loc = (strpos((string) $url, 'http') === 0) ? $url : SITEURL.$tp->replaceConstants($url,true);
 			$xml .= "
 			<url>
 				<loc>".$loc."</loc>";
@@ -117,10 +117,10 @@ class gsitemap_xml
 
 				if($imgUrl[0] === '/')
 				{
-					 $imgUrl = ltrim($imgUrl, '/');
+					 $imgUrl = ltrim((string) $imgUrl, '/');
 				}
 
-				$imgUrl = (strpos($imgUrl, 'http') === 0) ? $imgUrl : SITEURL.$tp->replaceConstants($imgUrl,true);
+				$imgUrl = (strpos((string) $imgUrl, 'http') === 0) ? $imgUrl : SITEURL.$tp->replaceConstants($imgUrl,true);
 
 				$xml .= "
 				<image:image>
@@ -229,7 +229,7 @@ if(e_QUERY == "show" || !empty($_GET['show']))
 
 	foreach($nfArray as $nfa)
 	{
-		$url = (substr($nfa['gsitemap_url'],0,4)== "http")? $nfa['gsitemap_url'] : SITEURL.$tp->replaceConstants($nfa['gsitemap_url'],TRUE);
+		$url = (substr((string) $nfa['gsitemap_url'],0,4)== "http")? $nfa['gsitemap_url'] : SITEURL.$tp->replaceConstants($nfa['gsitemap_url'],TRUE);
 		$text .= "<li>".$tp->toHTML($nfa['gsitemap_cat'],"","defs").": <a href='".$url."'>".$tp->toHTML($nfa['gsitemap_name'],"","defs")."</a></li>\n";
 	}
 	$text .= "</ul></div>";

--- a/install.php
+++ b/install.php
@@ -265,7 +265,7 @@ $override = array();
 
 if(isset($_POST['previous_steps']))
 {
-	$tmp = unserialize(base64_decode($_POST['previous_steps']));
+	$tmp = unserialize(base64_decode((string) $_POST['previous_steps']));
 	$override = (isset($tmp['paths']) && isset($tmp['paths']['hash'])) ? array('site_path'=>$tmp['paths']['hash']) : array();
 	unset($tmp);
 	unset($tmpadminpass1);
@@ -401,7 +401,7 @@ class e_install
 		$this->e107 = $e107;
 		if(isset($_POST['previous_steps']))
 		{
-			$this->previous_steps = unserialize(base64_decode($_POST['previous_steps']));
+			$this->previous_steps = unserialize(base64_decode((string) $_POST['previous_steps']));
 
 			// Save unfiltered admin password (#4004) - " are transformed into &#34;
 			$tmpadminpass2 = (isset($this->previous_steps['admin'])) ? $this->previous_steps['admin']['password'] : '';
@@ -597,7 +597,7 @@ class e_install
 		// $page_info = nl2br(LANINS_023);
 		$page_info = "<div class='alert alert-block alert-info'>".LANINS_141."</div>";
 		$e_forms->start_form("versions", $_SERVER['PHP_SELF'].($_SERVER['QUERY_STRING'] === "debug" ? "?debug" : ""));
-		$isrequired = (($_SERVER['SERVER_ADDR'] === "127.0.0.1") || ($_SERVER['SERVER_ADDR'] === "localhost") || ($_SERVER['SERVER_ADDR'] === "::1") || preg_match('/^192\.168\.\d{1,3}\.\d{1,3}$/',$_SERVER['SERVER_ADDR'])) ? "" :  "required='required'"; // Deals with IP V6, and 192.168.x.x address ranges, could be improved to validate x.x to a valid IP but for this use, I dont think its required to be that picky.
+		$isrequired = (($_SERVER['SERVER_ADDR'] === "127.0.0.1") || ($_SERVER['SERVER_ADDR'] === "localhost") || ($_SERVER['SERVER_ADDR'] === "::1") || preg_match('/^192\.168\.\d{1,3}\.\d{1,3}$/',(string) $_SERVER['SERVER_ADDR'])) ? "" :  "required='required'"; // Deals with IP V6, and 192.168.x.x address ranges, could be improved to validate x.x to a valid IP but for this use, I dont think its required to be that picky.
 
 		$output = "
 			<div style='width: 100%; padding-left: auto; padding-right: auto;'>
@@ -927,7 +927,7 @@ class e_install
 			$perms_pass = false;
 			foreach ($not_writable as $file)
 			{
-				$perms_errors .= (substr($file, -1) === "/" ? LANINS_010a : LANINS_010)."<br /><b>{$file}</b><br />\n";
+				$perms_errors .= (substr((string) $file, -1) === "/" ? LANINS_010a : LANINS_010)."<br /><b>{$file}</b><br />\n";
 			}
 			$perms_notes = LANINS_018;
 		}
@@ -936,7 +936,7 @@ class e_install
 			$perms_pass = true;
 			foreach ($opt_writable as $file)
 			{
-				$perms_errors .= (substr($file, -1) === "/" ? LANINS_010a : LANINS_010)."<br /><b>{$file}</b><br />\n";
+				$perms_errors .= (substr((string) $file, -1) === "/" ? LANINS_010a : LANINS_010)."<br /><b>{$file}</b><br />\n";
 			}
 			$perms_notes = LANINS_106;
 		}
@@ -1901,7 +1901,7 @@ return [
 		$this->previous_steps['prefs']['replyto_email']		= $this->previous_steps['admin']['email'];
 
 		// Cookie name fix, ended up with 406 error when non-latin words used
-		$cookiename 										= preg_replace('/[^a-z0-9]/i', '', trim($this->previous_steps['prefs']['sitename']));
+		$cookiename 										= preg_replace('/[^a-z0-9]/i', '', trim((string) $this->previous_steps['prefs']['sitename']));
 		$this->previous_steps['prefs']['cookie_name']		= ($cookiename ? substr($cookiename, 0, 4).'_' : 'e_').'cookie';
 		
 		### URL related prefs
@@ -2028,7 +2028,7 @@ return [
 		{
 			$this->previous_steps['language'] = $_POST['language'];
 		}		
-		
+
 		if(!isset($this->previous_steps['language']))
 		{
 			$this->previous_steps['language'] = "English";
@@ -2242,7 +2242,7 @@ return [
 			$sql_table = preg_replace("/create table\s/si", "CREATE TABLE {$this->previous_steps['mysql']['prefix']}", $sql_table);
 
 			// Drop existing tables before creating.
-			$tmp = explode("\n",$sql_table);
+			$tmp = explode("\n",(string) $sql_table);
 			$drop_table = str_replace($srch,$repl,$tmp[0]);
 			$this->dbqry($drop_table);
 
@@ -2261,7 +2261,7 @@ return [
 	{
 		$e107_config = 'e107_config.php';
 		$fp = @fopen($e107_config, 'w');
-		if (!@fwrite($fp, $data))
+		if (!@fwrite($fp, (string) $data))
 		{
 			@fclose ($fp);
 			return nl2br(LANINS_070);

--- a/login.php
+++ b/login.php
@@ -108,7 +108,7 @@ if (!USER || getperms('0'))
 
 
 	$login_message = SITENAME; //	$login_message = LAN_LOGIN_3." | ".SITENAME;
-	if(strpos($LOGIN_TABLE_HEADER,'LOGIN_TABLE_LOGINMESSAGE') === false && strpos($LOGIN_TABLE,'LOGIN_TABLE_LOGINMESSAGE') === false)
+	if(strpos((string) $LOGIN_TABLE_HEADER,'LOGIN_TABLE_LOGINMESSAGE') === false && strpos((string) $LOGIN_TABLE,'LOGIN_TABLE_LOGINMESSAGE') === false)
 	{
 		    if(deftrue('e_IFRAME'))
             {  

--- a/online.php
+++ b/online.php
@@ -62,12 +62,12 @@
 	foreach($listuserson as $uinfo => $pinfo)
 	{
 		$class_check = true;
-		list($oid, $oname) = explode(".", $uinfo, 2);
+		list($oid, $oname) = explode(".", (string) $uinfo, 2);
 		$online_location = $pinfo;
-		$online_location_page = substr(strrchr($online_location, "/"), 1);
-		if(strpos($online_location, "forum_") === false || strpos($online_location, "content.php") === false || strpos($online_location, "comment.php") === false)
+		$online_location_page = substr(strrchr((string) $online_location, "/"), 1);
+		if(strpos((string) $online_location, "forum_") === false || strpos((string) $online_location, "content.php") === false || strpos((string) $online_location, "comment.php") === false)
 		{
-			$online_location_page = str_replace(".php", "", substr(strrchr($online_location, "/"), 1));
+			$online_location_page = str_replace(".php", "", substr(strrchr((string) $online_location, "/"), 1));
 		}
 
 		switch($online_location_page)
@@ -180,9 +180,9 @@
 		$scArray = array();
 
 
-		if(strpos($online_location, "content.php") !== false)
+		if(strpos((string) $online_location, "content.php") !== false)
 		{
-			$tmp = explode(".", substr(strrchr($online_location, "php."), 2));
+			$tmp = explode(".", substr(strrchr((string) $online_location, "php."), 2));
 			if($tmp[0] == "article")
 			{
 				$sql->select("content", "content_heading, content_class", "content_id='" . (int) $tmp[1] . "'");
@@ -221,9 +221,9 @@
 			}
 		}
 
-		if(strpos($online_location, "comment.php") !== false)
+		if(strpos((string) $online_location, "comment.php") !== false)
 		{
-			$tmp = explode(".php.", $online_location);
+			$tmp = explode(".php.", (string) $online_location);
 			$tmp = explode(".", $tmp[1]);
 			if($tmp[1] == "news")
 			{
@@ -253,10 +253,10 @@
 			}
 		}
 
-		if(strpos($online_location, "forum") !== false)
+		if(strpos((string) $online_location, "forum") !== false)
 		{
-			$tmp = explode(".", substr(strrchr($online_location, "php."), 2));
-			if(strpos($online_location, "_viewtopic") !== false)
+			$tmp = explode(".", substr(strrchr((string) $online_location, "php."), 2));
+			if(strpos((string) $online_location, "_viewtopic") !== false)
 			{
 				if($tmp[2])
 				{
@@ -281,7 +281,7 @@
 					$online_location_page = ONLINE_EL13 . ": \"" . CLASSRESTRICTED . "\"";
 				}
 			}
-			elseif(strpos($online_location, "_viewforum") !== false)
+			elseif(strpos((string) $online_location, "_viewforum") !== false)
 			{
 				$sql->select("forum", "forum_name, forum_class", "forum_id=" . intval($tmp[0]));
 				$forum = $sql->fetch();
@@ -293,7 +293,7 @@
 					$online_location_page = ONLINE_EL13 . ": \"" . CLASSRESTRICTED . "\"";
 				}
 			}
-			elseif(strpos($online_location, "_post") !== false)
+			elseif(strpos((string) $online_location, "_post") !== false)
 			{
 				$sql->select("forum_thread", "thread_name, thread_forum_id", "thread_forum_id=" . intval($tmp[0]) . " AND thread_parent=0");
 				$forum_thread = $sql->fetch();
@@ -304,7 +304,7 @@
 			}
 		}
 
-		if(strpos($online_location, "admin") !== false)
+		if(strpos((string) $online_location, "admin") !== false)
 		{
 			$class_check = false;
 			$online_location_page = ADMINAREA;

--- a/page.php
+++ b/page.php
@@ -533,11 +533,11 @@ class pageClass
 			}
 			else
 			{
-				
+
 				$pageArray = $sql->db_getList();
 
 				$text = $tp->parseTemplate($template['start'], true, $var); // for parsing {SETIMAGE} etc.
-				
+
 				foreach($pageArray as $page)
 				{
 					/*$data = array(
@@ -552,23 +552,23 @@ class pageClass
 					$page['book_id']    = $page['chapter_parent'];
 					$page['book_name']  =  $this->getName($page['chapter_parent']);
 					$page['book_sef'] = $bookSef;
-					
+
 				//	$this->page = $page;
 					$this->batch->setVars($page);
 					$this->batch->breadcrumb();
 				//	$this->batch->setVars(new e_vars($data))->setScVar('page', $this->page);
 
 
-					
+
 
 				//	$url = e107::getUrl()->create('page/view', $page, 'allow=page_id,page_sef,chapter_sef,book_sef');
 					// $text .= "<li><a href='".$url."'>".$tp->toHTML($page['page_title'])."</a></li>";
 					$text .= e107::getParser()->parseTemplate($template['item'], true, $this->batch);
 				}
-				
+
 				$text .= $tp->parseTemplate($template['end'], true, $var);
-				
-		
+
+
 			//	$caption = ($title !='')? $title: LAN_PAGE_11;
 			//	e107::getRender()->tablerender($caption, $text,"cpage_list");
 			}
@@ -584,27 +584,27 @@ class pageClass
 	
 	function processViewPage()
 	{
-		
+
 		if($this->checkCache())
 		{
 			return;
 		}
-		
+
 		$sql = e107::getDb();
-		
+
 		$query = "SELECT p.*, u.user_id, u.user_name, user_login FROM #page AS p
 		LEFT JOIN #user AS u ON p.page_author = u.user_id
 		WHERE p.page_id=".intval($this->pageID); // REMOVED AND p.page_class IN (".USERCLASS_LIST.") - permission check is done later 
 
 
-		
-		
+
+
 		if(!$sql->gen($query))
 		{
 		 	header("HTTP/1.0 404 Not Found");
 		 //	exit; 
 			/*
-			
+
 			$ret['title'] = LAN_PAGE_12;			// ***** CHANGED
 			$ret['sub_title'] = '';
 			$ret['text'] = LAN_PAGE_3;
@@ -614,9 +614,9 @@ class pageClass
 			$ret['err'] = TRUE;
 			$ret['cachecontrol'] = false;
 			*/
-			
+
 			// ---------- New (to replace values above) ----
-			
+
 			$this->page['page_title'] = LAN_PAGE_12;			// ***** CHANGED
 			$this->page['sub_title'] = '';
 			$this->page['page_text'] = LAN_PAGE_3;
@@ -626,9 +626,9 @@ class pageClass
 			$this->page['err'] = TRUE;
 			$this->page['cachecontrol'] = false;
 
-			
+
 			// -------------------------------------
-			
+
 			$this->authorized = 'nf';
 			$this->template = e107::getCoreTemplate('page', 'default');
 		//	$this->batch = e107::getScBatch('page',null,'cpage')->setVars(new e_vars($ret))->setScVar('page', array()); ///Upgraded to setVars() array. (not using '$this->page')
@@ -639,10 +639,10 @@ class pageClass
 
 			$this->batch = e107::getScBatch('page',null,'cpage')->setVars($this->page)->wrapper('page/'.$this->templateID);
 			$this->batch->breadcrumb();
-			
+
 
 			e107::title($this->page['page_title']);
-			
+
 			return;
 		}
 
@@ -655,7 +655,7 @@ class pageClass
 		$this->templateID = vartrue($this->page['page_template'], 'default');
 
 		$this->template = e107::getCoreTemplate('page', $this->templateID, true, true);
-		
+
 		if(!$this->template)
 		{
 			// switch to default
@@ -713,9 +713,9 @@ class pageClass
 		$ret['err'] = FALSE;
 		$ret['cachecontrol'] = (isset($this->page['page_password']) && !$this->page['page_password'] && $this->authorized === true);		// Don't cache password protected pages
 		*/
-		
+
 	//	$this->batch->setVars(new e_vars($ret))->setScVar('page', $this->page); // Removed in favour of $this->var (cross-compatible with menus and other parts of e107 that use the same shortcodes) 
-	
+
 		// ---- New --- -
 		$this->page['page_text'] 	    = $this->pageToRender;
 	//	$this->page['np'] 			    = $pagenav;
@@ -977,20 +977,20 @@ class pageClass
 		
 		$this->pageTitles = array();		// Notice removal
 
-		if(preg_match_all('/\[newpage.*?\]/si', $this->pageText, $pt))
+		if(preg_match_all('/\[newpage.*?\]/si', (string) $this->pageText, $pt))
 		{
-			if (substr($this->pageText, 0, 6) == '[html]')
+			if (substr((string) $this->pageText, 0, 6) == '[html]')
 			{	// Need to strip html bbcode from wysiwyg on multi-page docs (handled automatically on single pages)
-				if (substr($this->pageText, -7, 7) == '[/html]')
+				if (substr((string) $this->pageText, -7, 7) == '[/html]')
 				{
-					$this->pageText = substr($this->pageText, 6, -7);
+					$this->pageText = substr((string) $this->pageText, 6, -7);
 				}
 				else
 				{
-					$this->pageText = substr($this->pageText, 6);
+					$this->pageText = substr((string) $this->pageText, 6);
 				}
 			}
-			$pages = preg_split("/\[newpage.*?\]/si", $this->pageText, -1, PREG_SPLIT_NO_EMPTY);
+			$pages = preg_split("/\[newpage.*?\]/si", (string) $this->pageText, -1, PREG_SPLIT_NO_EMPTY);
 			$this->multipageFlag = TRUE;
 		}
 		else
@@ -1076,14 +1076,14 @@ class pageClass
 	// FIXME most probably will fail when cache enabled
 	function pageRating($page_rating_flag)
 	{
-		
+
 		if($page_rating_flag)
 		{
 			return "<br /><div style='text-align:right'>".e107::getRate()->render("page", $this->pageID,array('label'=>LAN_PAGE_4))."</div>";
-			
+
 		}
-		
-		
+
+
 		// return $rate_text;
 	}
 
@@ -1175,10 +1175,10 @@ class pageClass
 	{
 		if(!$this->pageID || !vartrue($_POST['page_pw'])) return;
 		$pref = e107::getPref();
-		
+
 		$pref['pageCookieExpire'] = max($pref['pageCookieExpire'], 120);
 		$hash = md5($_POST['page_pw'].USERID);
-		
+
 		cookie($this->getCookieName(), $hash, (time() + $pref['pageCookieExpire']));
 		//header("location:".e_SELF."?".e_QUERY);
 		//exit;

--- a/print.php
+++ b/print.php
@@ -56,9 +56,9 @@ $source = preg_replace('/[^\w\d_\:]/',"", $qs[0]);
 $parms = varset($qs[1]);
 unset($qs);
 
-if(strpos($source,'plugin:') !== false)
+if(strpos((string) $source,'plugin:') !== false)
 {
-	$plugin = substr($source, 7);
+	$plugin = substr((string) $source, 7);
 
 	if($obj = e107::getAddon($plugin, 'e_print'))
 	{

--- a/search.php
+++ b/search.php
@@ -227,9 +227,9 @@ class search_front extends e_shortcode
 	function sc_search_type_sel($parm='')
 	{
 		return e107::getForm()->radio_switch('adv', vartrue($_GET['adv']), LAN_SEARCH_30, LAN_SEARCH_29, array('class'=>'e-expandit','reverse'=>1, 'data-target'=>'search-advanced'));
-		
-		
-		
+
+
+
 	//	return "<input type='radio' name='adv' value='0' ".(vartrue($_GET['adv']) ? "" : "checked='checked'")." /> ".LAN_SEARCH_29."&nbsp;
 	//	<input type='radio' name='adv' value='1' ".(vartrue($_GET['adv']) ? "checked='checked'" : "" )." /> ".LAN_SEARCH_30;
 	}
@@ -719,7 +719,7 @@ class search_front extends e_shortcode
 				{
 					if (isset($_SERVER['HTTP_REFERER'])) 
 					{
-						if (!$refpage = substr($_SERVER['HTTP_REFERER'], (strrpos($_SERVER['HTTP_REFERER'], "/")+1))) 
+						if (!$refpage = substr((string) $_SERVER['HTTP_REFERER'], (strrpos((string) $_SERVER['HTTP_REFERER'], "/")+1))) 
 						{
 							$refpage = "index.php";
 						}
@@ -733,7 +733,7 @@ class search_front extends e_shortcode
 					{
 						if ($value['refpage']) 
 						{
-							if (strpos($refpage, $value['refpage']) !== FALSE) 
+							if (strpos($refpage, (string) $value['refpage']) !== FALSE) 
 							{
 								$searchtype[$key] = true;
 								$_GET['t'] = $key;
@@ -795,8 +795,8 @@ class search_front extends e_shortcode
 		$query = $this->query;
 
 		
-		$_GET['q'] = rawurlencode(varset($_GET['q']));
-		$_GET['t'] = preg_replace('/[^\w\-]/i', '', varset($_GET['t']));
+		$_GET['q'] = rawurlencode((string) varset($_GET['q']));
+		$_GET['t'] = preg_replace('/[^\w\-]/i', '', (string) varset($_GET['t']));
 		
 		$search_prefs	= $this->search_prefs;
 		$result_flag	= $this->result_flag;
@@ -876,8 +876,8 @@ class search_front extends e_shortcode
 					$core_parms = array('r' => '', 'q' => '', 't' => '', 's' => '');
 					foreach ($_GET as $pparm_key => $pparm_value) 
 					{
-						$temp = preg_replace('/[^\w_]/i','',$pparm_key);
-						$temp1 = preg_replace('/[^\w_ +]/i','',$pparm_value);		// Filter 'non-word' charcters in search term
+						$temp = preg_replace('/[^\w_]/i','',(string) $pparm_key);
+						$temp1 = preg_replace('/[^\w_ +]/i','',(string) $pparm_value);		// Filter 'non-word' charcters in search term
 						//if (($temp == $pparm_key) && !isset($core_parms[$pparm_key]))
 					//	{
 						//	$parms .= "&".$pparm_key."=".$temp1; //FIXME Unused
@@ -916,7 +916,7 @@ class search_front extends e_shortcode
 			if (is_array($value)) {
 				$data[$key] = $this->magic_search($value);
 			} else {
-				$data[$key] = stripslashes($value);
+				$data[$key] = stripslashes((string) $value);
 			}
 		}
 		return $data;
@@ -941,7 +941,7 @@ class search_front extends e_shortcode
 			
 			if ($_GET['in']) 
 			{
-				$en_in = explode(' ', $_GET['in']);
+				$en_in = explode(' ', (string) $_GET['in']);
 				foreach ($en_in as $en_in_key) 
 				{
 					$full_query .= " +".$tp->filter($en_in_key);
@@ -950,7 +950,7 @@ class search_front extends e_shortcode
 			}
 			if ($_GET['ex']) 
 			{
-				$en_ex = explode(' ', $_GET['ex']);
+				$en_ex = explode(' ', (string) $_GET['ex']);
 				foreach ($en_ex as $en_ex_key) 
 				{
 					$full_query .= " -".$tp->filter($en_ex_key);
@@ -964,7 +964,7 @@ class search_front extends e_shortcode
 			}
 			if ($_GET['be']) 
 			{
-				$en_be = explode(' ', $_GET['be']);
+				$en_be = explode(' ', (string) $_GET['be']);
 				foreach ($en_be as $en_be_key) 
 				{
 					$full_query .= " ".$tp->filter($en_be_key)."*";
@@ -978,12 +978,12 @@ class search_front extends e_shortcode
 				$this->message = LAN_SEARCH_201;
 				$this->result_flag = false;
 			} 
-			else if (strlen($full_query) == 0) 
+			else if (strlen((string) $full_query) == 0) 
 			{
 				$perform_search = false;
 				$this->message = LAN_SEARCH_201;
 			} 
-			elseif (strlen($full_query) < ($char_count = ($this->search_prefs['mysql_sort'] ? 4 : 3))) 
+			elseif (strlen((string) $full_query) < ($char_count = ($this->search_prefs['mysql_sort'] ? 4 : 3))) 
 			{
 				$perform_search = false;
 				$this->message = str_replace('[x]', $char_count, LAN_417);
@@ -1015,7 +1015,7 @@ class search_front extends e_shortcode
 			
 
 			
-			$this->query = trim($full_query);
+			$this->query = trim((string) $full_query);
 
 			if ($this->query)
 			{
@@ -1208,7 +1208,7 @@ if ($perform_search)
 function parsesearch($text, $match) 
 {
 	$tp = e107::getParser();
-	$text = strip_tags($text);
+	$text = strip_tags((string) $text);
 	$temp = $tp->ustristr($text, $match);
 	$pos = $tp->ustrlen($text) - $tp->ustrlen($temp);
 	$matchedText = $tp->usubstr($text,$pos,$tp->ustrlen($match));

--- a/signup.php
+++ b/signup.php
@@ -166,7 +166,7 @@ if($signup_imagecode)
 if ((USER || (intval($pref['user_reg']) !== 1) || (vartrue($pref['auth_method'],'e107') != 'e107')) && !getperms('0'))
 {
 	e107::redirect();
-	
+
 }
 
 
@@ -195,7 +195,7 @@ if(e_QUERY && e_QUERY != 'stage1')
 if (isset($_POST['register']) && intval($pref['user_reg']) === 1) 
 {	
 	e107::getCache()->clear("online_menu_totals");
-	
+
 	if ($signup_imagecode)
 	{	
 		if ($badCodeMsg = e107::getSecureImg()->invalidCode($_POST['rand_num'], $_POST['code_verify'])) // better: allows class to return the error. 
@@ -223,13 +223,13 @@ if (isset($_POST['register']) && intval($pref['user_reg']) === 1)
 		{
 			$_POST['hideemail'] = 1;
 		}
-		
+
 		if(!isset($_POST['email_confirm']))
 		{
 			$_POST['email_confirm'] = $_POST['email'];	
 		}
-			
-			
+
+
 		// Use LoginName for DisplayName if restricted
 		if (!check_class($pref['displayname_class'],e_UC_PUBLIC.','.e_UC_MEMBER))
 		{
@@ -280,7 +280,7 @@ if (isset($_POST['register']) && intval($pref['user_reg']) === 1)
 		{
 			if($ipcount = $sql->select('user', '*', "user_ip='".$allData['user_ip']."' and user_ban !='2' "))
 			{
-				if($ipcount >= $pref['signup_maxip'] && trim($pref['signup_maxip']) != "")
+				if($ipcount >= $pref['signup_maxip'] && trim((string) $pref['signup_maxip']) != "")
 				{
 					$allData['errors']['user_email'] = ERR_GENERIC;
 					$allData['errortext']['user_email'] =  LAN_SIGNUP_71;
@@ -326,7 +326,7 @@ if (isset($_POST['register']) && intval($pref['user_reg']) === 1)
 
 		// Determine whether we have an error
 		$error = ((isset($allData['errors']) && count($allData['errors'])) || (isset($eufVals['errors']) && count($eufVals['errors'])) || count($extraErrors));
-		
+
 		// All validated here - handle any errors
 		if ($error) //FIXME - this ignores the errors caused by invalid image-code. 
 		{
@@ -353,7 +353,7 @@ if (isset($_POST['register']) && intval($pref['user_reg']) === 1)
 			{
 				message_handler('P_ALERT', implode('<br />', $temp));	
 			}
-	
+
 		}
 	}		// End of data validation
 	else
@@ -366,7 +366,7 @@ if (isset($_POST['register']) && intval($pref['user_reg']) === 1)
 		{
 			message_handler('P_ALERT', implode('<br />', $extraErrors));	// Workaround for image-code errors. 
 		}
-		
+
 	}
 
 
@@ -405,7 +405,7 @@ if (isset($_POST['register']) && intval($pref['user_reg']) === 1)
 		{
 			$allData['data']['user_ban'] = USER_VALIDATED;
 		}
-		
+
 		// Work out data to be written to user audit trail
 		$signup_data = array('user_name', 'user_loginname', 'user_email', 'user_ip');
 //		foreach (array() as $f)
@@ -415,7 +415,7 @@ if (isset($_POST['register']) && intval($pref['user_reg']) === 1)
 		}
 
 		$allData['data']['user_password'] = $userMethods->HashPassword($savePassword,$allData['data']['user_loginname']);
-		
+
 		if (vartrue($pref['allowEmailLogin']))
 		{  // Need to create separate password for email login
 			//$allData['data']['user_prefs'] = serialize(array('email_password' => $userMethods->HashPassword($savePassword, $allData['data']['user_email'])));
@@ -426,13 +426,13 @@ if (isset($_POST['register']) && intval($pref['user_reg']) === 1)
 		$allData['data']['user_ip'] = e107::getIPHandler()->getIP(FALSE);
 
 
-		
+
 		if(!vartrue($allData['data']['user_name']))
 		{
 			$allData['data']['user_name'] = $allData['data']['user_loginname'];	
 			$signup_data['user_name'] = $allData['data']['user_loginname'];
 		} 
-		
+
 		// The user_class, user_perms, user_prefs, user_realm fields don't have default value,
 		//   so we put apropriate ones, otherwise - broken DB Insert
 
@@ -453,9 +453,9 @@ if (isset($_POST['register']) && intval($pref['user_reg']) === 1)
 
 		// Actually write data to DB
 		validatorClass::addFieldTypes($userMethods->userVettingInfo, $allData);
-		
+
 		$nid = $sql->insert('user', $allData);
-		
+
 		if (isset($eufVals['data']) && count($eufVals['data']))
 		{
 			$usere->addFieldTypes($eufVals);		// Add in the data types for storage
@@ -464,7 +464,7 @@ if (isset($_POST['register']) && intval($pref['user_reg']) === 1)
 			$sql->gen("INSERT INTO `#user_extended` (user_extended_id) values ('{$nid}')");
 			$sql->update('user_extended', $eufVals);
 		}
-		
+
 	//	if (SIGNUP_DEBUG)
 	//	{
 		//	 $admin_log->addEvent(10,debug_backtrace(),"DEBUG","Signup new user",array_merge($allData['data'],$eufVals) ,FALSE,LOG_TO_ROLLING);
@@ -503,7 +503,7 @@ if (isset($_POST['register']) && intval($pref['user_reg']) === 1)
 				$allData['data']['activation_url'] = SITEURL."signup.php?activate.".$allData['data']['user_id'].".".$allData['data']['user_sess'];
 				// FIX missing user_name
 				if(!vartrue($allData['data']['user_name'])) $allData['data']['user_name'] = $allData['data']['user_login'];
-				
+
 				// prefered way to send user emails
 
 				if(getperms('0') && !empty($_POST['simulation']))
@@ -538,10 +538,10 @@ if (isset($_POST['register']) && intval($pref['user_reg']) === 1)
 				$eml['e107_header'] = $eml['userid'];
 				require_once(e_HANDLER.'mail.php');
 				$mailer = new e107Email();
-				
+
 				// FIX - sendEmail returns TRUE or error message...
 				$check = $mailer->sendEmail($allData['data']['user_email'], $allData['data']['user_name'], $eml,FALSE);*/
-				
+
 				if(true !== $check)
 				{
 					$error_message = LAN_SIGNUP_42; // There was a problem, the registration mail was not sent, please contact the website administrator.
@@ -580,7 +580,7 @@ if (isset($_POST['register']) && intval($pref['user_reg']) === 1)
 			{
 				$allData['data']['user_class'] = $init_class;
 				$user_class_update = $sql->update("user", "user_class = '{$allData['data']['user_class']}' WHERE user_name='{$allData['data']['user_name']}' LIMIT 1");
-				
+
 				if($user_class_update === FALSE)
 				{
 					//$admin_log->addEvent(10,debug_backtrace(),'USER','Userclass update fail',print_r($row,TRUE),FALSE,LOG_TO_ROLLING);
@@ -603,7 +603,7 @@ if (isset($_POST['register']) && intval($pref['user_reg']) === 1)
 				$text = LAN_SIGNUP_76."&nbsp;".SITENAME.", ".LAN_SIGNUP_12."<br /><br />";
 				$text .= str_replace(array('[',']'), array("<a href='".e_LOGIN."'>", "</a>"), LAN_SIGNUP_13);
 			}
-			
+
 			$ns->tablerender(LAN_SIGNUP_8,$text);
 			require_once(FOOTERF);
 			exit;

--- a/submitnews.php
+++ b/submitnews.php
@@ -90,8 +90,8 @@ class submitNews
 			exit;
 		}
 
-		$submitnews_user  = (USER ? USERNAME  : trim($tp->toDB($_POST['submitnews_name'])));
-		$submitnews_email = (USER ? USEREMAIL : trim(check_email($tp->toDB($_POST['submitnews_email']))));
+		$submitnews_user  = (USER ? USERNAME  : trim((string) $tp->toDB($_POST['submitnews_name'])));
+		$submitnews_email = (USER ? USEREMAIL : trim((string) check_email($tp->toDB($_POST['submitnews_email']))));
 		$submitnews_title = $tp->filter($_POST['submitnews_title']);
 		$submitnews_item  = $tp->filter($_POST['submitnews_item']);
 	//	$submitnews_item  = str_replace("src=&quot;e107_images", "src=&quot;".SITEURL."e107_images", $submitnews_item);

--- a/unsubscribe.php
+++ b/unsubscribe.php
@@ -29,7 +29,7 @@ class e_unsubscribe
 			return;	
 		}
 		
-		$tmp = base64_decode($_GET['id']);
+		$tmp = base64_decode((string) $_GET['id']);
 
 		parse_str($tmp,$data);
 

--- a/upload.php
+++ b/upload.php
@@ -28,16 +28,16 @@ class userUpload
 {
 	function __construct()
 	{
-		
+
 
 		/*
 		e107::css('inline', "
 			input[type=file] {
-			
-			
+
+
 			}
 		"); 
-		
+
 		e107::js('inline', "
 
 			function frmVerify()
@@ -63,7 +63,7 @@ class userUpload
 					return false;
 				}
 			}
-			
+
 		");
 		*/
    		
@@ -161,7 +161,7 @@ class userUpload
 
 	    	if(!empty($_POST['category']))
 		    {
-		        list($catOwner, $catID) = explode("__",$_POST['category'],2);
+		        list($catOwner, $catID) = explode("__",(string) $_POST['category'],2);
 		    }
 		    else
 		    {

--- a/userposts.php
+++ b/userposts.php
@@ -175,7 +175,7 @@ elseif ($action == 'forums')
 	$USERPOSTS_TEMPLATE = e107::getCoreTemplate('userposts');
 
 	$s_info = '';
-	$_POST['f_query'] = trim(varset($_POST['f_query']));
+	$_POST['f_query'] = trim((string) varset($_POST['f_query']));
 	if ($_POST['f_query'] !== '')
 	{
 		$f_query = $tp->toDB($_POST['f_query']);

--- a/usersettings.php
+++ b/usersettings.php
@@ -597,7 +597,7 @@ class usersettings_front // Begin Usersettings rewrite.
 		{
 /*			if(!empty($_POST['updated_data']) && !empty($_POST['currentpassword']) && !empty($_POST['updated_key']))
 			{	// Got some data confirmed with password entry*/
-				$new_data = base64_decode($_POST['updated_data']);
+				$new_data = base64_decode((string) $_POST['updated_data']);
 
 				 // Should only happen if someone's fooling around
 				if ($this->getValidationKey($new_data) !== $_POST['updated_key'] || ($userMethods->hasReadonlyField($new_data) !==false))
@@ -990,7 +990,7 @@ class usersettings_front // Begin Usersettings rewrite.
 	 */
 	private function getValidationKey($string)
 	{
-		return crypt($string, e_TOKEN);
+		return crypt((string) $string, e_TOKEN);
 	}
 
 


### PR DESCRIPTION
Rule: NullToStrictStringFuncCallArgRector (https://getrector.com/rule-detail/null-to-strict-string-func-call-arg-rector)

In versions of PHP prior to 8.1, passing null to native functions that expected a string (such as strlen(), explode(), trim(), or str_replace()) would trigger an internal "coercion." PHP would silently convert the null value into an empty string (""), allowing the execution to continue without warnings.

As of PHP 8.1, this behavior was deprecated, and in PHP 8.4 and 8.5, the engine has moved towards strict type enforcement. This Rector rule explicitly adds a (string) cast to arguments passed to these native functions whenever the variable could potentially be null.

### Motivation and Context
Being able to use e107 with php8.5 and future releases. Avoid potential flaws.

### Description
Cast to string (null ==> '') for arguments where non null values are expected. 

Used php rector for the changes, just the rule: NullToStrictStringFuncCallArgRector 

Also: Some identation is changed because of the tool: empty lines will remove trailing spaces.

### How Has This Been Tested?
Running the tests

### Types of Changes
- [X] Bug fix (non-breaking change which fixes a FUTURE issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [X] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist
- [X] My code adheres to the e107 [code style standard](https://github.com/e107inc/e107/wiki/e107-Coding-Standard).
- [X] I have read the [**contributing** document](https://github.com/e107inc/e107/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/e107inc/e107/tree/master/e107_tests) to cover my changes.
- [ ] All new and existing tests pass.