### PR TITLE
Gallery categories list order

### DIFF
--- a/e107_handlers/media_class.php
+++ b/e107_handlers/media_class.php
@@ -408,7 +408,7 @@ class e_media
 	 * @param string $owner
 	 * @return array
 	 */
-	public function getCategories($owner='')
+	public function getCategories($owner='', $orderby='media_cat_order')
 	{
 		$ret = array();
 		
@@ -416,7 +416,7 @@ class e_media
 		$qry = "SELECT * FROM #core_media_cat ";
 		$qry .= ($owner) ? " WHERE media_cat_owner = '".$owner."' " : " (1) ";
 		$qry .= "AND media_cat_class IN (".USERCLASS_LIST.") ";
-		$qry .= "ORDER BY media_cat_order";
+		$qry .= "ORDER BY ".$orderby;
 		
 		e107::getDb()->gen($qry);
 		while($row = e107::getDb()->fetch())

--- a/e107_plugins/gallery/admin_gallery.php
+++ b/e107_plugins/gallery/admin_gallery.php
@@ -159,7 +159,7 @@ class gallery_cat_admin_ui extends e_admin_ui
 	 *
 	 * @var string
 	 */
-	protected $listOrder = 'media_cat_order';
+	protected $listOrder = 'media_cat_id DESC';
 
 	/**
 	 * SQL query for listing. Without any Order or Limit.
@@ -346,6 +346,22 @@ class gallery_cat_admin_ui extends e_admin_ui
 			'type'  => 'number',
 			'data'  => 'int',
 			'help'  => LAN_GALLERY_ADMIN_21,
+		),
+		'cat_orderby'                    => array(
+			'title'      => LAN_GALLERY_ADMIN_72,
+			'tab'        => 0,
+			'type'       => 'dropdown',
+			'data'       => 'str',
+			'writeParms' => array(
+				'optArray' => array(
+					'media_cat_id ASC'      => LAN_GALLERY_ADMIN_73,
+					'media_cat_id DESC'       => LAN_GALLERY_ADMIN_74,
+					'media_cat_order ASC'  => LAN_GALLERY_ADMIN_77,
+					'media_cat_order DESC' => LAN_GALLERY_ADMIN_78,
+					'media_cat_title ASC'     => LAN_GALLERY_ADMIN_75,
+					'media_cat_title DESC'    => LAN_GALLERY_ADMIN_76,
+				),
+			),
 		),
 		'orderby'                    => array(
 			'title'      => LAN_GALLERY_ADMIN_22,

--- a/e107_plugins/gallery/controllers/index.php
+++ b/e107_plugins/gallery/controllers/index.php
@@ -66,9 +66,11 @@ class plugin_gallery_index_controller extends eControllerFront
 
 	public function init()
 	{
+		$plugPrefs = e107::getPlugConfig('gallery')->getPref();
+		$orderBy = varset($plugPrefs['cat_orderby'], 'media_cat_id DESC');
 		e107::plugLan('gallery', 'front');
 		e107::css('gallery', 'css/gallery.css');
-		$this->catList = e107::getMedia()->getCategories('gallery');
+		$this->catList = e107::getMedia()->getCategories('gallery', $orderBy);
 	}
 
 	public function actionIndex()

--- a/e107_plugins/gallery/gallery.php
+++ b/e107_plugins/gallery/gallery.php
@@ -48,7 +48,9 @@ class gallery
 
 	function __construct()
 	{
-		$this->catList = e107::getMedia()->getCategories('gallery');
+		$plugPrefs = e107::getPlugConfig('gallery')->getPref();
+		$orderBy = varset($plugPrefs['cat_orderby'], 'media_cat_id DESC');
+		$this->catList = e107::getMedia()->getCategories('gallery', $orderBy);
 
 		if((vartrue($_GET['cat'])) && isset($this->catList[$_GET['cat']]))
 		{

--- a/e107_plugins/gallery/languages/English/English_admin.php
+++ b/e107_plugins/gallery/languages/English/English_admin.php
@@ -80,4 +80,11 @@ return [
     'LAN_GALLERY_ADMIN_69' => "Facebook",
     'LAN_GALLERY_ADMIN_70' => "Load prettyPhoto globally",
     'LAN_GALLERY_ADMIN_71' => "prettyPhoto attribute (hook)",
+    'LAN_GALLERY_ADMIN_72' => "Order categories by",
+    'LAN_GALLERY_ADMIN_73' => "Category ID ASC",
+    'LAN_GALLERY_ADMIN_74' => "Category ID DESC",
+    'LAN_GALLERY_ADMIN_75' => "Category Name ASC",
+    'LAN_GALLERY_ADMIN_76' => "Category Name DESC",
+    'LAN_GALLERY_ADMIN_77' => "Category Order ASC",
+    'LAN_GALLERY_ADMIN_78' => "Category Order DESC",
 ];

--- a/e107_plugins/gallery/plugin.xml
+++ b/e107_plugins/gallery/plugin.xml
@@ -23,6 +23,7 @@
 		<pref name="slideshow_freq">4000</pref>
 		<pref name="slideshow_effect">scrollHorz</pref>	
 		<pref name="perpage">12</pref>
+		<pref name="cat_orderby">media_cat_id DESC</pref>
 		<pref name="orderby">media_id DESC</pref>
 		<pref name="pp_global">0</pref>
 		<pref name="pp_hook">data-gal</pref>


### PR DESCRIPTION
Enhancement to allow ordering of Gallery categories list.

Currently there is no way to order Gallery categories list except from the hard coded one (trough cat order field). This is not a problem with only a couple of categories, however with heavy usage of Gallery plugin (many categories) it become tedious to keep note of the order value and probably most of the users will not even bother to enter it. 

Most logical way is, as with many other records, to show them in the order of adding (latest first). These modifications do exactly that, but also keeps the functionality of order by Order field.

### Why

<!-- What problem does this solve? Link the issue: Fixes #N or Closes #N -->

### What Changed

<!-- Describe the change. If the diff is self-explanatory, a one-liner is fine. -->

### How It Was Tested

<!-- How did you verify this works? Ran the test suite, loaded a page, traced the code? Be honest; "traced only, not reproduced" is fine. -->

### Backwards Compatibility

<!-- Does this change any rendered HTML, public API, or default behavior? If yes, describe the impact and the migration path. If no, just write "No BC impact." -->

### AI Model (Optional)

<!-- If this PR was written with or by an AI assistant, name the model (e.g., Claude 3 Opus, GPT-4o, Gemini 1.0 Pro). This helps reviewers anticipate model-specific bias patterns. Omit if not applicable. -->

### Checklist

- [ ] One issue per PR: the diff is scoped to this change only
- [ ] Commit messages explain *why*, not just *what*
- [ ] New or changed behavior has test coverage (or explain why not)
- [ ] No unrelated reformatting, renames, or import reordering
