### PR TITLE
Text to LAN's History + file creation

### DIFF
--- a/e107_admin/history.php
+++ b/e107_admin/history.php
@@ -9,10 +9,9 @@ if (!getperms('7'))
 	e107::redirect('admin');
 	exit;
 }
+
 e107::includeLan(e_LANGUAGEDIR.e_LANGUAGE."/admin/lan_history.php");
-
 e107::css('inline', " td.history-data pre { max-width: 800px; } }");
-
 
 class history_adminArea extends e_admin_dispatcher
 {
@@ -56,7 +55,7 @@ class history_adminArea extends e_admin_dispatcher
 class admin_history_ui extends e_admin_ui
 {
 			
-		protected $pluginTitle		= 'LAN_HISTORY';
+		protected $pluginTitle		= LAN_HISTORY;
 		protected $pluginName		= 'myplugin';
 	//	protected $eventName		= 'myplugin-admin_history'; // remove comment to enable event triggers in admin. 		
 		protected $table			= 'admin_history';
@@ -269,7 +268,8 @@ class admin_history_form_ui extends e_admin_form_ui
 
 			$type = $row['history_action'];
 			$name = ($type === 'delete') ? "restore_deleted[$id]" : "restore_updated[$id]";
-            $text .= "<button class='btn btn-primary' type='submit' name='$name' title='".e107::getParser()->toAttribute($restoreTitle)."'><i class='admin-ui-option fa fa-undo fa-2x fa-fw'></i></button>";
+		
+			$text .= "<button class='btn btn-primary' type='submit' name='$name' title='".e107::getParser()->toAttribute($restoreTitle)."'><i class='admin-ui-option fa fa-undo fa-2x fa-fw'></i></button>";
 		}
 
 		$att['readParms']['editClass'] = 999; // disable it.

--- a/e107_admin/history.php
+++ b/e107_admin/history.php
@@ -9,9 +9,10 @@ if (!getperms('7'))
 	e107::redirect('admin');
 	exit;
 }
+e107::includeLan(e_LANGUAGEDIR.e_LANGUAGE."/admin/lan_history.php");
 
-// e107::lan('history',true);
 e107::css('inline', " td.history-data pre { max-width: 800px; } }");
+
 
 class history_adminArea extends e_admin_dispatcher
 {
@@ -43,7 +44,7 @@ class history_adminArea extends e_admin_dispatcher
 		'main/edit'	=> 'main/list'				
 	);	
 	
-	protected $menuTitle = 'History';
+	protected $menuTitle = LAN_HISTORY;
 
 	protected $adminMenuIcon = '{e_IMAGE}admin_images/undo_32.png';
 }
