### PR TITLE
Refs #5210: one list item per dropdown link in PM nav menu

### DIFF
--- a/e107_plugins/pm/e_shortcode.php
+++ b/e107_plugins/pm/e_shortcode.php
@@ -63,11 +63,9 @@ class pm_shortcodes extends e_shortcode
 
 		return '<a class="pm-nav nav-link dropdown-toggle" data-toggle="dropdown" data-bs-toggle="dropdown" data-bs-toggle="dropdown" href="#">'.$icon.$count.'</a>
 		<ul class="dropdown-menu dropdown-menu-end">
-		<li>
-			<a class="dropdown-item" href="'.$urlInbox.'">'.LAN_PLUGIN_PM_INBOX.'</a>
-			<a class="dropdown-item" href="'.$urlOutbox.'">'.LAN_PLUGIN_PM_OUTBOX.'</a>
-			<a class="dropdown-item" href="'.$urlCompose.'">'.LAN_PLUGIN_PM_NEW.'</a> 
-		</li>
+			<li><a class="dropdown-item" href="'.$urlInbox.'">'.LAN_PLUGIN_PM_INBOX.'</a></li>
+			<li><a class="dropdown-item" href="'.$urlOutbox.'">'.LAN_PLUGIN_PM_OUTBOX.'</a></li>
+			<li><a class="dropdown-item" href="'.$urlCompose.'">'.LAN_PLUGIN_PM_NEW.'</a></li> 
 		</ul>';
 
 	}


### PR DESCRIPTION
### Why

Refs #5210 (follow-up to the ARIA PR). In `sc_pm_nav` all three dropdown links
(Inbox / Outbox / Send New Message) were wrapped in a single `<li>`. A `<ul>`
is a list and each `<li>` is one item, so screen readers announced the menu as
"list, 1 item" instead of 3, and per-item list navigation skipped over a single
block instead of stepping through the three choices. Bootstrap 5's dropdown
also expects each `.dropdown-item` to be the direct child of its own `<li>`.

### What Changed

Split the single `<li>` into one `<li>` per `.dropdown-item`:

```html

  Inbox
  Outbox
  Send New Message

```

No classes, hrefs, or attributes changed — only the list structure.
### How It Was Tested

Loaded the signin menu logged in, using the core Bootstrap 5 theme. The dropdown
renders and behaves identically — no visual changes. The list is now exposed as
three items rather than one. Not run against an automated a11y suite.

### Backwards Compatibility

No visual BC impact with the core Bootstrap 5 theme (verified). The rendered
HTML structure changes: the menu now contains three `<li>` elements instead of
one. Bootstrap's own dropdown styling targets `.dropdown-item`, which is
unchanged, so layout is unaffected. A custom skin with CSS that specifically
relied on the old single-`<li>` markup (e.g. `dropdown-menu > li` matching one
node) could in theory be affected, but this is the structurally correct form
the framework expects.

### AI Model (Optional)

Claude Opus 4.8

### Checklist

- [x] One issue per PR: the diff is scoped to this change only
- [x] Commit messages explain *why*, not just *what*
- [ ] New or changed behavior has test coverage (or explain why not) — N/A, structural markup output with no template-output test harness; verified manually
- [x] No unrelated reformatting, renames, or import reordering
