### PR TITLE
PM alias in e_url.php #5712

### DIFF
--- a/e107_plugins/pm/e_url.php
+++ b/e107_plugins/pm/e_url.php
@@ -45,8 +45,9 @@ class pm_url // plugin-folder + '_url'
 
 
 		$config['index'] = array(
-			'regex'			=> '^pm/?(.*)', 						// matched against url, and if true, redirected to 'redirect' below.
-			'sef'			=> 'pm', 							// used by e107::url(); to create a url from the db table.
+			'alias'         => 'pm',
+			'regex'			=> '^{alias}/?(.*)', 						// matched against url, and if true, redirected to 'redirect' below.
+			'sef'			=> '{alias}', 							// used by e107::url(); to create a url from the db table.
 			'redirect'		=> '{e_PLUGIN}pm/pm.php$1', 		// file-path of what to load when the regex returns true.
 
 		);


### PR DESCRIPTION
### Why
To be able to change SEF-URL for PM plugin

Closes #5712 

### What Changed

Added alias key to e_url config for PM plugin

### How It Was Tested

Used on the live site with Slovak string.

### Backwards Compatibility

No BC impact

### AI Model (Optional)
 
No AI

### Checklist

- [x] One issue per PR: the diff is scoped to this change only
- [ ] Commit messages explain *why*, not just *what*
- [ ] New or changed behavior has test coverage (or explain why not)
- [x] No unrelated reformatting, renames, or import reordering
