### PR TITLE
feat(fpw): Accept class parm on `{FPW_SUBMIT}` shortcode

### DIFF
--- a/e107_core/shortcodes/batch/fpw_shortcodes.php
+++ b/e107_core/shortcodes/batch/fpw_shortcodes.php
@@ -48,7 +48,13 @@ class fpw_shortcodes extends e_shortcode
 		// return "<input class='button btn btn-primary btn-block' type='submit' name='pwsubmit' value='".$label."' />";
 		$label = deftrue('LAN_FPW_102', LAN_SUBMIT);
 
-		return e107::getForm()->button('pwsubmit', $label);
+		$options = array();
+		if(!empty($parm['class']))
+		{
+			$options['class'] = $parm['class'];
+		}
+
+		return e107::getForm()->button('pwsubmit', $label, 'submit', '', $options);
 	}
 
 	function sc_fpw_captcha_lan($parm = null)

--- a/e107_tests/tests/unit/e_parse_shortcodeTest.php
+++ b/e107_tests/tests/unit/e_parse_shortcodeTest.php
@@ -1162,6 +1162,41 @@ class e_parse_shortcodeTest extends \Codeception\Test\Unit
 
 	}
 
+	/**
+	 * {FPW_SUBMIT} default render must not stack a second "btn submit" prefix on
+	 * top of the one the form handler already applies, and {FPW_SUBMIT class=X}
+	 * must pass X through to the rendered button.
+	 *
+	 * @see https://github.com/e107inc/e107/pull/5330
+	 */
+	public function testFpwSubmitShortcodeAcceptsClassParm()
+	{
+		require_once(e_CORE."shortcodes/batch/fpw_shortcodes.php");
+
+		try
+		{
+			/** @var fpw_shortcodes $sc */
+			$sc = $this->make('fpw_shortcodes');
+		}
+		catch (Exception $e)
+		{
+			$this->fail($e->getMessage());
+		}
+
+		$sc->__construct();
+
+		$tp = e107::getParser();
+
+		$defaultHtml = $tp->parseTemplate('{FPW_SUBMIT}', true, $sc);
+		$this->assertMatchesRegularExpression('/class=[\'"]btn submit btn-success[\'"]/', $defaultHtml);
+		$this->assertStringNotContainsString('btn submit btn submit', $defaultHtml);
+
+		$withParmHtml = $tp->parseTemplate('{FPW_SUBMIT: class=my-class}', true, $sc);
+		$this->assertStringContainsString('my-class', $withParmHtml);
+		$this->assertStringContainsString('btn submit', $withParmHtml);
+		$this->assertStringNotContainsString('btn submit btn submit', $withParmHtml);
+	}
+
 
 
     public function testForumShortcodes()


### PR DESCRIPTION
### Motivation and Context

Supersedes #5330. Enables `{FPW_SUBMIT: class=my-class}` for easier templating, matching the existing convention in `sc_login_table_submit` (`e107_core/shortcodes/batch/login_shortcodes.php:179`) and `sc_signup_button` (`e107_core/shortcodes/batch/signup_shortcodes.php:663`). Related: #3837.

Co-authors @Jimmi08, who opened #5330 and gave [permission](https://github.com/e107inc/e107/pull/5330#issuecomment-4288262329) for me to carry the narrow fix forward. The class-override addition is his idea; this revision only adjusts *how* the override is applied so it doesn't clobber the form handler's defaults.

### Description

#5330 set `$options['class'] = "btn submit btn-success"` unconditionally, which duplicated the prefix in the rendered HTML (`class="btn submit btn submit btn-success"`) because `e_form::admin_button()` already prepends `btn submit` and falls back to `btn-success` for the `submit` action. Credit to @e107help for spotting this during review.

This revision only sets `$options['class']` when a parm is actually supplied:

```php
$options = array();
if(!empty($parm['class']))
{
    $options['class'] = $parm['class'];
}

return e107::getForm()->button('pwsubmit', $label, 'submit', '', $options);
```

Scope is intentionally narrow — just the `{FPW_SUBMIT}` shortcode. The broader consolidation of default classes across login/signup/coppa submit buttons raised by @Jimmi08 in the #5330 thread is deferred to #5597.

### How Has This Been Tested?

Added `e_parse_shortcodeTest::testFpwSubmitShortcodeAcceptsClassParm`, which asserts:

- `{FPW_SUBMIT}` renders with `class='btn submit btn-success'` (no duplicated prefix).
- `{FPW_SUBMIT: class=my-class}` passes `my-class` through to the rendered button while keeping the handler's `btn submit` prefix intact.

To confirm the test actually catches the regression, I temporarily re-applied #5330's logic locally and the test failed as expected (`class='btn submit btn submit btn-success'`), then passed again once the corrected logic was restored.

Ran the full `e_parse_shortcodeTest` class to check for collateral damage — the pre-existing `testNewsShortcodes` / `testDownloadShortcodes` / `testForumShortcodes` errors reproduce on `master` unchanged, so they are unrelated.

### Types of Changes

- [x] New feature (non-breaking change which adds functionality)

### Checklist

- [x] My code adheres to the e107 [code style standard](https://github.com/e107inc/e107/wiki/e107-Coding-Standard).
- [x] I have read the [**contributing** document](https://github.com/e107inc/e107/blob/master/.github/CONTRIBUTING.md).
- [x] I have added [tests](https://github.com/e107inc/e107/tree/master/e107_tests) to cover my changes.
- [x] All new and existing tests pass.