### PR TITLE
fix: guard SCRIPT_URL access in installer stats pixel

### DIFF
--- a/install.php
+++ b/install.php
@@ -2025,7 +2025,7 @@ return [
 	{
 		global $e_forms;
 
-		$data = array('name'=>$this->previous_steps['prefs']['sitename'], 'theme'=>$this->previous_steps['prefs']['sitetheme'], 'language'=>$this->previous_steps['language'], 'url'=>$_SERVER['SCRIPT_URL'],'version'=> defset('e_VERSION'), 'php'=>defset('PHP_VERSION'));
+		$data = array('name'=>$this->previous_steps['prefs']['sitename'], 'theme'=>$this->previous_steps['prefs']['sitetheme'], 'language'=>$this->previous_steps['language'], 'url'=>varset($_SERVER['SCRIPT_URL']),'version'=> defset('e_VERSION'), 'php'=>defset('PHP_VERSION'));
 		$base = base64_encode(http_build_query($data, '','&'));
 		$url = "https://e107.org/e-install/".$base;
 		$e_forms->add_plain_html("<img src='".$url."' style='width:1px; height:1px' />");


### PR DESCRIPTION
### Why

Fixes #5775. The installer's `stats()` builds its phone-home URL from `$_SERVER['SCRIPT_URL']` directly. That variable is supplied by Apache mod_rewrite and is absent on the PHP built-in server, CLI, nginx, and some WAMP setups, so completing a fresh install logs `Undefined array key "SCRIPT_URL"` on PHP 8+.

### What Changed

Wrapped the read in `varset()` so an absent key yields an empty string instead of warning, matching how the rest of `install.php` reads optional `$_SERVER`/step values.

### How It Was Tested

Traced the code path and lint-checked the file. The pixel still renders with an empty `url` when the key is missing, identical to the existing behavior on SAPIs that do set it.

### Backwards Compatibility

No BC impact. When `SCRIPT_URL` is present the value is unchanged; only the missing-key warning is suppressed.

### Checklist

- [x] One issue per PR: the diff is scoped to this change only
- [x] Commit messages explain *why*, not just *what*
- [ ] New or changed behavior has test coverage (or explain why not) — `install.php` is the procedural installer and is not exercised by the unit suite; the adjacent help-text guard in #5773 shipped without a test for the same reason
- [x] No unrelated reformatting, renames, or import reordering
