### PR TITLE
Accept jpeg and gif attachments as images in the SMF importer

### DIFF
--- a/e107_plugins/import/providers/smf_import_class.php
+++ b/e107_plugins/import/providers/smf_import_class.php
@@ -325,7 +325,7 @@ class smf_import extends base_import_class
 		}
 
 
-		if($source['fileext'] == 'png' || $source['fileext'] == 'jpg' || $source['fileext'] == 'jpg')
+		if(in_array($source['fileext'], array('png', 'jpg', 'jpeg', 'gif')))
 		{
 			$type = 'img';
 		}

--- a/e107_plugins/import/providers/smf_import_class.php
+++ b/e107_plugins/import/providers/smf_import_class.php
@@ -325,7 +325,7 @@ class smf_import extends base_import_class
 		}
 
 
-		if(in_array($source['fileext'], array('png', 'jpg', 'jpeg', 'gif')))
+		if(in_array($source['fileext'], array('png', 'jpg', 'jpeg', 'gif', 'webp')))
 		{
 			$type = 'img';
 		}

--- a/e107_tests/tests/unit/plugins/import/smfAttachmentsTest.php
+++ b/e107_tests/tests/unit/plugins/import/smfAttachmentsTest.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * e107 website system
+ *
+ * Copyright (C) 2008-2026 e107 Inc (e107.org)
+ * Released under the terms and conditions of the
+ * GNU General Public License (http://www.gnu.org/licenses/gpl.txt)
+ *
+ */
+
+/**
+ * Which post_attachments key the SMF provider files an attachment under: 'img' for an image, 'file' for the rest.
+ */
+class smfAttachmentsTest extends \Test\Unit
+{
+	/** @var smf_import */
+	private $smf;
+
+	protected function _before()
+	{
+		require_once(e_PLUGIN.'import/providers/smf_import_class.php');
+
+		$this->smf = new smf_import();
+	}
+
+	/**
+	 * @param string|null $filename null for a message without an attachment
+	 * @param string|null $fileext  as SMF stores it
+	 * @return array|null the decoded post_attachments the provider produced
+	 */
+	private function attachmentsOf($filename, $fileext)
+	{
+		$target = array();
+		$source = array(
+			'id_msg'         => 7,
+			'body'           => 'hello',
+			'id_topic'       => 3,
+			'id_board'       => 2,
+			'approved'       => 1,
+			'poster_time'    => 1490000000,
+			'id_member'      => 5,
+			'modified_time'  => 0,
+			'post_edit_user' => 0,
+			'poster_ip'      => '127.0.0.1',
+			'poster_name'    => 'someone',
+			'filename'       => $filename,
+			'fileext'        => $fileext,
+			'size'           => '1234',
+		);
+
+		$this->smf->copyForumPostData($target, $source);
+
+		return $target['post_attachments'] === null ? null : e107::unserialize($target['post_attachments']);
+	}
+
+	public function testEveryImageExtensionIsFiledUnderImg()
+	{
+		foreach (array('png', 'jpg', 'jpeg', 'gif', 'webp') as $ext)
+		{
+			$attachments = $this->attachmentsOf('picture.'.$ext, $ext);
+
+			self::assertSame(array('img'), array_keys($attachments), $ext.' is an image');
+			self::assertSame('picture.'.$ext, $attachments['img'][0]['file']);
+			self::assertSame('1234', $attachments['img'][0]['size']);
+		}
+	}
+
+	public function testAnythingElseIsFiledUnderFile()
+	{
+		$attachments = $this->attachmentsOf('notes.pdf', 'pdf');
+
+		self::assertSame(array('file'), array_keys($attachments));
+		self::assertSame('notes.pdf', $attachments['file'][0]['file']);
+	}
+
+	public function testAMessageWithoutAnAttachmentStoresNothing()
+	{
+		self::assertNull($this->attachmentsOf(null, null));
+	}
+}


### PR DESCRIPTION
`smf_import::processAttachments` decides between an image attachment and a plain file, and its condition tests `jpg` twice, so the third slot never covered anything. An SMF board that has `.gif` or `.jpeg` attachments imports them as generic files rather than images.

I did not guess the missing name. Everywhere else e107 spells the image set out as jpg, jpeg, png and gif, in `media_class.php`, `e_thumbnail_class.php`, `e_parse_class.php` and the form handler regex, so I used that same set here and folded the chain into `in_array` to keep it readable. Newer parts of the tree also carry `webp`, which I left out because an SMF board old enough to import predates it.
