### PR TITLE
Update news_shortcodes.php

### DIFF
--- a/e107_core/shortcodes/batch/news_shortcodes.php
+++ b/e107_core/shortcodes/batch/news_shortcodes.php
@@ -890,6 +890,8 @@ class news_shortcodes extends e_shortcode
 		{
 			return '';
 		}
+
+		$parms = eHelper::scDualParams($parm);
 		
 		if(isset($newsThumb) && $vThumb = e107::getParser()->toVideo($newsThumb, array('thumb'=>'src')))
 		{
@@ -899,8 +901,7 @@ class news_shortcodes extends e_shortcode
 		}
 		else
 		{
-			$parms = eHelper::scDualParams($parm);
-			
+						
 			if(empty($parms[2])) // get {SETIMAGE} values when no parm provided. 
 			{
 				$parms[2] = array('aw' => $tp->thumbWidth(), 'ah'=> $tp->thumbHeight());


### PR DESCRIPTION
Move eHelper::scDualParams($parm) call outside (before) if ... else ... block, otherwise if video is used as news media - $parms[1] is always null, thus always returning the default case from switch statement at the end completely ignoring first parameter values: link|src|tag


