### PR TITLE
Refs #5210 improve a11y of signin template (icons, dropdown toggles)

### DIFF
--- a/e107_plugins/signin/templates/signin_template.php
+++ b/e107_plugins/signin/templates/signin_template.php
@@ -13,7 +13,7 @@ $SIGNIN_TEMPLATE['signin'] = '
 				{SIGNIN_SIGNUP_HREF}
 				<li class="divider-vertical"></li>
 				<li class="nav-item dropdown">
-				<a class="nav-link dropdown-toggle" data-bs-toggle="dropdown" href="#" data-toggle="dropdown">{LAN=LAN_LOGINMENU_51} <strong class="caret"></strong></a>
+				<a class="nav-link dropdown-toggle" data-bs-toggle="dropdown" href="#" data-toggle="dropdown" role="button" aria-expanded="false">{LAN=LAN_LOGINMENU_51} <strong class="caret" aria-hidden="true"></strong></a>
 					<div class="dropdown-menu col-sm-12" style="min-width:250px; padding: 15px; padding-bottom: 0px;">
 					
 					{SIGNIN_FORM=start}
@@ -42,7 +42,7 @@ $SIGNIN_TEMPLATE['signin'] = '
 
 
 
-$SIGNIN_WRAPPER['signout']['SIGNIN_ADMIN_HREF'] = '<li><a class="dropdown-item signin-sc admin" id="signin-sc-admin" href="{---}"><span class="fa fa-cogs"></span> {LAN=LAN_LOGINMENU_11}</a></li>';
+$SIGNIN_WRAPPER['signout']['SIGNIN_ADMIN_HREF'] = '<li><a class="dropdown-item signin-sc admin" id="signin-sc-admin" href="{---}"><span class="fa fa-cogs" aria-hidden="true"></span> {LAN=LAN_LOGINMENU_11}</a></li>';
 $SIGNIN_WRAPPER['signout']['SIGNIN_PM_NAV'] = '<li class="dropdown dropdown-pm">{---}</li>';
 
 
@@ -50,20 +50,19 @@ $SIGNIN_TEMPLATE['signout'] = '
 
 		<ul class="navbar-nav navbar-right">
 			{SIGNIN_PM_NAV}
-			<li class="dropdown dropdown-avatar"><a href="#" class="nav-link dropdown-toggle" data-bs-toggle="dropdown" data-toggle="dropdown">{USER_AVATAR: w=30&h=30&crop=1&shape=circle} {SIGNIN_USERNAME} <b class="caret"></b></a>
+			<li class="dropdown dropdown-avatar"><a href="#" class="nav-link dropdown-toggle" data-bs-toggle="dropdown" data-toggle="dropdown" role="button" aria-expanded="false">{USER_AVATAR: w=30&h=30&crop=1&shape=circle} {SIGNIN_USERNAME} <b class="caret" aria-hidden="true"></b></a>
 				<ul class="dropdown-menu dropdown-menu-end">
 				<li>
-					<a class="dropdown-item" href="{SIGNIN_USERSETTINGS_HREF}"><span class="fa fa-cog"></span> {LAN=LAN_SETTINGS}</a>
+					<a class="dropdown-item" href="{SIGNIN_USERSETTINGS_HREF}"><span class="fa fa-cog" aria-hidden="true"></span> {LAN=LAN_SETTINGS}</a>
 				</li>
 				<li>
-					<a class="dropdown-item" role="button" href="{SIGNIN_PROFILE_HREF}"><span class="fa fa-user"></span> {LAN=LAN_LOGINMENU_13}</a>
+					<a class="dropdown-item" role="button" href="{SIGNIN_PROFILE_HREF}"><span class="fa fa-user" aria-hidden="true"></span> {LAN=LAN_LOGINMENU_13}</a>
 				</li>
 				<li class="divider"></li>
 				{SIGNIN_ADMIN_HREF}
-				<li><a class="dropdown-item" href="{SIGNIN_LOGOUT_HREF}"><span class="fa fa-power-off"></span> {LAN=LAN_LOGOUT}</a></li>
+				<li><a class="dropdown-item" href="{SIGNIN_LOGOUT_HREF}"><span class="fa fa-power-off" aria-hidden="true"></span> {LAN=LAN_LOGOUT}</a></li>
 				</ul>
 			</li>
 		</ul>
 		
 		';
-


### PR DESCRIPTION
### Why

Refs #5210 (partial). The signin login menu has accessibility gaps: decorative
Font Awesome icons are exposed to screen readers, and the dropdown toggles lack
the ARIA state attributes assistive tech relies on. This addresses the parts
that live in the template itself.

### What Changed

- `aria-hidden="true"` on the four decorative icons (`fa-cogs`, `fa-cog`,
  `fa-user`, `fa-power-off`) — each already has a visible `{LAN=...}` label.
- `role="button"` + `aria-expanded="false"` on both dropdown toggle anchors
  (login toggle in `signin`, avatar toggle in `signout`).
- `aria-hidden="true"` on the empty `caret` elements (CSS-only arrows).

### How It Was Tested

Loaded the menu in both logged-out and logged-in states; confirmed it renders
identically and `aria-expanded` flips on open/close. Verified with browser
devtools accessibility tree that the icons are no longer announced. Not run
against an automated a11y test suite.

### Backwards Compatibility

No BC impact. Only additive ARIA attributes; no rendered text, classes, layout,
or public API changed. PM nav (`{SIGNIN_PM_NAV}`), the avatar `alt`, and the
login form input labels are out of scope — they come from the pm plugin and
shortcodes, and need separate fixes (follow-up to #5210).

### AI Model (Optional)

Claude Opus 4.8

### Checklist

- [x] One issue per PR: the diff is scoped to this change only
- [x] Commit messages explain *why*, not just *what*
- [ ] New or changed behavior has test coverage (or explain why not) — N/A, ARIA-only markup change, no test harness for template output
- [x] No unrelated reformatting, renames, or import reordering
