### PR TITLE
Fixing a bug with getMedia() function

### DIFF
--- a/e107_handlers/media_class.php
+++ b/e107_handlers/media_class.php
@@ -553,9 +553,14 @@ class e_media
 		
 		$fields = ($amount == 'all') ? "media_id" : "*";
 		
-		$query = "SELECT ".$fields." FROM #core_media WHERE `media_category` REGEXP '(^|,)".implode("|",$catArray)."(,|$)' 
-		AND `media_userclass` IN (".USERCLASS_LIST.") 
-		AND `media_type` LIKE '".$type."/%' " ;
+		$catAnchored = array_map(function($c) {
+			return '(^|,)' . preg_quote($c, '/') . '(,|$)';
+		}, $catArray);
+
+		$query = "SELECT ".$fields." FROM #core_media WHERE `media_category` REGEXP '" . implode("|", $catAnchored) . "'
+		AND `media_userclass` IN (".USERCLASS_LIST.")
+		AND `media_type` LIKE '".$type."/%' ";
+
 
 		if($search)
 		{


### PR DESCRIPTION
When category is passed for example  'gallery_image_1' it not only matches all records with media_category field containing   gallery_image_1 but also records with gallery_image_10, gallery_image_11, gallery_image_12 ... etc. thus returning extra images that are not in the same category

