### PR TITLE
Restyle English_front.php

### DIFF
--- a/e107_plugins/gsitemap/languages/English_front.php
+++ b/e107_plugins/gsitemap/languages/English_front.php
@@ -17,6 +17,7 @@
 
 return [
     'GSLAN_Name' => "Sitemap",
+	/*
     'GSLAN_1' => "Site Link",
     'GSLAN_2' => "Import?",
     'GSLAN_3' => "Type",
@@ -57,4 +58,5 @@ return [
     'GSLAN_38' => "For more information on Google Sitemap protocol, go to <a href='http://www.google.com/webmasters/sitemaps/docs/en/protocol.html'>http://www.google.com/webmasters/sitemaps/docs/en/protocol.html</a>.",
     'GSLAN_39' => "No links in sitemap - import sitelinks?",
     'GSLAN_40' => "Google Sitemap Entries",
+	*/
 ];


### PR DESCRIPTION
language conversion failed ? 

only LAn 'GSLAN_Name' => "Sitemap"  is correct in place

### Why

during translation conversion?  LAN lines who were commented out became activated

### What Changed

open file where **only first LAN** ( name=sitemap) is used in **Front php**
**rest of file commented out again**

### How It Was Tested
running checks on LAN"s in use but they do not exist anymore or now present in langfiles   gsitemap/languages/English_admin.php  and  gsitemap/admin_config.php

### Backwards Compatibility

No BC impact.

### Checklist

- [x] One issue per PR: the diff is scoped to this change only
- [ ] Commit messages explain *why*, not just *what*
- [x] New or changed behavior has test coverage
- [ ] No unrelated reformatting, renames, or import reordering