@@ -55,7 +56,7 @@ class history_adminArea extends e_admin_dispatcher
 class admin_history_ui extends e_admin_ui
 {
 			
-		protected $pluginTitle		= 'History';
+		protected $pluginTitle		= 'LAN_HISTORY';
 		protected $pluginName		= 'myplugin';
 	//	protected $eventName		= 'myplugin-admin_history'; // remove comment to enable event triggers in admin. 		
 		protected $table			= 'admin_history';
@@ -75,12 +76,12 @@ class admin_history_ui extends e_admin_ui
 			'checkboxes'              => array ( 'title' => '', 'type' => null, 'data' => null, 'width' => '5%', 'thclass' => 'center', 'forced' => 'value', 'class' => 'center', 'toggle' => 'e-multiselect', 'readParms' => [], 'writeParms' => [],),
 		//	'history_id'              => array ( 'title' => LAN_ID, 'type' => 'number', 'data' => 'int', 'width' => '5%', 'help' => '', 'readParms' => [], 'writeParms' => [], 'class' => 'left', 'thclass' => 'left',),
 			'history_datestamp'       => array ( 'title' => LAN_DATESTAMP, 'type' => 'datestamp', 'data' => 'int', 'width' => '15%', 'filter' => true, 'help' => '', 'readParms' => [], 'writeParms' => [], 'class' => 'left', 'thclass' => 'left',),
-			'history_table'           => array ( 'title' => 'Table', 'type' => 'text', 'data' => 'safestr', 'width' => 'auto', 'filter' => true, 'help' => '', 'readParms' => [], 'writeParms' => [], 'class' => 'left', 'thclass' => 'left',),
+			'history_table'           => array ( 'title' => LAN_HISTORY_TABLE, 'type' => 'text', 'data' => 'safestr', 'width' => 'auto', 'filter' => true, 'help' => '', 'readParms' => [], 'writeParms' => [], 'class' => 'left', 'thclass' => 'left',),
 			'history_record_id'       => array ( 'title' => LAN_ID, 'type' => 'number', 'data' => 'int', 'width' => '5%', 'help' => '', 'readParms' => [], 'writeParms' => [], 'class' => 'left', 'thclass' => 'left',),
-			'history_action'          => array ( 'title' => 'Action', 'type' => 'dropdown', 'data' => 'int', 'width' => 'auto', 'filter' => true, 'help' => '', 'readParms' => [], 'writeParms' => [], 'class' => 'left', 'thclass' => 'left', 'batch' => false,),
-			'history_data'            => array ( 'title' => 'Changed Data', 'type' => 'method', 'data' => 'str', 'width' => 'auto', 'help' => '', 'readParms' => [], 'writeParms' => [], 'class' => 'history-data left', 'thclass' => 'left', 'filter' => false, 'batch' => false,),
+			'history_action'          => array ( 'title' => LAN_HISTORY_ACTION, 'type' => 'dropdown', 'data' => 'int', 'width' => 'auto', 'filter' => true, 'help' => '', 'readParms' => [], 'writeParms' => [], 'class' => 'left', 'thclass' => 'left', 'batch' => false,),
+			'history_data'            => array ( 'title' => LAN_HISTORY_CHANGED_DATA, 'type' => 'method', 'data' => 'str', 'width' => 'auto', 'help' => '', 'readParms' => [], 'writeParms' => [], 'class' => 'history-data left', 'thclass' => 'left', 'filter' => false, 'batch' => false,),
 			'history_user_id'         => array ( 'title' => LAN_USER, 'type' => 'user', 'data' => 'int', 'width' => '5%', 'filter' => true, 'help' => '', 'readParms' => [], 'writeParms' => [], 'class' => 'left', 'thclass' => 'left',),
-			'history_restored'         => array ( 'title' => "Restored", 'type' => 'datestamp', 'data' => 'int', 'width' => '5%', 'filter' => true, 'help' => '', 'readParms' => [], 'writeParms' => [], 'class' => 'center', 'thclass' => 'center',),
+			'history_restored'         => array ( 'title' => LAN_HISTORY_RESTORE_COLUMN, 'type' => 'datestamp', 'data' => 'int', 'width' => '5%', 'filter' => true, 'help' => '', 'readParms' => [], 'writeParms' => [], 'class' => 'center', 'thclass' => 'center',),
 
 			'options'                 => array ( 'title' => LAN_OPTIONS, 'type' => 'method', 'data' => null, 'width' => '10%', 'thclass' => 'center last', 'class' => 'center last', 'forced' => 'value', 'readParms' => [], 'writeParms' => [],),
 		);		
@@ -98,7 +99,7 @@ class admin_history_ui extends e_admin_ui
 				$this->fields['history_action']['writeParms']['optArray'] = [
 					'delete'    => "<span class='label label-danger'>". LAN_DELETE."</span>",
 					'update'    =>  "<span class='label label-success'>". LAN_UPDATE."</span>",
-					'restore'    =>  "<span class='label label-warning'>Restore</span>"
+					'restore'    =>  "<span class='label label-warning'>". LAN_HISTORY_RESTORE ."</span>"
 				];
 
 
@@ -228,16 +229,16 @@ class admin_history_ui extends e_admin_ui
 	{
 		$caption = LAN_HELP;
 		$text = "
-        <p>This page allows you to view the <strong>history of changes</strong> made to records in the system and restore records to a previous state when needed.</p>
+        <p>".LAN_HISTORY_HELP_INTRO."</p>
         
-        <h4>Features of this page:</h4>
+        <h4>".LAN_HISTORY_HELP_FEATURES."</h4>
         <ul>
-            <li><strong>View Changes:</strong> See details of updates and deletions, including who made the changes and when.</li>
-            <li><strong>Revert Changes:</strong> Restore a record to its earlier version, undoing accidental or undesired modifications.</li>
-            <li><strong>Audit Trail:</strong> Track all actions performed on records for accountability and transparency.</li>
+            <li>".LAN_HISTORY_HELP_VIEW."</li>
+            <li>".LAN_HISTORY_HELP_REVERT."</li>
+            <li>".LAN_HISTORY_HELP_AUDIT."</li>
         </ul>
         
-        <p>Use the filters to narrow down the history logs or locate specific changes. If a record can be restored, an option will be available in the Options menu.</p>
+        <p>".LAN_HISTORY_HELP_FILTERS."</p>
     ";
 
 		return ['caption' => $caption, 'text' => $text];
@@ -264,11 +265,11 @@ class admin_history_form_ui extends e_admin_form_ui
 		if (!empty($id))
 		{
 			// Generate Restore button
-			$restoreTitle = "Restore this Record";
+			$restoreTitle = LAN_HISTORY_RESTORE_RECORD_BUTTON;
 
 			$type = $row['history_action'];
 			$name = ($type === 'delete') ? "restore_deleted[$id]" : "restore_updated[$id]";
-			$text .= "<button class='btn btn-primary' type='submit' name='$name' title='{$restoreTitle}'><i class='admin-ui-option fa fa-undo fa-2x fa-fw'></i></button>";
+            $text .= "<button class='btn btn-primary' type='submit' name='$name' title='".e107::getParser()->toAttribute($restoreTitle)."'><i class='admin-ui-option fa fa-undo fa-2x fa-fw'></i></button>";
 		}
 
 		$att['readParms']['editClass'] = 999; // disable it.
@@ -318,5 +319,3 @@ require_once(e_ADMIN."auth.php");
 e107::getAdminUI()->runPage();
 
 require_once(e_ADMIN."footer.php");
-
-

--- a/e107_admin/history.php
+++ b/e107_admin/history.php
@@ -267,8 +267,7 @@ class admin_history_form_ui extends e_admin_form_ui
 			$restoreTitle = LAN_HISTORY_RESTORE_RECORD_BUTTON;
 
 			$type = $row['history_action'];
-			$name = ($type === 'delete') ? "restore_deleted[$id]" : "restore_updated[$id]";
-		
+			$name = ($type === 'delete') ? "restore_deleted[$id]" : "restore_updated[$id]";		
 			$text .= "<button class='btn btn-primary' type='submit' name='$name' title='".e107::getParser()->toAttribute($restoreTitle)."'><i class='admin-ui-option fa fa-undo fa-2x fa-fw'></i></button>";
 		}
 

