### PR TITLE
Include Plupload i18n file in generated language pack

### DIFF
--- a/e107_admin/lancheck.php
+++ b/e107_admin/lancheck.php
@@ -724,6 +724,22 @@ class lancheck
 
 		$file = array_merge($core,$core_admin, $plugs, $theme, $docs, $handlers);
 
+		// Patch (lancheck-plupload-i18n): include the Plupload i18n translation
+		// (e107_web/js/plupload/i18n/<iso>.js) in the generated pack so the file
+		// uploader is localised too. Core only bundles en.js, but a translator can
+		// drop their locale file in; without this it was silently left out of every
+		// pack, leaving Plupload in English regardless of the selected language.
+		$locale = $this->findLocale($language);
+		if($locale)
+		{
+			$iso = strtolower(substr($locale, 0, 2));
+			$pluploadJs = e_WEB.'js/plupload/i18n/'.$iso.'.js';
+			if(is_readable($pluploadJs))
+			{
+				$file[] = $pluploadJs;
+			}
+		}
+
 		$file = array_unique($file);
 
 		return $file;


### PR DESCRIPTION
### Problem

When an admin generates a Language Pack from **Admin → Tools → Language Check → Generate Language Pack** (`e107_admin/lancheck.php`), the resulting ZIP bundles `.php`/`.xml` from `e107_languages/`, `e107_plugins/`, `e107_themes/`, `e107_handlers/` and `e107_docs/help/`, but it **never includes** the Plupload uploader translation at `e107_web/js/plupload/i18n/<iso>.js`.

As a consequence, a fresh install of any generated pack leaves the Plupload uploader (file manager, media manager, mailout attachments, …) **in English** no matter which site language is selected. Translators currently have to ship the `.js` out-of-band or tell users to copy it manually.

### Fix

`getFileList()` is the single place that builds the array of files handed to `$archive->create($data, PCLZIP_OPT_REMOVE_PATH, e_BASE)`. The fix resolves the ISO-639-1 code from the existing `findLocale()` helper and, **only if** `e107_web/js/plupload/i18n/<iso>.js` exists, appends it to that list:

```php
$locale = $this->findLocale($language);
if($locale)
{
    $iso = strtolower(substr($locale, 0, 2));
    $pluploadJs = e_WEB.'js/plupload/i18n/'.$iso.'.js';
    if(is_readable($pluploadJs))
    {
        $file[] = $pluploadJs;
    }
}
```

Because the archive is created with `PCLZIP_OPT_REMOVE_PATH e_BASE`, the file is stored at the correct path `e107_web/js/plupload/i18n/<iso>.js` inside the ZIP — no extra `$archive->add()` call needed.

### Behaviour

| Scenario | Result |
|---|---|
| Spanish selected, `es.js` exists | `es.js` packaged at `e107_web/js/plupload/i18n/es.js` |
| Portuguese selected, `pt.js` exists | `pt.js` packaged |
| Locale has no plupload `.js` yet | Pack still generated; nothing added (silent, legacy behaviour) |
| `findLocale()` can't resolve | Skipped silently |

### Scope / safety

- **Single function touched** (`getFileList()`), **+16 lines**, no deletions.
- No public API changes, no new translatable strings.
- Zero impact on installs that don't generate packs.
- Deliberately implemented in `getFileList()` (not `makeLanguagePack()`) to stay **conflict-free** with PR #5703, which is in review and edits the XML-manifest block of `makeLanguagePack()`.
- Core only ships `en.js`; this simply lets a translator's locale file be picked up automatically when present.

Refs e107translations/Translator-Information#5

---

*Disclosure: parts of this contribution were prepared with AI assistance and reviewed by me before submission.*