--- a/e107_admin/history.php
+++ b/e107_admin/history.php
@@ -267,7 +267,7 @@ class admin_history_form_ui extends e_admin_form_ui
 			$restoreTitle = LAN_HISTORY_RESTORE_RECORD_BUTTON;
 
 			$type = $row['history_action'];
-			$name = ($type === 'delete') ? "restore_deleted[$id]" : "restore_updated[$id]";		
+			$name = ($type === 'delete') ? "restore_deleted[$id]" : "restore_updated[$id]";	
 			$text .= "<button class='btn btn-primary' type='submit' name='$name' title='".e107::getParser()->toAttribute($restoreTitle)."'><i class='admin-ui-option fa fa-undo fa-2x fa-fw'></i></button>";
 		}
 

--- a/e107_languages/English/admin/lan_history.php
+++ b/e107_languages/English/admin/lan_history.php
@@ -1,0 +1,22 @@
+<?php
+/*
+ * Copyright (C) 2008-2026 e107 Inc (e107.org), Licensed under GNU GPL (http://www.gnu.org/licenses/gpl.txt)
+ *
+ * Admin History.Language File
+ *
+*/
+
+return [
+    'LAN_HISTORY_TABLE' => "Table",
+    'LAN_HISTORY_ACTION' => "Action",
+    'LAN_HISTORY_CHANGED_DATA' => "Changed Data",
+    'LAN_HISTORY_RESTORE_COLUMN' => "Restored",
+    'LAN_HISTORY_RESTORE' => "Restore",
+    'LAN_HISTORY_RESTORE_RECORD_BUTTON' => "Restore this record",
+    'LAN_HISTORY_HELP_INTRO' => "This page allows you to view the <strong>history of changes</strong> made to records in the system and restore records to a previous state when needed.",
+    'LAN_HISTORY_HELP_FEATURES' => "Features of this page:",
+    'LAN_HISTORY_HELP_VIEW' => "<strong>View Changes:</strong> See details of updates and deletions, including who made the changes and when.",
+    'LAN_HISTORY_HELP_REVERT' => "<strong>Revert Changes:</strong> Restore a record to its earlier version, undoing accidental or undesired modifications.",
+    'LAN_HISTORY_HELP_AUDIT' => "<strong>Audit Trail:</strong> Track all actions performed on records for accountability and transparency.",
+    'LAN_HISTORY_HELP_FILTERS' => "Use the filters to narrow down the history logs or locate specific changes. If a record can be restored, an option will be available in the Options menu.",
+];


### PR DESCRIPTION
### Why

History hardcoded texts to LAN's for translations

### What Changed

History hardcoded texts to LAN's . LAN's in own admin lan_history.php Mian file added lang.path

### How It Was Tested

Visual (local) on 2 languages (EN,NL) diff php versions; 'cosmetics checked', multiple scenarios tested. 
Database> iff actions will take place in table using 2 langs.

### Backwards Compatibility
No: Master only


### Checklist

- [x] One issue per PR: the diff is scoped to this change only
- [x] Commit messages explain *why*, not just *what*
- [x] New or changed behavior has test coverage (or explain why not)
- [x] No unrelated reformatting, renames, or import reordering
